### PR TITLE
Default appPathPrefix to empty string

### DIFF
--- a/config/default.cjs
+++ b/config/default.cjs
@@ -20,7 +20,7 @@ module.exports = {
    */
   port: process.env.PORT || 3009,
   env: process.env.NODE_ENV || 'development',
-  appPathPrefix: process.env.APP_PATH_PREFIX || '',
+  appPathPrefix: process.env.APP_PATH_PREFIX,
   previewMode: false,
   enforceCsrf: true,
   sandbox: false,

--- a/config/default.cjs
+++ b/config/default.cjs
@@ -20,7 +20,7 @@ module.exports = {
    */
   port: process.env.PORT || 3009,
   env: process.env.NODE_ENV || 'development',
-  appPathPrefix: process.env.APP_PATH_PREFIX || '/forms-runner',
+  appPathPrefix: process.env.APP_PATH_PREFIX || '',
   previewMode: false,
   enforceCsrf: true,
   sandbox: false,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -84,7 +84,9 @@ const serverOptions = (): ServerOptions => {
 }
 
 const registrationOptions = {
-  routes: { prefix: config.appPathPrefix }
+  routes: {
+    prefix: config.appPathPrefix === '' ? undefined : config.appPathPrefix
+  }
 }
 
 async function createServer(routeConfig: RouteConfig) {

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -79,11 +79,11 @@ export const plugin = {
     server.app.forms = {}
     const forms = server.app.forms
 
-    configs.forEach((config) => {
+    configs.forEach((form) => {
       const basePath =
-        formBasePath === '' ? config.id : `${formBasePath}/${config.id}`
+        formBasePath === '' ? form.id : `${formBasePath}/${form.id}`
 
-      forms[config.id] = new FormModel(config.configuration, {
+      forms[form.id] = new FormModel(form.configuration, {
         ...modelOptions,
         basePath
       })

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -80,9 +80,12 @@ export const plugin = {
     const forms = server.app.forms
 
     configs.forEach((config) => {
+      const basePath =
+        formBasePath === '' ? config.id : `${formBasePath}/${config.id}`
+
       forms[config.id] = new FormModel(config.configuration, {
         ...modelOptions,
-        basePath: `${formBasePath}/${config.id}`
+        basePath
       })
     })
 

--- a/src/server/utils/configSchema.ts
+++ b/src/server/utils/configSchema.ts
@@ -24,6 +24,12 @@ export const configSchema = Joi.object({
   appDir: Joi.string()
     .optional()
     .default(resolve(dirname(configPath), '../../server')),
+  appPathPrefix: Joi.string()
+    .optional()
+    .uri({ relativeOnly: true })
+    .trim()
+    .empty('/')
+    .default(''),
   publicDir: Joi.string()
     .optional()
     .default(resolve(dirname(configPath), '../../../public')),

--- a/test/cases/server/csrf.test.js
+++ b/test/cases/server/csrf.test.js
@@ -4,6 +4,7 @@ import cheerio from 'cheerio'
 import FormData from 'form-data'
 import cookie from 'cookie'
 import createServer from '../../../src/server/index.js'
+import config from '../../../src/server/config.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
 
@@ -15,7 +16,7 @@ describe('CSRF', () => {
   const options = () => {
     return {
       method: 'POST',
-      url: '/basic-v0/start',
+      url: `${config.appPathPrefix}/basic-v0/start`,
       headers: form.getHeaders(),
       payload: form.getBuffer()
     }
@@ -38,7 +39,7 @@ describe('CSRF', () => {
   test('get request returns CSRF header', async () => {
     const options = {
       method: 'GET',
-      url: '/basic-v0/start'
+      url: `${config.appPathPrefix}/basic-v0/start`
     }
 
     const response = await server.inject(options)

--- a/test/cases/server/csrf.test.js
+++ b/test/cases/server/csrf.test.js
@@ -15,7 +15,7 @@ describe('CSRF', () => {
   const options = () => {
     return {
       method: 'POST',
-      url: '/forms-runner/basic-v0/start',
+      url: '/basic-v0/start',
       headers: form.getHeaders(),
       payload: form.getBuffer()
     }
@@ -38,7 +38,7 @@ describe('CSRF', () => {
   test('get request returns CSRF header', async () => {
     const options = {
       method: 'GET',
-      url: '/forms-runner/basic-v0/start'
+      url: '/basic-v0/start'
     }
 
     const response = await server.inject(options)

--- a/test/cases/server/feedback.test.js
+++ b/test/cases/server/feedback.test.js
@@ -2,6 +2,7 @@ import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import cheerio from 'cheerio'
 import createServer from '../../../src/server/index.js'
+import config from '../../../src/server/config.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
 
@@ -23,7 +24,7 @@ describe(`Feedback`, () => {
   test('get request returns configured form page', async () => {
     const options = {
       method: 'GET',
-      url: '/feedback/uk-passport'
+      url: `${config.appPathPrefix}/feedback/uk-passport`
     }
 
     const response = await server.inject(options)

--- a/test/cases/server/feedback.test.js
+++ b/test/cases/server/feedback.test.js
@@ -23,7 +23,7 @@ describe(`Feedback`, () => {
   test('get request returns configured form page', async () => {
     const options = {
       method: 'GET',
-      url: `/forms-runner/feedback/uk-passport`
+      url: '/feedback/uk-passport'
     }
 
     const response = await server.inject(options)

--- a/test/cases/server/health-check.test.js
+++ b/test/cases/server/health-check.test.js
@@ -18,7 +18,7 @@ describe(`/health-check Route`, () => {
   test('/health-check route response is correct', async () => {
     const options = {
       method: 'GET',
-      url: '/health-check'
+      url: `${config.appPathPrefix}/health-check`
     }
 
     const { result } = await server.inject(options)

--- a/test/cases/server/health-check.test.js
+++ b/test/cases/server/health-check.test.js
@@ -18,7 +18,7 @@ describe(`/health-check Route`, () => {
   test('/health-check route response is correct', async () => {
     const options = {
       method: 'GET',
-      url: '/forms-runner/health-check'
+      url: '/health-check'
     }
 
     const { result } = await server.inject(options)

--- a/test/cases/server/phase-banner.test.js
+++ b/test/cases/server/phase-banner.test.js
@@ -23,7 +23,7 @@ describe(`Phase banner`, () => {
 
     const options = {
       method: 'GET',
-      url: `/forms-runner/phase-default/first-page`
+      url: `/phase-default/first-page`
     }
 
     const response = await server.inject(options)
@@ -43,7 +43,7 @@ describe(`Phase banner`, () => {
 
     const options = {
       method: 'GET',
-      url: `/forms-runner/phase-alpha/first-page`
+      url: '/phase-alpha/first-page'
     }
 
     const response = await server.inject(options)
@@ -63,7 +63,7 @@ describe(`Phase banner`, () => {
 
     const options = {
       method: 'GET',
-      url: `/forms-runner/phase-none/first-page`
+      url: '/phase-none/first-page'
     }
 
     const response = await server.inject(options)

--- a/test/cases/server/phase-banner.test.js
+++ b/test/cases/server/phase-banner.test.js
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import cheerio from 'cheerio'
 import createServer from '../../../src/server/index.js'
+import config from '../../../src/server/config.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
 
@@ -23,7 +24,7 @@ describe(`Phase banner`, () => {
 
     const options = {
       method: 'GET',
-      url: `/phase-default/first-page`
+      url: `${config.appPathPrefix}/phase-default/first-page`
     }
 
     const response = await server.inject(options)
@@ -43,7 +44,7 @@ describe(`Phase banner`, () => {
 
     const options = {
       method: 'GET',
-      url: '/phase-alpha/first-page'
+      url: `${config.appPathPrefix}/phase-alpha/first-page`
     }
 
     const response = await server.inject(options)
@@ -63,7 +64,7 @@ describe(`Phase banner`, () => {
 
     const options = {
       method: 'GET',
-      url: '/phase-none/first-page'
+      url: `${config.appPathPrefix}/phase-none/first-page`
     }
 
     const response = await server.inject(options)

--- a/test/cases/server/plugins/auth.test.ts
+++ b/test/cases/server/plugins/auth.test.ts
@@ -65,7 +65,7 @@ describe('Server Auth', () => {
       // Create an initial session
       const prepResponse = await server.inject({
         method: 'GET',
-        url: '/forms-runner'
+        url: '/'
       })
       const initialSession = prepResponse.headers['set-cookie'].find((cookie) =>
         cookie.startsWith('session=')
@@ -74,7 +74,7 @@ describe('Server Auth', () => {
       // We can first check the created session works as expected:
       const checkPrepResponse = await server.inject({
         method: 'GET',
-        url: '/forms-runner',
+        url: '/',
         headers: {
           Cookie: initialSession.replace('Secure; HttpOnly; ', '')
         }
@@ -113,7 +113,7 @@ describe('Server Auth', () => {
     test("shows a 'sign out' link in the header if logged in", async () => {
       const options = {
         method: 'GET',
-        url: '/forms-runner/test/start',
+        url: '/test/start',
         auth: {
           strategy: 'session',
           credentials: {
@@ -135,7 +135,7 @@ describe('Server Auth', () => {
     test("does not show a 'sign out' link in the header if logged out", async () => {
       const options = {
         method: 'GET',
-        url: '/forms-runner/test/start'
+        url: '/test/start'
       }
 
       const res = await server.inject(options)
@@ -147,35 +147,31 @@ describe('Server Auth', () => {
     test('redirects to login page if accessing a question page', async () => {
       const options = {
         method: 'GET',
-        url: '/forms-runner/test/uk-passport'
+        url: '/test/uk-passport'
       }
 
       const res = await server.inject(options)
 
       expect(res.statusCode).toBe(302)
-      expect(res.headers.location).toBe(
-        '/login?returnUrl=/forms-runner/test/uk-passport'
-      )
+      expect(res.headers.location).toBe('/login?returnUrl=/test/uk-passport')
     })
 
     test('redirects to login page if accessing a summary page', async () => {
       const options = {
         method: 'GET',
-        url: '/forms-runner/test/summary'
+        url: '/test/summary'
       }
 
       const res = await server.inject(options)
 
       expect(res.statusCode).toBe(302)
-      expect(res.headers.location).toBe(
-        '/login?returnUrl=/forms-runner/test/summary'
-      )
+      expect(res.headers.location).toBe('/login?returnUrl=/test/summary')
     })
 
     test('does not redirect to login if accessing the start page', async () => {
       const options = {
         method: 'GET',
-        url: '/forms-runner/test/start'
+        url: '/test/start'
       }
 
       const res = await server.inject(options)

--- a/test/cases/server/plugins/auth.test.ts
+++ b/test/cases/server/plugins/auth.test.ts
@@ -65,7 +65,7 @@ describe('Server Auth', () => {
       // Create an initial session
       const prepResponse = await server.inject({
         method: 'GET',
-        url: '/'
+        url: `${config.appPathPrefix || '/'}`
       })
       const initialSession = prepResponse.headers['set-cookie'].find((cookie) =>
         cookie.startsWith('session=')
@@ -74,7 +74,7 @@ describe('Server Auth', () => {
       // We can first check the created session works as expected:
       const checkPrepResponse = await server.inject({
         method: 'GET',
-        url: '/',
+        url: `${config.appPathPrefix || '/'}`,
         headers: {
           Cookie: initialSession.replace('Secure; HttpOnly; ', '')
         }
@@ -113,7 +113,7 @@ describe('Server Auth', () => {
     test("shows a 'sign out' link in the header if logged in", async () => {
       const options = {
         method: 'GET',
-        url: '/test/start',
+        url: `${config.appPathPrefix}/test/start`,
         auth: {
           strategy: 'session',
           credentials: {
@@ -135,7 +135,7 @@ describe('Server Auth', () => {
     test("does not show a 'sign out' link in the header if logged out", async () => {
       const options = {
         method: 'GET',
-        url: '/test/start'
+        url: `${config.appPathPrefix}/test/start`
       }
 
       const res = await server.inject(options)
@@ -147,31 +147,35 @@ describe('Server Auth', () => {
     test('redirects to login page if accessing a question page', async () => {
       const options = {
         method: 'GET',
-        url: '/test/uk-passport'
+        url: `${config.appPathPrefix}/test/uk-passport`
       }
 
       const res = await server.inject(options)
 
       expect(res.statusCode).toBe(302)
-      expect(res.headers.location).toBe('/login?returnUrl=/test/uk-passport')
+      expect(res.headers.location).toBe(
+        `/login?returnUrl=${config.appPathPrefix}/test/uk-passport`
+      )
     })
 
     test('redirects to login page if accessing a summary page', async () => {
       const options = {
         method: 'GET',
-        url: '/test/summary'
+        url: `${config.appPathPrefix}/test/summary`
       }
 
       const res = await server.inject(options)
 
       expect(res.statusCode).toBe(302)
-      expect(res.headers.location).toBe('/login?returnUrl=/test/summary')
+      expect(res.headers.location).toBe(
+        `/login?returnUrl=${config.appPathPrefix}/test/summary`
+      )
     })
 
     test('does not redirect to login if accessing the start page', async () => {
       const options = {
         method: 'GET',
-        url: '/test/start'
+        url: `${config.appPathPrefix}/test/start`
       }
 
       const res = await server.inject(options)

--- a/test/cases/server/plugins/router.test.ts
+++ b/test/cases/server/plugins/router.test.ts
@@ -15,7 +15,7 @@ describe('Server Router', () => {
   test('cookies page is served', async () => {
     const options = {
       method: 'GET',
-      url: `/forms-runner/help/cookies`
+      url: '/help/cookies'
     }
 
     const res = await server.inject(options)
@@ -34,7 +34,7 @@ describe('Server Router', () => {
       payload: {
         cookies: 'accept'
       },
-      url: '/forms-runner/help/cookies'
+      url: '/help/cookies'
     }
 
     const res = await server.inject(options)
@@ -45,7 +45,7 @@ describe('Server Router', () => {
   test('accessibility statement page is served', async () => {
     const options = {
       method: 'GET',
-      url: `/forms-runner/help/accessibility-statement`
+      url: '/help/accessibility-statement'
     }
 
     const res = await server.inject(options)
@@ -61,7 +61,7 @@ describe('Server Router', () => {
   test('terms and conditions page is served', async () => {
     const options = {
       method: 'GET',
-      url: `/forms-runner/help/terms-and-conditions`
+      url: '/help/terms-and-conditions'
     }
 
     const res = await server.inject(options)

--- a/test/cases/server/plugins/router.test.ts
+++ b/test/cases/server/plugins/router.test.ts
@@ -1,3 +1,4 @@
+import config from '../../../../src/server/config.js'
 import createServer from '../../../../src/server/index.js'
 
 describe('Server Router', () => {
@@ -15,7 +16,7 @@ describe('Server Router', () => {
   test('cookies page is served', async () => {
     const options = {
       method: 'GET',
-      url: '/help/cookies'
+      url: `${config.appPathPrefix}/help/cookies`
     }
 
     const res = await server.inject(options)
@@ -34,7 +35,7 @@ describe('Server Router', () => {
       payload: {
         cookies: 'accept'
       },
-      url: '/help/cookies'
+      url: `${config.appPathPrefix}/help/cookies`
     }
 
     const res = await server.inject(options)
@@ -45,7 +46,7 @@ describe('Server Router', () => {
   test('accessibility statement page is served', async () => {
     const options = {
       method: 'GET',
-      url: '/help/accessibility-statement'
+      url: `${config.appPathPrefix}/help/accessibility-statement`
     }
 
     const res = await server.inject(options)
@@ -61,7 +62,7 @@ describe('Server Router', () => {
   test('terms and conditions page is served', async () => {
     const options = {
       method: 'GET',
-      url: '/help/terms-and-conditions'
+      url: `${config.appPathPrefix}/help/terms-and-conditions`
     }
 
     const res = await server.inject(options)

--- a/test/cases/server/titles.test.js
+++ b/test/cases/server/titles.test.js
@@ -24,7 +24,7 @@ describe('Title and section title', () => {
   it('does not render the section title if it is the same as the title', async () => {
     const options = {
       method: 'GET',
-      url: `/forms-runner/titles/applicant-one?visit=1`
+      url: '/titles/applicant-one?visit=1'
     }
 
     const response = await server.inject(options)
@@ -36,7 +36,7 @@ describe('Title and section title', () => {
   it('does render the section title if it is not the same as the title', async () => {
     const options = {
       method: 'GET',
-      url: `/forms-runner/titles/applicant-one-address?visit=1`
+      url: '/titles/applicant-one-address?visit=1'
     }
 
     const response = await server.inject(options)
@@ -48,7 +48,7 @@ describe('Title and section title', () => {
   it('renders the section title as H2, outside of the H1', async () => {
     const options = {
       method: 'GET',
-      url: `/forms-runner/titles/applicant-one-address?visit=1`
+      url: '/titles/applicant-one-address?visit=1'
     }
 
     const response = await server.inject(options)
@@ -61,7 +61,7 @@ describe('Title and section title', () => {
   it('Does not render the section title if hideTitle is set to true', async () => {
     const options = {
       method: 'GET',
-      url: `/forms-runner/titles/applicant-two?visit=1`
+      url: '/titles/applicant-two?visit=1'
     }
 
     const response = await server.inject(options)

--- a/test/cases/server/titles.test.js
+++ b/test/cases/server/titles.test.js
@@ -2,6 +2,7 @@ import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import cheerio from 'cheerio'
 import createServer from '../../../src/server/index.js'
+import config from '../../../src/server/config.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
 
@@ -24,7 +25,7 @@ describe('Title and section title', () => {
   it('does not render the section title if it is the same as the title', async () => {
     const options = {
       method: 'GET',
-      url: '/titles/applicant-one?visit=1'
+      url: `${config.appPathPrefix}/titles/applicant-one?visit=1`
     }
 
     const response = await server.inject(options)
@@ -36,7 +37,7 @@ describe('Title and section title', () => {
   it('does render the section title if it is not the same as the title', async () => {
     const options = {
       method: 'GET',
-      url: '/titles/applicant-one-address?visit=1'
+      url: `${config.appPathPrefix}/titles/applicant-one-address?visit=1`
     }
 
     const response = await server.inject(options)
@@ -48,7 +49,7 @@ describe('Title and section title', () => {
   it('renders the section title as H2, outside of the H1', async () => {
     const options = {
       method: 'GET',
-      url: '/titles/applicant-one-address?visit=1'
+      url: `${config.appPathPrefix}/titles/applicant-one-address?visit=1`
     }
 
     const response = await server.inject(options)
@@ -61,7 +62,7 @@ describe('Title and section title', () => {
   it('Does not render the section title if hideTitle is set to true', async () => {
     const options = {
       method: 'GET',
-      url: '/titles/applicant-two?visit=1'
+      url: `${config.appPathPrefix}/titles/applicant-two?visit=1`
     }
 
     const response = await server.inject(options)

--- a/test/cases/server/upload.test.js
+++ b/test/cases/server/upload.test.js
@@ -34,14 +34,14 @@ describe('uploads', () => {
     // form.append('file2', Buffer.from([]))
     const options = {
       method: 'POST',
-      url: '/upload/upload-file',
+      url: `${config.appPathPrefix}/upload/upload-file`,
       headers: form.getHeaders(),
       payload: form.getBuffer()
     }
     const response = await server.inject(options)
     expect(response.statusCode).toBe(302)
     expect(response.headers).toMatchObject({
-      location: '/upload/summary'
+      location: `${config.appPathPrefix}/upload/summary`
     })
   })
 
@@ -67,7 +67,7 @@ describe('uploads', () => {
     form.append('file1', fs.readFileSync(join(testDir, 'dummy.pdf')))
     const options = {
       method: 'POST',
-      url: '/upload/upload-file',
+      url: `${config.appPathPrefix}/upload/upload-file`,
       headers: form.getHeaders(),
       payload: form.getBuffer()
     }
@@ -89,7 +89,7 @@ describe('uploads', () => {
     form.append('file1', data)
     const options = {
       method: 'POST',
-      url: '/upload/upload-file',
+      url: `${config.appPathPrefix}/upload/upload-file`,
       headers: form.getHeaders(),
       payload: null
     }
@@ -120,7 +120,7 @@ describe('uploads', () => {
     form.append('file1', fs.readFileSync(join(testDir, 'dummy.pdf')))
     const options = {
       method: 'POST',
-      url: '/upload/upload-file',
+      url: `${config.appPathPrefix}/upload/upload-file`,
       headers: form.getHeaders(),
       payload: form.getBuffer()
     }

--- a/test/cases/server/upload.test.js
+++ b/test/cases/server/upload.test.js
@@ -34,14 +34,14 @@ describe('uploads', () => {
     // form.append('file2', Buffer.from([]))
     const options = {
       method: 'POST',
-      url: '/forms-runner/upload/upload-file',
+      url: '/upload/upload-file',
       headers: form.getHeaders(),
       payload: form.getBuffer()
     }
     const response = await server.inject(options)
     expect(response.statusCode).toBe(302)
     expect(response.headers).toMatchObject({
-      location: '/forms-runner/upload/summary'
+      location: '/upload/summary'
     })
   })
 
@@ -67,7 +67,7 @@ describe('uploads', () => {
     form.append('file1', fs.readFileSync(join(testDir, 'dummy.pdf')))
     const options = {
       method: 'POST',
-      url: '/forms-runner/upload/upload-file',
+      url: '/upload/upload-file',
       headers: form.getHeaders(),
       payload: form.getBuffer()
     }
@@ -89,7 +89,7 @@ describe('uploads', () => {
     form.append('file1', data)
     const options = {
       method: 'POST',
-      url: '/forms-runner/upload/upload-file',
+      url: '/upload/upload-file',
       headers: form.getHeaders(),
       payload: null
     }
@@ -120,7 +120,7 @@ describe('uploads', () => {
     form.append('file1', fs.readFileSync(join(testDir, 'dummy.pdf')))
     const options = {
       method: 'POST',
-      url: '/forms-runner/upload/upload-file',
+      url: '/upload/upload-file',
       headers: form.getHeaders(),
       payload: form.getBuffer()
     }


### PR DESCRIPTION
Replace the default `appPathPrefix` (/forms-runner) with empty string.

Keep the capabilty to have a path prefix in case it needs to be reintroduced.