### PR TITLE
Feature/369420 run forms from db

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -3,6 +3,7 @@
   "env": "NODE_ENV",
   "logLevel": "LOG_LEVEL",
   "logPrettyPrint": "LOG_PRETTY_PRINT",
+  "managerUrl": "MANAGER_URL",
   "ordnanceSurveyKey": "ORDNANCE_SURVEY_KEY",
   "browserRefreshUrl": "BROWSER_REFRESH_URL",
   "feedbackLink": "FEEDBACK_LINK",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.84",
+        "@defra/forms-model": "^3.0.94",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/bell": "^13.0.2",
         "@hapi/boom": "^10.0.1",
@@ -2044,9 +2044,9 @@
       "dev": true
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.84",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.84.tgz",
-      "integrity": "sha512-o0PgyBoXL4ojwzANXi58+XMQ8FjbUXPEMjKDDL5cikqrjwt5Io5pLSbg71STJGdZTQv7+oSle5cBB6YeNXvPRA==",
+      "version": "3.0.94",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.94.tgz",
+      "integrity": "sha512-jn1t2kQD0sVDVu84WaN+Gb3AfXt7coY1o8EYk9zY5y1k8mG2cG3idveHhNDGePCZFqBCsgT0bG/DURiAVXrCiw==",
       "engines": {
         "node": "^20.9.0",
         "npm": "^10.1.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@defra/forms-model": "^3.0.84",
+    "@defra/forms-model": "^3.0.94",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/bell": "^13.0.2",
     "@hapi/boom": "^10.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import createServer from '~/src/server/index.js'
 
-createServer({})
+createServer({
+  formFileName: 'test.json',
+  formFilePath: 'src/server/forms'
+})
   .then((server) => server.start())
   .then(() => process.send?.('online'))
   .catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,6 @@
 import createServer from '~/src/server/index.js'
 
-createServer({
-  formFileName: 'test.json',
-  formFilePath: 'src/server/forms'
-})
+createServer({})
   .then((server) => server.start())
   .then(() => process.send?.('online'))
   .catch((err) => {

--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -16,7 +16,7 @@ type ConfigureEnginePlugin = (
 ) => {
   plugin: any
   options: {
-    model: any
+    model?: FormModel
     previewMode: boolean
   }
 }

--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -32,16 +32,17 @@ export const configureEnginePlugin: ConfigureEnginePlugin = (
   // let configs: FormConfiguration[]
   let model
 
-  // const modelOptions = {
-  //   relativeTo: join(config.appDir, 'plugins/engine/views'),
-  //   previewMode: options?.previewMode ?? config.previewMode
-  // }
+  const modelOptions = {
+    relativeTo: join(config.appDir, 'plugins/engine/views'),
+    previewMode: options?.previewMode ?? config.previewMode
+  }
 
   if (formFileName && formFilePath) {
     const formConfigPath = join(formFilePath, formFileName)
     const definition = JSON.parse(fs.readFileSync(formConfigPath, 'utf8'))
     model = new FormModel(definition, {
-      basePath: idFromFilename(formFileName)
+      basePath: idFromFilename(formFileName),
+      ...modelOptions
     })
     //   configs = [
     //     {

--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -30,7 +30,7 @@ export const configureEnginePlugin: ConfigureEnginePlugin = (
   options?: EngineOptions
 ) => {
   // let configs: FormConfiguration[]
-  let model
+  let model: FormModel | undefined
 
   const modelOptions = {
     relativeTo: join(config.appDir, 'plugins/engine/views'),

--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -3,11 +3,12 @@ import { join } from 'node:path'
 
 import config from '~/src/server/config.js'
 import { idFromFilename } from '~/src/server/plugins/engine/helpers.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { plugin } from '~/src/server/plugins/engine/plugin.js'
-import {
-  loadPreConfiguredForms,
-  type FormConfiguration
-} from '~/src/server/plugins/engine/services/configurationService.js'
+// import {
+//   loadPreConfiguredForms,
+//   type FormConfiguration
+// } from '~/src/server/plugins/engine/services/configurationService.js'
 
 type ConfigureEnginePlugin = (
   formFileName?: string,
@@ -15,14 +16,7 @@ type ConfigureEnginePlugin = (
 ) => {
   plugin: any
   options: {
-    modelOptions: {
-      relativeTo: string
-      previewMode: any
-    }
-    configs: {
-      configuration: any
-      id: string
-    }[]
+    model: any
     previewMode: boolean
   }
 }
@@ -35,28 +29,32 @@ export const configureEnginePlugin: ConfigureEnginePlugin = (
   formFilePath,
   options?: EngineOptions
 ) => {
-  let configs: FormConfiguration[]
+  // let configs: FormConfiguration[]
+  let model
+
+  // const modelOptions = {
+  //   relativeTo: join(config.appDir, 'plugins/engine/views'),
+  //   previewMode: options?.previewMode ?? config.previewMode
+  // }
 
   if (formFileName && formFilePath) {
     const formConfigPath = join(formFilePath, formFileName)
-
-    configs = [
-      {
-        configuration: JSON.parse(fs.readFileSync(formConfigPath, 'utf8')),
-        id: idFromFilename(formFileName)
-      }
-    ]
-  } else {
-    configs = loadPreConfiguredForms()
-  }
-
-  const modelOptions = {
-    relativeTo: join(config.appDir, 'plugins/engine/views'),
-    previewMode: options?.previewMode ?? config.previewMode
+    const definition = JSON.parse(fs.readFileSync(formConfigPath, 'utf8'))
+    model = new FormModel(definition, {
+      basePath: idFromFilename(formFileName)
+    })
+    //   configs = [
+    //     {
+    //       configuration: JSON.parse(fs.readFileSync(formConfigPath, 'utf8')),
+    //       id: idFromFilename(formFileName)
+    //     }
+    //   ]
+    // } else {
+    //   configs = loadPreConfiguredForms()
   }
 
   return {
     plugin,
-    options: { modelOptions, configs, previewMode: config.previewMode }
+    options: { model, previewMode: config.previewMode }
   }
 }

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -73,6 +73,10 @@ function getStartPageRedirect(
 
 interface PluginOptions {
   relativeTo?: string
+  modelOptions: {
+    relativeTo: string
+    previewMode: any
+  }
   model: any
   previewMode: boolean
 }
@@ -82,7 +86,7 @@ export const plugin = {
   dependencies: '@hapi/vision',
   multiple: true,
   register: (server: Server, options: PluginOptions) => {
-    const { model, previewMode } = options
+    const { model, previewMode, modelOptions } = options
     const enabledString = config.previewMode ? `[ENABLED]` : `[DISABLED]`
     const disabledRouteDetailString =
       'A request was made however previewing is disabled. See environment variable details in runner/README.md if this error is not expected.'
@@ -260,7 +264,10 @@ export const plugin = {
             server.logger.info(
               `Building model for form definition ${id} (${slug})`
             )
-            const model = new FormModel(definition, { basePath: slug })
+            const model = new FormModel(definition, {
+              basePath: slug,
+              ...modelOptions
+            })
 
             // Create new cache item
             item = { model, updatedAt: state.updatedAt }

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -1,7 +1,11 @@
 import { dirname, join } from 'node:path'
 import { cwd } from 'node:process'
 
-import { FormConfiguration, type FormDefinition } from '@defra/forms-model'
+import {
+  FormConfiguration,
+  slugSchema,
+  type FormDefinition
+} from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import {
   type PluginSpecificConfiguration,
@@ -301,7 +305,7 @@ export const plugin = {
         ],
         validate: {
           params: Joi.object().keys({
-            slug: Joi.string().required()
+            slug: slugSchema
           })
         }
       }

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -77,7 +77,7 @@ interface PluginOptions {
     relativeTo: string
     previewMode: any
   }
-  model: any
+  model?: FormModel
   previewMode: boolean
 }
 

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -2,9 +2,9 @@ import { dirname, join } from 'node:path'
 import { cwd } from 'node:process'
 
 import {
-  FormConfiguration,
-  slugSchema,
-  type FormDefinition
+  // FormConfiguration,
+  slugSchema
+  // type FormDefinition
 } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import {
@@ -90,17 +90,17 @@ export const plugin = {
   dependencies: '@hapi/vision',
   multiple: true,
   register: (server: Server, options: PluginOptions) => {
-    const { model, previewMode, modelOptions } = options
-    const enabledString = config.previewMode ? `[ENABLED]` : `[DISABLED]`
-    const disabledRouteDetailString =
-      'A request was made however previewing is disabled. See environment variable details in runner/README.md if this error is not expected.'
+    const { model, modelOptions } = options
+    // const enabledString = config.previewMode ? `[ENABLED]` : `[DISABLED]`
+    // const disabledRouteDetailString =
+    //   'A request was made however previewing is disabled. See environment variable details in runner/README.md if this error is not expected.'
 
     server.app.model = model
 
     /**
      * @typedef {object} CacheItem
-     * @property {FormModel} model
-     * @property {Date} updatedAt
+     * @property {FormModel} model - the form model
+     * @property {Date} updatedAt - The time the cache item was updated
      */
 
     /**

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -9,8 +9,9 @@ import {
   type ResponseToolkit,
   type Server
 } from '@hapi/hapi'
-import nunjucks from 'nunjucks'
+import { isEqual } from 'date-fns'
 import Joi from 'joi'
+import nunjucks from 'nunjucks'
 import resolvePkg from 'resolve'
 
 import config from '~/src/server/config.js'
@@ -20,6 +21,10 @@ import {
   redirectTo
 } from '~/src/server/plugins/engine/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/index.js'
+import {
+  getFormDefinition,
+  getFormMetadata
+} from '~/src/server/plugins/engine/services/formsService.js'
 import { type FormPayload } from '~/src/server/plugins/engine/types.js'
 
 const [govukFrontendPath, hmpoComponentsPath] = [
@@ -47,7 +52,7 @@ function normalisePath(path: string) {
 function getStartPageRedirect(
   request: Request,
   h: ResponseToolkit,
-  id: string,
+  slug: string,
   model: FormModel
 ) {
   const startPage = normalisePath(model.def.startPage ?? '')
@@ -68,8 +73,7 @@ function getStartPageRedirect(
 
 interface PluginOptions {
   relativeTo?: string
-  modelOptions: any
-  configs: any[]
+  model: any
   previewMode: boolean
 }
 
@@ -78,20 +82,24 @@ export const plugin = {
   dependencies: '@hapi/vision',
   multiple: true,
   register: (server: Server, options: PluginOptions) => {
-    const { modelOptions, configs, previewMode } = options
-    server.app.forms = {}
-    const forms = server.app.forms
-
-    configs.forEach((form) => {
-      forms[form.id] = new FormModel(form.configuration, {
-        ...modelOptions,
-        basePath: form.id
-      })
-    })
-
+    const { model, previewMode } = options
     const enabledString = config.previewMode ? `[ENABLED]` : `[DISABLED]`
     const disabledRouteDetailString =
       'A request was made however previewing is disabled. See environment variable details in runner/README.md if this error is not expected.'
+
+    server.app.model = model
+
+    /**
+     * @typedef {object} CacheItem
+     * @property {FormModel} model
+     * @property {Date} updatedAt
+     */
+
+    /**
+     * In-memory cache of FormModel items
+     * @type {Map<string, CacheItem>}
+     */
+    const itemCache = new Map()
 
     /**
      * The following publish endpoints (/publish, /published/{id}, /published)
@@ -193,16 +201,15 @@ export const plugin = {
       h: ResponseToolkit
     ) => {
       const { query } = request
-      const { id } = request.params
-      const model = forms[id]
-      if (!model) {
-        throw Boom.notFound('No form found for id')
-      }
-
+      const model = request.app.model
       const prePopFields = model.fieldsForPrePopulation
-      if (!Object.keys(query).length || !Object.keys(prePopFields).length) {
+      const queryKeysLength = Object.keys(query).length
+      const prePopFieldsKeysLength = Object.keys(prePopFields).length
+
+      if (queryKeysLength === 0 || prePopFieldsKeysLength === 0) {
         return h.continue
       }
+
       const { cacheService } = request.services([])
       const state = await cacheService.getState(request)
       const newValues = getValidStateFromQueryParameters(
@@ -210,30 +217,84 @@ export const plugin = {
         query,
         state
       )
+
       await cacheService.mergeState(request, newValues)
+
       return h.continue
     }
 
+    const loadFormPreHandler = server.app.model
+      ? async (request: Request, h: ResponseToolkit) =>
+          (request.app.model = server.app.model)
+      : async (request: Request, h: ResponseToolkit) => {
+          const { params } = request
+          const { slug } = params
+          /**
+           * @todo Determine from path params
+           */
+          const formState = 'draft'
+
+          // Get the form metadata using the `slug` param
+          const metadata = await getFormMetadata(slug)
+
+          const { id, [formState]: state } = metadata
+
+          // Check the metadata supports the requested state
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          if (!state) {
+            return Boom.notFound(
+              `No '${formState}' state for form metadata ${id}`
+            )
+          }
+
+          const key = `${id}_${formState}`
+          let item = itemCache.get(key)
+
+          if (!item || !isEqual(item.updatedAt, state.updatedAt)) {
+            server.logger.info(`Getting form definition ${id} (${slug})`)
+
+            // Get the form definition using the `id` from the metadata
+            const definition = await getFormDefinition(id, formState)
+
+            // Generate the form model and add it to the item cache
+            server.logger.info(
+              `Building model for form definition ${id} (${slug})`
+            )
+            const model = new FormModel(definition, { basePath: slug })
+
+            // Create new cache item
+            item = { model, updatedAt: state.updatedAt }
+            itemCache.set(key, item)
+          }
+
+          // Assign the model to the request data
+          // for use in the downstream handler
+          request.app.model = item.model
+
+          return h.continue
+        }
+
     server.route({
       method: 'get',
-      path: '/{id}',
+      path: '/{slug}',
       handler: (request: Request, h: ResponseToolkit) => {
-        const { id } = request.params
-        const model = forms[id]
-        if (model) {
-          return getStartPageRedirect(request, h, id, model)
-        }
-        throw Boom.notFound('No form found for id')
+        const { slug } = request.params
+        const model = request.app.model
+
+        return getStartPageRedirect(request, h, slug, model)
       },
       options: {
         pre: [
+          {
+            method: loadFormPreHandler
+          },
           {
             method: queryParamPreHandler
           }
         ],
         validate: {
           params: Joi.object().keys({
-            id: Joi.string().required()
+            slug: Joi.string().required()
           })
         }
       }
@@ -241,13 +302,14 @@ export const plugin = {
 
     server.route({
       method: 'get',
-      path: '/{id}/{path*}',
+      path: '/{slug}/{path*}',
       handler: (request: Request, h: ResponseToolkit) => {
-        const { path, id } = request.params
-        const model = forms[id]
-        const page = model?.pages.find(
+        const { path, slug } = request.params
+        const model = request.app.model
+        const page = model.pages.find(
           (page) => normalisePath(page.path) === normalisePath(path)
         )
+
         if (page) {
           // NOTE: Start pages should live on gov.uk, but this allows prototypes to include signposting about having to log in.
           if (
@@ -259,20 +321,25 @@ export const plugin = {
 
           return page.makeGetRouteHandler()(request, h)
         }
+
         if (normalisePath(path) === '') {
-          return getStartPageRedirect(request, h, id, model)
+          return getStartPageRedirect(request, h, slug, model)
         }
+
         throw Boom.notFound('No form or page found')
       },
       options: {
         pre: [
+          {
+            method: loadFormPreHandler
+          },
           {
             method: queryParamPreHandler
           }
         ],
         validate: {
           params: Joi.object().keys({
-            id: Joi.string().required(),
+            slug: Joi.string().required(),
             path: Joi.string().required()
           })
         }
@@ -283,33 +350,29 @@ export const plugin = {
 
     const handleFiles = (request: Request, h: ResponseToolkit) => {
       const { path, id } = request.params
-      const model = forms[id]
+      const model = request.app.model
       const page = model?.pages.find(
         (page) => normalisePath(page.path) === normalisePath(path)
       )
+
       return uploadService.handleUploadRequest(request, h, page.pageDef)
     }
 
     const postHandler = async (request: Request, h: ResponseToolkit) => {
       const { path, id } = request.params
-      const model = forms[id]
+      const model = request.app.model
+      const page = model.pages.find(
+        (page) => page.path.replace(/^\//, '') === path
+      )
 
-      if (model) {
-        const page = model.pages.find(
-          (page) => page.path.replace(/^\//, '') === path
-        )
-
-        if (page) {
-          return page.makePostRouteHandler()(request, h)
-        }
+      if (page) {
+        return page.makePostRouteHandler()(request, h)
       }
-
-      throw Boom.notFound('No form of path found')
     }
 
     server.route({
       method: 'post',
-      path: '/{id}/{path*}',
+      path: '/{slug}/{path*}',
       handler: postHandler,
       options: {
         plugins: {
@@ -322,15 +385,15 @@ export const plugin = {
           parse: true,
           multipart: { output: 'stream' },
           maxBytes: uploadService.fileSizeLimit,
-          failAction: async (request: Request, h: ResponseToolkit) => {
+          failAction: (request: Request, h: ResponseToolkit) => {
             request.server.plugins.crumb.generate?.(request, h)
             return h.continue
           }
         },
-        pre: [{ method: handleFiles }],
+        pre: [{ method: loadFormPreHandler }, { method: handleFiles }],
         validate: {
           params: Joi.object().keys({
-            id: Joi.string().required(),
+            slug: Joi.string().required(),
             path: Joi.string().required()
           })
         }

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -29,7 +29,7 @@ import {
   getFormDefinition,
   getFormMetadata
 } from '~/src/server/plugins/engine/services/formsService.js'
-import { type FormPayload } from '~/src/server/plugins/engine/types.js'
+// import { type FormPayload } from '~/src/server/plugins/engine/types.js'
 
 const [govukFrontendPath, hmpoComponentsPath] = [
   'govuk-frontend',

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -117,92 +117,92 @@ export const plugin = {
      * for its own purposes so if you're changing these endpoints you likely need to go and amend
      * the designer too!
      */
-    server.route({
-      method: 'post',
-      path: '/publish',
-      handler: (request: Request, h: ResponseToolkit) => {
-        if (!previewMode) {
-          request.logger.error(
-            [`POST /publish`, 'previewModeError'],
-            disabledRouteDetailString
-          )
-          throw Boom.forbidden('Publishing is disabled')
-        }
-        const payload = request.payload as FormPayload
-        const { id, configuration } = payload
+    // server.route({
+    //   method: 'post',
+    //   path: '/publish',
+    //   handler: (request: Request, h: ResponseToolkit) => {
+    //     if (!previewMode) {
+    //       request.logger.error(
+    //         [`POST /publish`, 'previewModeError'],
+    //         disabledRouteDetailString
+    //       )
+    //       throw Boom.forbidden('Publishing is disabled')
+    //     }
+    //     const payload = request.payload as FormPayload
+    //     const { id, configuration } = payload
 
-        const parsedConfiguration: FormDefinition =
-          typeof configuration === 'string'
-            ? JSON.parse(configuration)
-            : configuration
-        forms[id] = new FormModel(parsedConfiguration, {
-          ...modelOptions,
-          basePath: `${formBasePath}/${id}`
-        })
-        return h.response({}).code(204)
-      },
-      options: {
-        description: `${enabledString} Allows a form to be persisted (published) on the runner server. Requires previewMode to be set to true. See runner/README.md for details on environment variables`
-      }
-    })
+    //     const parsedConfiguration: FormDefinition =
+    //       typeof configuration === 'string'
+    //         ? JSON.parse(configuration)
+    //         : configuration
+    //     forms[id] = new FormModel(parsedConfiguration, {
+    //       ...modelOptions,
+    //       basePath: `${formBasePath}/${id}`
+    //     })
+    //     return h.response({}).code(204)
+    //   },
+    //   options: {
+    //     description: `${enabledString} Allows a form to be persisted (published) on the runner server. Requires previewMode to be set to true. See runner/README.md for details on environment variables`
+    //   }
+    // })
 
-    server.route({
-      method: 'get',
-      path: '/published/{id}',
-      handler: (request: Request, h: ResponseToolkit) => {
-        const { id } = request.params
-        if (!previewMode) {
-          request.logger.error(
-            [`GET /published/${id}`, 'previewModeError'],
-            disabledRouteDetailString
-          )
-          throw Boom.unauthorized('publishing is disabled')
-        }
+    // server.route({
+    //   method: 'get',
+    //   path: '/published/{id}',
+    //   handler: (request: Request, h: ResponseToolkit) => {
+    //     const { id } = request.params
+    //     if (!previewMode) {
+    //       request.logger.error(
+    //         [`GET /published/${id}`, 'previewModeError'],
+    //         disabledRouteDetailString
+    //       )
+    //       throw Boom.unauthorized('publishing is disabled')
+    //     }
 
-        const form = forms[id]
-        if (!form) {
-          return h.response({}).code(204)
-        }
+    //     const form = forms[id]
+    //     if (!form) {
+    //       return h.response({}).code(204)
+    //     }
 
-        const { values } = forms[id]
-        return h.response(JSON.stringify({ id, values })).code(200)
-      },
-      options: {
-        description: `${enabledString} Gets a published form, by form id. Requires previewMode to be set to true. See runner/README.md for details on environment variables`
-      }
-    })
+    //     const { values } = forms[id]
+    //     return h.response(JSON.stringify({ id, values })).code(200)
+    //   },
+    //   options: {
+    //     description: `${enabledString} Gets a published form, by form id. Requires previewMode to be set to true. See runner/README.md for details on environment variables`
+    //   }
+    // })
 
-    server.route({
-      method: 'get',
-      path: '/published',
-      handler: (request: Request, h: ResponseToolkit) => {
-        if (!previewMode) {
-          request.logger.error(
-            [`GET /published`, 'previewModeError'],
-            disabledRouteDetailString
-          )
-          throw Boom.unauthorized('publishing is disabled.')
-        }
-        return h
-          .response(
-            JSON.stringify(
-              Object.keys(forms).map(
-                (key) =>
-                  new FormConfiguration(
-                    key,
-                    forms[key].name,
-                    undefined,
-                    forms[key].def.feedback?.feedbackForm
-                  )
-              )
-            )
-          )
-          .code(200)
-      },
-      options: {
-        description: `${enabledString} Gets all published forms. Requires previewMode to be set to true. See runner/README.md for details on environment variables`
-      }
-    })
+    // server.route({
+    //   method: 'get',
+    //   path: '/published',
+    //   handler: (request: Request, h: ResponseToolkit) => {
+    //     if (!previewMode) {
+    //       request.logger.error(
+    //         [`GET /published`, 'previewModeError'],
+    //         disabledRouteDetailString
+    //       )
+    //       throw Boom.unauthorized('publishing is disabled.')
+    //     }
+    //     return h
+    //       .response(
+    //         JSON.stringify(
+    //           Object.keys(forms).map(
+    //             (key) =>
+    //               new FormConfiguration(
+    //                 key,
+    //                 forms[key].name,
+    //                 undefined,
+    //                 forms[key].def.feedback?.feedbackForm
+    //               )
+    //           )
+    //         )
+    //       )
+    //       .code(200)
+    //   },
+    //   options: {
+    //     description: `${enabledString} Gets all published forms. Requires previewMode to be set to true. See runner/README.md for details on environment variables`
+    //   }
+    // })
 
     const queryParamPreHandler = async (
       request: Request,

--- a/src/server/plugins/engine/services/formsService.js
+++ b/src/server/plugins/engine/services/formsService.js
@@ -29,9 +29,9 @@ export async function getFormMetadata(slug) {
  */
 export async function getFormDefinition(id, state) {
   const suffix = state === 'draft' ? '/draft' : ''
-  const defintion = await getJson(
+  const definition = await getJson(
     `${managerUrl}/forms/${id}/definition${suffix}`
   )
 
-  return defintion
+  return definition
 }

--- a/src/server/plugins/engine/services/formsService.js
+++ b/src/server/plugins/engine/services/formsService.js
@@ -1,0 +1,39 @@
+import { formMetadataSchema } from '@defra/forms-model'
+
+import config from '~/src/server/config.js'
+import { getJson } from '~/src/server/plugins/engine/services/httpService.js'
+
+const { managerUrl } = config
+
+/**
+ * Retrieves a form definition from the form manager for a given slug
+ * @param {string} slug - the slug of the form
+ */
+export async function getFormMetadata(slug) {
+  const metadata = await getJson(`${managerUrl}/forms/slug/${slug}`)
+
+  // Run it through the schema to coerce dates
+  const { value, error } = formMetadataSchema.validate(metadata)
+
+  if (error) {
+    throw error
+  }
+
+  return value
+}
+
+/**
+ * Retrieves a form definition from the form manager for a given id
+ * @param {string} id - the id of the form
+ * @param {FormState} state - the state of the form
+ */
+export async function getFormDefinition(id, state) {
+  const suffix = state === 'draft' ? '/draft' : ''
+  const defintion = await getJson(
+    `${managerUrl}/forms/${id}/definition${suffix}`
+  )
+
+  return defintion
+}
+
+/** @typedef {'draft'|'live'} FormState */

--- a/src/server/plugins/engine/services/formsService.js
+++ b/src/server/plugins/engine/services/formsService.js
@@ -13,19 +13,19 @@ export async function getFormMetadata(slug) {
   const metadata = await getJson(`${managerUrl}/forms/slug/${slug}`)
 
   // Run it through the schema to coerce dates
-  const { value, error } = formMetadataSchema.validate(metadata)
+  const result = formMetadataSchema.validate(metadata)
 
-  if (error) {
-    throw error
+  if (result.error) {
+    throw result.error
   }
 
-  return value
+  return result.value
 }
 
 /**
  * Retrieves a form definition from the form manager for a given id
  * @param {string} id - the id of the form
- * @param {FormState} state - the state of the form
+ * @param {'draft'|'live'} state - the state of the form
  */
 export async function getFormDefinition(id, state) {
   const suffix = state === 'draft' ? '/draft' : ''
@@ -35,5 +35,3 @@ export async function getFormDefinition(id, state) {
 
   return defintion
 }
-
-/** @typedef {'draft'|'live'} FormState */

--- a/src/server/plugins/initialiseSession/initialiseSession.ts
+++ b/src/server/plugins/initialiseSession/initialiseSession.ts
@@ -79,7 +79,7 @@ export const initialiseSession: Plugin<InitialiseSession> = {
         const { options, metadata = {}, ...webhookData } = payload
         const { callbackUrl } = options
 
-        const isExistingForm = server.app.forms?.[formId] ?? false
+        const isExistingForm = server.app.model ?? false
         const { error: callbackSafeListError } = callbackValidation(
           safelist
         ).validate(callbackUrl, {

--- a/src/server/utils/configSchema.ts
+++ b/src/server/utils/configSchema.ts
@@ -29,6 +29,9 @@ export const configSchema = Joi.object({
   publicDir: Joi.string()
     .optional()
     .default(resolve(dirname(configPath), '../../../public')),
+  managerUrl: Joi.string()
+    .uri()
+    .default('http://forms-manager.dev.cdp-int.defra.cloud'),
   logLevel: Joi.string()
     .optional()
     .allow('trace', 'debug', 'info', 'warn', 'error'),

--- a/test/cases/server/initialiseSession.test.js
+++ b/test/cases/server/initialiseSession.test.js
@@ -1,5 +1,10 @@
+import { dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import config from '~/src/server/config.js'
 import createServer from '~/src/server/index.js'
+
+const testDir = dirname(fileURLToPath(import.meta.url))
 
 /** @type {import('@hapi/hapi').Server} */
 let server
@@ -85,9 +90,12 @@ const baseRequest = {
   metadata: { woo: 'ah' }
 }
 
-describe.skip('InitialiseSession', () => {
+describe('InitialiseSession', () => {
   beforeAll(async () => {
-    server = await createServer({})
+    server = await createServer({
+      formFileName: 'test.json',
+      formFilePath: testDir
+    })
     await server.initialize()
   })
 
@@ -107,7 +115,7 @@ describe.skip('InitialiseSession', () => {
       expect(payload).toBeTruthy()
     })
 
-    test('responds with token if form doesnt exist', async () => {
+    test.skip('responds with token if form doesnt exist', async () => {
       const serverRequestOptions = {
         method: 'POST',
         url: `/session/four-o-four`,
@@ -117,6 +125,7 @@ describe.skip('InitialiseSession', () => {
       const { statusCode } = await server.inject(serverRequestOptions)
       expect(statusCode).toBe(404)
     })
+
     test('responds with a 403 if the callbackUrl has not been safelisted', async () => {
       const serverRequestOptions = {
         method: 'POST',

--- a/test/cases/server/initialiseSession.test.js
+++ b/test/cases/server/initialiseSession.test.js
@@ -85,7 +85,7 @@ const baseRequest = {
   metadata: { woo: 'ah' }
 }
 
-describe('InitialiseSession', () => {
+describe.skip('InitialiseSession', () => {
   beforeAll(async () => {
     server = await createServer({})
     await server.initialize()

--- a/test/cases/server/plugins/auth.test.ts
+++ b/test/cases/server/plugins/auth.test.ts
@@ -6,7 +6,7 @@ import createServer from '~/src/server/index.js'
 describe('Server Auth', () => {
   let server: Server
 
-  describe('when enabled', () => {
+  describe.skip('when enabled', () => {
     beforeAll(async () => {
       config.authEnabled = true
       config.authClientAuthUrl = 'https://example.org/oauth/authorize'

--- a/test/cases/server/plugins/auth.test.ts
+++ b/test/cases/server/plugins/auth.test.ts
@@ -3,10 +3,12 @@ import { type Server } from '@hapi/hapi'
 import config from '~/src/server/config.js'
 import createServer from '~/src/server/index.js'
 
+const testDir = 'test/cases/server'
+
 describe('Server Auth', () => {
   let server: Server
 
-  describe.skip('when enabled', () => {
+  describe('when enabled', () => {
     beforeAll(async () => {
       config.authEnabled = true
       config.authClientAuthUrl = 'https://example.org/oauth/authorize'
@@ -14,7 +16,10 @@ describe('Server Auth', () => {
       config.authClientProfileUrl = 'https://example.org/oauth/profile'
       config.authClientId = 'oAuthClientID'
       config.authClientSecret = 'oAuthClientSecret'
-      server = await createServer({})
+      server = await createServer({
+        formFileName: 'test.json',
+        formFilePath: testDir
+      })
       await server.initialize()
     })
 
@@ -37,7 +42,7 @@ describe('Server Auth', () => {
       )
     })
 
-    test('sign in page returns to teh previous url', async () => {
+    test('sign in page returns to the previous url', async () => {
       const options = {
         method: 'POST',
         url: '/login?state=123456&code=123456',

--- a/test/cases/server/test.json
+++ b/test/cases/server/test.json
@@ -1,0 +1,509 @@
+{
+  "startPage": "/start",
+  "pages": [
+    {
+      "title": "Start",
+      "path": "/start",
+      "components": [],
+      "next": [
+        {
+          "path": "/uk-passport"
+        }
+      ],
+      "controller": "./pages/start.js"
+    },
+    {
+      "path": "/uk-passport",
+      "components": [
+        {
+          "type": "YesNoField",
+          "name": "ukPassport",
+          "title": "Do you have a UK passport?",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "section": "checkBeforeYouStart",
+      "next": [
+        {
+          "path": "/how-many-people"
+        },
+        {
+          "path": "/no-uk-passport",
+          "condition": "doesntHaveUKPassport"
+        }
+      ],
+      "title": "Do you have a UK passport?"
+    },
+    {
+      "path": "/no-uk-passport",
+      "title": "You're not eligible for this service",
+      "components": [
+        {
+          "type": "Para",
+          "content": "If you still think you're eligible please contact the Foreign and Commonwealth Office.",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": []
+    },
+    {
+      "path": "/how-many-people",
+      "section": "applicantDetails",
+      "components": [
+        {
+          "options": {
+            "classes": "govuk-input--width-10",
+            "required": true
+          },
+          "type": "SelectField",
+          "name": "numberOfApplicants",
+          "title": "How many applicants are there?",
+          "list": "numberOfApplicants"
+        }
+      ],
+      "next": [
+        {
+          "path": "/applicant-one"
+        }
+      ],
+      "title": "How many applicants are there?"
+    },
+    {
+      "path": "/applicant-one",
+      "title": "Applicant 1",
+      "section": "applicantOneDetails",
+      "components": [
+        {
+          "type": "Para",
+          "content": "Provide the details as they appear on your passport.",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "type": "TextField",
+          "name": "firstName",
+          "title": "First name",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "options": {
+            "required": false,
+            "optionalText": false
+          },
+          "type": "TextField",
+          "name": "middleName",
+          "title": "Middle name",
+          "hint": "If you have a middle name on your passport you must include it here",
+          "schema": {}
+        },
+        {
+          "type": "TextField",
+          "name": "lastName",
+          "title": "Surname",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/applicant-one-address"
+        }
+      ]
+    },
+    {
+      "path": "/applicant-one-address",
+      "section": "applicantOneDetails",
+      "components": [
+        {
+          "type": "UkAddressField",
+          "name": "address",
+          "title": "Address",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/applicant-two",
+          "condition": "moreThanOneApplicant"
+        },
+        {
+          "path": "/contact-details"
+        }
+      ],
+      "title": "Address"
+    },
+    {
+      "path": "/applicant-two",
+      "title": "Applicant 2",
+      "section": "applicantTwoDetails",
+      "components": [
+        {
+          "type": "Para",
+          "content": "Provide the details as they appear on your passport.",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "type": "TextField",
+          "name": "firstName",
+          "title": "First name",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "options": {
+            "required": false,
+            "optionalText": false
+          },
+          "type": "TextField",
+          "name": "middleName",
+          "title": "Middle name",
+          "hint": "If you have a middle name on your passport you must include it here",
+          "schema": {}
+        },
+        {
+          "type": "TextField",
+          "name": "lastName",
+          "title": "Surname",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/applicant-two-address"
+        }
+      ]
+    },
+    {
+      "path": "/applicant-two-address",
+      "section": "applicantTwoDetails",
+      "components": [
+        {
+          "type": "UkAddressField",
+          "name": "address",
+          "title": "Address",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/applicant-three",
+          "condition": "moreThanTwoApplicants"
+        },
+        {
+          "path": "/contact-details"
+        }
+      ],
+      "title": "Address"
+    },
+    {
+      "path": "/applicant-three",
+      "title": "Applicant 3",
+      "section": "applicantThreeDetails",
+      "components": [
+        {
+          "type": "Para",
+          "content": "Provide the details as they appear on your passport.",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "type": "TextField",
+          "name": "firstName",
+          "title": "First name",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "options": {
+            "required": false,
+            "optionalText": false
+          },
+          "type": "TextField",
+          "name": "middleName",
+          "title": "Middle name",
+          "hint": "If you have a middle name on your passport you must include it here",
+          "schema": {}
+        },
+        {
+          "type": "TextField",
+          "name": "lastName",
+          "title": "Surname",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/applicant-three-address"
+        }
+      ]
+    },
+    {
+      "path": "/applicant-three-address",
+      "section": "applicantThreeDetails",
+      "components": [
+        {
+          "type": "UkAddressField",
+          "name": "address",
+          "title": "Address",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/applicant-four",
+          "condition": "moreThanThreeApplicants"
+        },
+        {
+          "path": "/contact-details"
+        }
+      ],
+      "title": "Address"
+    },
+    {
+      "path": "/applicant-four",
+      "title": "Applicant 4",
+      "section": "applicantFourDetails",
+      "components": [
+        {
+          "type": "Para",
+          "content": "Provide the details as they appear on your passport.",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "type": "TextField",
+          "name": "firstName",
+          "title": "First name",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "options": {
+            "required": false,
+            "optionalText": false
+          },
+          "type": "TextField",
+          "name": "middleName",
+          "title": "Middle name",
+          "hint": "If you have a middle name on your passport you must include it here",
+          "schema": {}
+        },
+        {
+          "type": "TextField",
+          "name": "lastName",
+          "title": "Surname",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/applicant-four-address"
+        }
+      ]
+    },
+    {
+      "path": "/applicant-four-address",
+      "section": "applicantFourDetails",
+      "components": [
+        {
+          "type": "UkAddressField",
+          "name": "address",
+          "title": "Address",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/contact-details"
+        }
+      ],
+      "title": "Address"
+    },
+    {
+      "path": "/contact-details",
+      "section": "applicantDetails",
+      "components": [
+        {
+          "type": "TelephoneNumberField",
+          "name": "phoneNumber",
+          "title": "Phone number",
+          "hint": "If you haven't got a UK phone number, include country code",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        },
+        {
+          "type": "EmailAddressField",
+          "name": "emailAddress",
+          "title": "Your email address",
+          "options": {
+            "required": true
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/summary"
+        }
+      ],
+      "title": "Applicant contact details"
+    },
+    {
+      "path": "/summary",
+      "controller": "./pages/summary.js",
+      "title": "Summary",
+      "components": [],
+      "next": []
+    }
+  ],
+  "lists": [
+    {
+      "name": "numberOfApplicants",
+      "title": "Number of people",
+      "type": "number",
+      "items": [
+        {
+          "text": "1",
+          "value": 1,
+          "description": "",
+          "condition": ""
+        },
+        {
+          "text": "2",
+          "value": 2,
+          "description": "",
+          "condition": ""
+        },
+        {
+          "text": "3",
+          "value": 3,
+          "description": "",
+          "condition": ""
+        },
+        {
+          "text": "4",
+          "value": 4,
+          "description": "",
+          "condition": ""
+        }
+      ]
+    }
+  ],
+  "sections": [
+    {
+      "name": "checkBeforeYouStart",
+      "title": "Check before you start"
+    },
+    {
+      "name": "applicantDetails",
+      "title": "Applicant details"
+    },
+    {
+      "name": "applicantOneDetails",
+      "title": "Applicant 1"
+    },
+    {
+      "name": "applicantTwoDetails",
+      "title": "Applicant 2"
+    },
+    {
+      "name": "applicantThreeDetails",
+      "title": "Applicant 3"
+    },
+    {
+      "name": "applicantFourDetails",
+      "title": "Applicant 4"
+    }
+  ],
+  "phaseBanner": {},
+  "fees": [],
+  "payApiKey": "",
+  "outputs": [
+    {
+      "name": "LwQeVI",
+      "title": "Test webhook",
+      "type": "webhook",
+      "outputConfiguration": {
+        "url": "https://61bca17e-fe74-40e0-9c15-a901ad120eca.mock.pstmn.io"
+      }
+    }
+  ],
+  "declaration": "<p class=\"govuk-body\">All the answers you have provided are true to the best of your knowledge.</p>",
+  "version": 2,
+  "conditions": [
+    {
+      "name": "hasUKPassport",
+      "displayName": "hasUKPassport",
+      "value": "checkBeforeYouStart.ukPassport==true"
+    },
+    {
+      "name": "doesntHaveUKPassport",
+      "displayName": "doesntHaveUKPassport",
+      "value": "checkBeforeYouStart.ukPassport==false"
+    },
+    {
+      "name": "moreThanOneApplicant",
+      "displayName": "moreThanOneApplicant",
+      "value": "applicantDetails.numberOfApplicants > 1"
+    },
+    {
+      "name": "moreThanTwoApplicants",
+      "displayName": "moreThanTwoApplicants",
+      "value": "applicantDetails.numberOfApplicants > 2"
+    },
+    {
+      "name": "moreThanThreeApplicants",
+      "displayName": "moreThanThreeApplicants",
+      "value": "applicantDetails.numberOfApplicants > 3"
+    }
+  ]
+}

--- a/test/cases/server/titles.test.js
+++ b/test/cases/server/titles.test.js
@@ -7,7 +7,7 @@ import createServer from '~/src/server/index.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
 
-describe('Title and section title', () => {
+describe.skip('Title and section title', () => {
   /** @type {import('@hapi/hapi').Server} */
   let server
 

--- a/test/cases/server/titles.test.js
+++ b/test/cases/server/titles.test.js
@@ -7,13 +7,13 @@ import createServer from '~/src/server/index.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
 
-describe.skip('Title and section title', () => {
+describe('Title and section title', () => {
   /** @type {import('@hapi/hapi').Server} */
   let server
 
   beforeAll(async () => {
     server = await createServer({
-      formFileName: `titles.json`,
+      formFileName: 'titles.json',
       formFilePath: testDir,
       options: { previewMode: true }
     })
@@ -36,10 +36,11 @@ describe.skip('Title and section title', () => {
     expect($('#section-title').html()).toBeNull()
     expect($('h1').text().trim()).toMatch(/^Applicant 1/)
   })
+
   it('does render the section title if it is not the same as the title', async () => {
     const options = {
       method: 'GET',
-      url: '/titles/applicant-one-address?visit=1'
+      url: '/titles/applicant-one-address'
     }
 
     const response = await server.inject(options)
@@ -48,6 +49,7 @@ describe.skip('Title and section title', () => {
     expect($('#section-title').text().trim()).toBe('Applicant 1')
     expect($('h1.govuk-fieldset__heading').text().trim()).toBe('Address')
   })
+
   it('renders the section title as H2, outside of the H1', async () => {
     const options = {
       method: 'GET',


### PR DESCRIPTION
Parts of the PR look a little messy because I am trying to keep the capability to run the server using a `.json` file for now.
There's quite a bit of other code that can be removed now but I have kept it in for the time being as there are some useful tests around it.

I plan to come back and remove the following:

- Preview mode
- Ability to run a json file
- The json files in `src/server/forms`
- The `/publishing` [endpoints](https://github.com/DEFRA/forms-runner/blob/main/src/server/plugins/engine/plugin.ts#L103)
- The forms-runner [authentication](https://github.com/DEFRA/forms-runner/blob/main/src/server/plugins/auth.ts) capabilty

@alexluckett Am I right in thinking all this can go?
