### PR TITLE
Bugfix: view form bad request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.104",
+        "@defra/forms-model": "^3.0.105",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/bell": "^13.0.2",
         "@hapi/boom": "^10.0.1",
@@ -2044,9 +2044,9 @@
       "dev": true
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.104",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.104.tgz",
-      "integrity": "sha512-wuqOzfq3waEXnm73xR1HSQxReN+Xbmn+M0F4EZDndul8bRH4diLtQcpJfFdRTJCtocYRwUBkYf0Mjo6CAqjkag==",
+      "version": "3.0.105",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.105.tgz",
+      "integrity": "sha512-jIo2EOqGmrcBeV8pmixR323rZx4TlM8adBQ+ic3IUIa/dqBcjmQ7l6qFzcjMHa4RlpYR8iAftPgA4w10pUxruw==",
       "dependencies": {
         "slug": "^9.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@defra/forms-model": "^3.0.104",
+    "@defra/forms-model": "^3.0.105",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/bell": "^13.0.2",
     "@hapi/boom": "^10.0.1",

--- a/src/server/utils/configSchema.ts
+++ b/src/server/utils/configSchema.ts
@@ -31,7 +31,7 @@ export const configSchema = Joi.object({
     .default(resolve(dirname(configPath), '../../../public')),
   managerUrl: Joi.string()
     .uri()
-    .default('http://forms-manager.dev.cdp-int.defra.cloud'),
+    .default('https://forms-manager.dev.cdp-int.defra.cloud'),
   logLevel: Joi.string()
     .optional()
     .allow('trace', 'debug', 'info', 'warn', 'error'),


### PR DESCRIPTION
Since HTTPS wasn't used, forms were coming back empty and validation failed. This forces HTTPS for the default config entry, and bumps forms-model so validation passes with the new Azure IDs.