### PR TITLE
Skip `prestart` build script on Docker start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,4 @@ ARG PORT
 ENV PORT ${PORT}
 EXPOSE ${PORT}
 
-CMD [ "npm", "run", "start" ]
+CMD [ "npm", "start", "--ignore-scripts" ]


### PR DESCRIPTION
The Docker container already has "the build" so we can skip the `prestart` build script