### PR TITLE
Clone objects using `structuredClone()`

### DIFF
--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -1,5 +1,4 @@
 import {
-  clone,
   ConditionsModel,
   formDefinitionSchema,
   type ConditionRawData,
@@ -65,7 +64,7 @@ export class FormModel {
 
     // Make a clone of the shallow copy returned
     // by joi so as not to change the source data.
-    def = clone(result.value)
+    def = structuredClone(result.value)
 
     // Add default lists
     def.lists.push({

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -1,5 +1,5 @@
 import { type Request } from '@hapi/hapi'
-import { clone, reach } from '@hapi/hoek'
+import { reach } from '@hapi/hoek'
 import { type ValidationResult } from 'joi'
 
 import config from '~/src/server/config.js'
@@ -214,7 +214,7 @@ function gatherRepeatPages(state) {
   if (Object.values(state).find((section) => Array.isArray(section))) {
     return state
   }
-  const clonedState = clone(state)
+  const clonedState = structuredClone(state)
   Object.entries(state).forEach(([key, section]) => {
     if (key === 'progress') {
       return


### PR DESCRIPTION
This PR switches to [`structuredClone()`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) versus `clone()` from `@hapi/hoek` or `@defra/forms-model`

Just some leftover changes when I was looking at reducing form editor JS bundle size (e.g. unnecessary helpers)