### PR TITLE
Ensure Babel compiles `.js` extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "npm run build:server && npm run build:client",
     "build:client": "sass src/client/sass:public/build/stylesheets -s compressed -I ./node_modules --quiet-deps",
-    "build:server": "babel --delete-dir-on-start --extensions \".ts\" --ignore \"**/*.test.ts\" --copy-files --no-copy-ignored --source-maps --out-dir ./.server ./src",
+    "build:server": "babel --delete-dir-on-start --extensions \".js\",\".ts\" --ignore \"**/*.test.ts\" --copy-files --no-copy-ignored --source-maps --out-dir ./.server ./src",
     "dev": "concurrently \"npm run client:watch\" \"npm run server:watch\"",
     "dev:debug": "concurrently \"npm run client:watch\" \"npm run server:debug\"",
     "format": "npm run format:check -- --write",


### PR DESCRIPTION
Like we do on other repos, this PR supports JavaScript alongside TypeScript

E.g. We now have [server/plugins/engine/services/**formsService.js**](https://github.com/DEFRA/forms-runner/commit/dbc3191c598616c8ef9009c2b6b2d3f995669604#diff-5b8487a772db8796153c963b8231e54480ed45923092a30c8415ca7c1cf4fb9a)