### PR TITLE
Use GOV.UK Design System component import paths

### DIFF
--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -51,7 +51,7 @@ export const configureEnginePlugin: ConfigureEnginePlugin = (
   }
 
   const modelOptions = {
-    relativeTo: join(config.appDir, 'plugins/engine'),
+    relativeTo: join(config.appDir, 'plugins/engine/views'),
     previewMode: options?.previewMode ?? config.previewMode
   }
 

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -1,5 +1,7 @@
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { cwd } from 'node:process'
 import nunjucks from 'nunjucks'
+import resolvePkg from 'resolve'
 import { getValidStateFromQueryParameters, redirectTo } from './helpers.js'
 import { FormConfiguration } from '@defra/forms-model'
 
@@ -15,13 +17,24 @@ import { shouldLogin } from '../../plugins/auth.js'
 import config from '../../config.js'
 import type { FormPayload } from './types.js'
 
+const [govukFrontendPath, hmpoComponentsPath] = [
+  'govuk-frontend',
+  'hmpo-components'
+].map((pkgName) =>
+  dirname(
+    resolvePkg.sync(`${pkgName}/package.json`, {
+      basedir: cwd()
+    })
+  )
+)
+
 nunjucks.configure([
   // Configure Nunjucks to allow rendering of content that is revealed conditionally.
   join(config.appDir, 'plugins/engine/views'),
   join(config.appDir, 'plugins/engine/views/partials'),
-  'node_modules/govuk-frontend/govuk/',
-  'node_modules/govuk-frontend/govuk/components/',
-  'node_modules/hmpo-components/components'
+  join(govukFrontendPath, 'govuk'),
+  join(govukFrontendPath, 'govuk/components'),
+  join(hmpoComponentsPath, 'components')
 ])
 
 function normalisePath(path: string) {

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -31,7 +31,6 @@ const [govukFrontendPath, hmpoComponentsPath] = [
 nunjucks.configure([
   // Configure Nunjucks to allow rendering of content that is revealed conditionally.
   join(config.appDir, 'plugins/engine/views'),
-  join(config.appDir, 'plugins/engine/views/partials'),
   govukFrontendPath,
   join(hmpoComponentsPath, 'components')
 ])

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -32,8 +32,7 @@ nunjucks.configure([
   // Configure Nunjucks to allow rendering of content that is revealed conditionally.
   join(config.appDir, 'plugins/engine/views'),
   join(config.appDir, 'plugins/engine/views/partials'),
-  join(govukFrontendPath, 'govuk'),
-  join(govukFrontendPath, 'govuk/components'),
+  govukFrontendPath,
   join(hmpoComponentsPath, 'components')
 ])
 

--- a/src/server/plugins/engine/views/components/autocompletefield.html
+++ b/src/server/plugins/engine/views/components/autocompletefield.html
@@ -1,6 +1,6 @@
-{% from "error-message/macro.njk" import govukErrorMessage -%}
-{% from "hint/macro.njk" import govukHint %}
-{% from "label/macro.njk" import govukLabel %}
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage -%}
+{% from "govuk/components/hint/macro.njk" import govukHint %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
 
 {% macro AutocompleteField(component) %}
 {% set describedBy = component.model.describedBy if component.model.describedBy else "" %}

--- a/src/server/plugins/engine/views/components/checkboxesfield.html
+++ b/src/server/plugins/engine/views/components/checkboxesfield.html
@@ -1,4 +1,4 @@
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% macro CheckboxesField(component) %}
   {{ govukCheckboxes(component.model) }}

--- a/src/server/plugins/engine/views/components/datefield.html
+++ b/src/server/plugins/engine/views/components/datefield.html
@@ -1,4 +1,4 @@
-{% from "./textfield.html" import TextField %}
+{% from "components/textfield.html" import TextField %}
 
 {% macro DateField(component) %}
   {{ TextField(component) }}

--- a/src/server/plugins/engine/views/components/datepartsfield.html
+++ b/src/server/plugins/engine/views/components/datepartsfield.html
@@ -1,4 +1,4 @@
-{% from "date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
 {% macro DatePartsField(component) %}
   {{ govukDateInput(component.model) }}

--- a/src/server/plugins/engine/views/components/datetimefield.html
+++ b/src/server/plugins/engine/views/components/datetimefield.html
@@ -1,4 +1,4 @@
-{% from "./textfield.html" import TextField %}
+{% from "components/textfield.html" import TextField %}
 
 {% macro DateTimeField(component) %}
   {{ TextField(component) }}

--- a/src/server/plugins/engine/views/components/datetimepartsfield.html
+++ b/src/server/plugins/engine/views/components/datetimepartsfield.html
@@ -1,4 +1,4 @@
-{% from "date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
 {% macro DateTimePartsField(component) %}
   {{ govukDateInput(component.model) }}

--- a/src/server/plugins/engine/views/components/details.html
+++ b/src/server/plugins/engine/views/components/details.html
@@ -1,7 +1,6 @@
-{% from "details/macro.njk" import govukDetails %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% macro Details(component) %}
   {# {{ getContext(component) | dump | safe }} #}
   {{ govukDetails(component.model)}}
 {% endmacro %}
-

--- a/src/server/plugins/engine/views/components/emailaddressfield.html
+++ b/src/server/plugins/engine/views/components/emailaddressfield.html
@@ -1,4 +1,4 @@
-{% from "./textfield.html" import TextField %}
+{% from "components/textfield.html" import TextField %}
 
 {% macro EmailAddressField(component) %}
   {{ TextField(component) }}

--- a/src/server/plugins/engine/views/components/fileuploadfield.html
+++ b/src/server/plugins/engine/views/components/fileuploadfield.html
@@ -1,4 +1,5 @@
-{% from "file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+
 {% macro FileUploadField(component) %}
   {{ govukFileUpload(component.model) }}
   {% if component.model.value %}

--- a/src/server/plugins/engine/views/components/insettext.html
+++ b/src/server/plugins/engine/views/components/insettext.html
@@ -1,4 +1,4 @@
-{% from "inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% macro InsetText(component) %}
   {{ govukInsetText({

--- a/src/server/plugins/engine/views/components/monthyearfield.html
+++ b/src/server/plugins/engine/views/components/monthyearfield.html
@@ -1,4 +1,4 @@
-{% from "date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 
 {% macro MonthYearField(component) %}
   {{ govukDateInput(component.model) }}

--- a/src/server/plugins/engine/views/components/multilinetextfield.html
+++ b/src/server/plugins/engine/views/components/multilinetextfield.html
@@ -1,5 +1,5 @@
-{% from "textarea/macro.njk" import govukTextarea %}
-{% from "character-count/macro.njk" import govukCharacterCount %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
 {% macro MultilineTextField(component) %}
   {% if component.model.isCharacterOrWordCount == true %}
@@ -8,5 +8,3 @@
     {{ govukTextarea(component.model) }}
   {% endif %}
 {% endmacro %}
-
-

--- a/src/server/plugins/engine/views/components/numberfield.html
+++ b/src/server/plugins/engine/views/components/numberfield.html
@@ -1,4 +1,4 @@
-{% from "./textfield.html" import TextField %}
+{% from "components/textfield.html" import TextField %}
 
 {% macro NumberField(component) %}
   {{ TextField(component) }}

--- a/src/server/plugins/engine/views/components/radiosfield.html
+++ b/src/server/plugins/engine/views/components/radiosfield.html
@@ -1,4 +1,4 @@
-{% from "radios/macro.njk" import govukRadios %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% macro RadiosField(component) %}
   {{ govukRadios(component.model) }}

--- a/src/server/plugins/engine/views/components/selectfield.html
+++ b/src/server/plugins/engine/views/components/selectfield.html
@@ -1,6 +1,5 @@
-{% from "select/macro.njk" import govukSelect %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
 
 {% macro SelectField(component) %}
   {{ govukSelect(component.model) }}
 {% endmacro %}
-

--- a/src/server/plugins/engine/views/components/telephonenumberfield.html
+++ b/src/server/plugins/engine/views/components/telephonenumberfield.html
@@ -1,4 +1,4 @@
-{% from "./textfield.html" import TextField %}
+{% from "components/textfield.html" import TextField %}
 
 {% macro TelephoneNumberField(component) %}
   {{ TextField(component) }}

--- a/src/server/plugins/engine/views/components/textfield.html
+++ b/src/server/plugins/engine/views/components/textfield.html
@@ -1,4 +1,4 @@
-{% from "input/macro.njk" import govukInput %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% macro TextField(component) %}
   {{ govukInput(component.model) }}

--- a/src/server/plugins/engine/views/components/timefield.html
+++ b/src/server/plugins/engine/views/components/timefield.html
@@ -1,4 +1,4 @@
-{% from "./textfield.html" import TextField %}
+{% from "components/textfield.html" import TextField %}
 
 {% macro TimeField(component) %}
   {{ TextField(component) }}

--- a/src/server/plugins/engine/views/components/ukaddressfield.html
+++ b/src/server/plugins/engine/views/components/ukaddressfield.html
@@ -1,4 +1,4 @@
-{% from "../partials/components.html" import componentList %}
+{% from "partials/components.html" import componentList %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 

--- a/src/server/plugins/engine/views/components/ukaddressfield.html
+++ b/src/server/plugins/engine/views/components/ukaddressfield.html
@@ -1,6 +1,6 @@
 {% from "../partials/components.html" import componentList %}
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% macro UkAddressField(component) %}
   {% call govukFieldset({

--- a/src/server/plugins/engine/views/components/websitefield.html
+++ b/src/server/plugins/engine/views/components/websitefield.html
@@ -1,4 +1,4 @@
-{% from "input/macro.njk" import govukInput %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% macro WebsiteField(component) %}
   {{ govukInput(component.model) }}

--- a/src/server/plugins/engine/views/components/yesnofield.html
+++ b/src/server/plugins/engine/views/components/yesnofield.html
@@ -1,4 +1,4 @@
-{% from "./radiosfield.html" import RadiosField %}
+{% from "components/radiosfield.html" import RadiosField %}
 
 {% macro YesNoField(component) %}
   {{ RadiosField(component) }}

--- a/src/server/plugins/engine/views/index.html
+++ b/src/server/plugins/engine/views/index.html
@@ -4,7 +4,7 @@
   {{ super() }}
 {% endblock %}}
 
-{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "partials/components.html" import componentList with context %}
 
 {% block content %}

--- a/src/server/plugins/engine/views/partials/conditional-components.html
+++ b/src/server/plugins/engine/views/partials/conditional-components.html
@@ -1,3 +1,3 @@
-{% from "./components.html" import componentList with context %}
+{% from "partials/components.html" import componentList with context %}
 
 {{ componentList(components) }}

--- a/src/server/plugins/engine/views/partials/form.html
+++ b/src/server/plugins/engine/views/partials/form.html
@@ -1,5 +1,5 @@
-{% from "button/macro.njk" import govukButton %}
-{% from "summary-list/macro.njk" import govukSummaryList -%}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
 
 <form method="post" enctype="multipart/form-data" autocomplete="on">
   <input type="hidden" name="crumb" value="{{crumb}}"/>

--- a/src/server/plugins/views.ts
+++ b/src/server/plugins/views.ts
@@ -66,8 +66,7 @@ export default {
        */
       join(config.appDir, 'views'),
       join(config.appDir, 'plugins/engine/views'),
-      join(govukFrontendPath, 'govuk'),
-      join(govukFrontendPath, 'govuk/components'),
+      govukFrontendPath,
       join(hmpoComponentsPath, 'components')
     ],
     isCached: !config.isDev,

--- a/src/server/plugins/views.ts
+++ b/src/server/plugins/views.ts
@@ -10,6 +10,17 @@ import config from '../config.js'
 import additionalContexts from '../templates/additionalContexts.json'
 import type { Request } from '@hapi/hapi'
 
+const [govukFrontendPath, hmpoComponentsPath] = [
+  'govuk-frontend',
+  'hmpo-components'
+].map((pkgName) =>
+  dirname(
+    resolvePkg.sync(`${pkgName}/package.json`, {
+      basedir: cwd()
+    })
+  )
+)
+
 export default {
   plugin: vision,
   options: {
@@ -55,9 +66,9 @@ export default {
        */
       join(config.appDir, 'views'),
       join(config.appDir, 'plugins/engine/views'),
-      `${dirname(resolvePkg.sync('govuk-frontend', { basedir: cwd() }))}`,
-      `${dirname(resolvePkg.sync('govuk-frontend', { basedir: cwd() }))}/components`,
-      `${dirname(resolvePkg.sync('hmpo-components'))}/components`
+      join(govukFrontendPath, 'govuk'),
+      join(govukFrontendPath, 'govuk/components'),
+      join(hmpoComponentsPath, 'components')
     ],
     isCached: !config.isDev,
     context: (request: Request) => ({

--- a/src/server/routes/public.ts
+++ b/src/server/routes/public.ts
@@ -1,10 +1,21 @@
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { cwd } from 'node:process'
+
+import resolvePkg from 'resolve'
 
 import config from '../config.js'
 
-const routesDir = dirname(fileURLToPath(import.meta.url))
-const modulesDir = join(routesDir, '../../../node_modules')
+const [accessibleAutocompletePath, govukFrontendPath, hmpoComponentsPath] = [
+  'accessible-autocomplete',
+  'govuk-frontend',
+  'hmpo-components'
+].map((pkgName) =>
+  dirname(
+    resolvePkg.sync(`${pkgName}/package.json`, {
+      basedir: cwd()
+    })
+  )
+)
 
 export default [
   {
@@ -16,10 +27,10 @@ export default [
           path: [
             join(config.publicDir, 'static'),
             join(config.publicDir, 'build'),
-            join(modulesDir, 'accessible-autocomplete', 'dist'),
-            join(modulesDir, 'govuk-frontend', 'govuk'),
-            join(modulesDir, 'govuk-frontend', 'govuk', 'assets'),
-            join(modulesDir, 'hmpo-components', 'assets')
+            join(govukFrontendPath, 'govuk'),
+            join(govukFrontendPath, 'govuk/assets'),
+            join(hmpoComponentsPath, 'assets'),
+            accessibleAutocompletePath
           ]
         }
       }

--- a/src/server/views/application-error.html
+++ b/src/server/views/application-error.html
@@ -1,4 +1,4 @@
-{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% extends 'layout.html' %}
 {% block content %}

--- a/src/server/views/confirmation.html
+++ b/src/server/views/confirmation.html
@@ -1,6 +1,6 @@
 {% set mainClasses = "govuk-main-wrapper--l" %}
 {% set skipTimeoutWarning = true %}
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% extends 'layout.html' %}
 {% from "partials/components.html" import componentList %}
 

--- a/src/server/views/help/cookies.html
+++ b/src/server/views/help/cookies.html
@@ -1,6 +1,6 @@
 {% extends 'layout.html' %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block content %}
 <div class="govuk-grid-row">

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -1,10 +1,10 @@
-{% extends "template.njk" %}
+{% extends "govuk/template.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "footer/macro.njk" import govukFooter -%}
-{% from "phase-banner/macro.njk" import govukPhaseBanner %}
-{% from "skip-link/macro.njk" import govukSkipLink -%}
-{% from "cookie-banner/macro.njk" import govukCookieBanner %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/footer/macro.njk" import govukFooter -%}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/skip-link/macro.njk" import govukSkipLink -%}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
 
 {% block head %}

--- a/src/server/views/partials/summary-detail.html
+++ b/src/server/views/partials/summary-detail.html
@@ -1,4 +1,4 @@
-{% from "./summary-row.html" import summaryRow %}
+{% from "partials/summary-row.html" import summaryRow %}
 
 {% macro summaryDetail(data) %}
     {%  set isRepeatableSection = (data.items[0] | isArray) %}

--- a/src/server/views/pay-error.html
+++ b/src/server/views/pay-error.html
@@ -1,5 +1,5 @@
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% extends 'layout.html' %}
 {% block content %}

--- a/src/server/views/repeating-summary.html
+++ b/src/server/views/repeating-summary.html
@@ -1,6 +1,6 @@
 {% from "partials/summary-detail.html" import summaryDetail %}
-{% from "summary-list/macro.njk" import govukSummaryList -%}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% extends 'layout.html' %}
 
@@ -24,4 +24,3 @@
     </div>
   </div>
 {% endblock %}
-

--- a/src/server/views/summary.html
+++ b/src/server/views/summary.html
@@ -1,5 +1,5 @@
 {% from "partials/summary-detail.html" import summaryDetail %}
-{% from "components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% extends 'layout.html' %}
 
 {% block content %}

--- a/src/server/views/timeout.html
+++ b/src/server/views/timeout.html
@@ -1,6 +1,6 @@
 {% set mainClasses = "govuk-main-wrapper--l" %}
 {% set skipTimeoutWarning = true %}
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% extends 'layout.html' %}
 

--- a/src/server/views/upload-playback.html
+++ b/src/server/views/upload-playback.html
@@ -1,8 +1,8 @@
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "details/macro.njk" import govukDetails %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% extends "layout.html" %}
 
@@ -50,4 +50,3 @@
     </div>
   </div>
 {% endblock %}
-


### PR DESCRIPTION
To simplify sharing Nunjucks templates with **forms-designer** I've followed [**Set up Nunjucks and use the page template**](https://frontend.design-system.service.gov.uk/v4/use-nunjucks/#set-up-nunjucks-and-use-the-page-template) from the GOV.UK Frontend documentation