### PR TITLE
Spike 386453 - Include slugs in help pages

### DIFF
--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -51,6 +51,9 @@ export class FormModel {
   DefaultPageController: any = PageController
   /** the id of the form used for the first url parameter eg localhost:3009/test */
   basePath: string
+  isPreview: boolean
+  formState: string
+
   conditions: Partial<Record<string, ExecutableCondition>>
   fieldsForContext: ComponentCollection
   fieldsForPrePopulation: Record<string, any>
@@ -94,6 +97,9 @@ export class FormModel {
     this.options = options
     this.name = def.name
     this.values = result.value
+
+    this.isPreview = options.isPreview
+    this.formState = options.formState
 
     if (options.defaultPageController) {
       this.DefaultPageController = getPageController(

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -135,6 +135,7 @@ export class PageControllerBase {
     backLink?: string
     serviceStartPage: string
     phaseTag?: string | undefined
+    model: FormModel
   } {
     let showTitle = true
     let pageTitle = this.title
@@ -181,7 +182,8 @@ export class PageControllerBase {
       components,
       errors,
       isStartPage: false,
-      serviceStartPage
+      serviceStartPage,
+      model: this.model
     }
   }
 

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -481,6 +481,29 @@ export const plugin = {
         }
       }
     })
-
+    server.route(
+      helpPageRoutes().flatMap((page: string) => [
+        {
+          method: 'get',
+          path: `/{slug}/${page}`,
+          handler: dummyRouteHandler(page)
+        },
+        {
+          method: 'get',
+          path: `/{slug}/{state}/${page}`,
+          handler: dummyRouteHandler(page)
+        }
+      ])
+    )
   }
+}
+
+function dummyRouteHandler(requestName: string) {
+  return (request: Request, h: ResponseToolkit) => {
+    return requestName
+  }
+}
+
+function helpPageRoutes() {
+  return ['cookies', 'privacy-policy', 'accessibility', 'support']
 }

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -231,7 +231,7 @@ export const plugin = {
 
       const { params, path } = request
       const { slug } = params
-      const isPreview = path.toLowerCase().startsWith(PREVIEW_PATH_PREFIX)
+      const isPreview = path.toLowerCase().includes(PREVIEW_PATH_PREFIX)
       const formState = isPreview ? params.state : 'live'
 
       // Get the form metadata using the `slug` param
@@ -274,7 +274,7 @@ export const plugin = {
 
         // Set up the basePath for the model
         const basePath = isPreview
-          ? `${PREVIEW_PATH_PREFIX.substring(1)}/${formState}/${slug}`
+          ? `${slug}/${PREVIEW_PATH_PREFIX.substring(1)}/${formState}`
           : slug
 
         // Construct the form model
@@ -361,77 +361,6 @@ export const plugin = {
       ]
     }
 
-    server.route({
-      method: 'get',
-      path: '/{slug}',
-      handler: dispatchHandler,
-      options: {
-        ...dispatchRouteOptions,
-        validate: {
-          params: Joi.object().keys({
-            slug: slugSchema
-          })
-        }
-      }
-    })
-
-    server.route({
-      method: 'get',
-      path: '/preview/{state}/{slug}',
-      handler: dispatchHandler,
-      options: {
-        ...dispatchRouteOptions,
-        validate: {
-          params: Joi.object().keys({
-            slug: slugSchema,
-            state: stateSchema
-          })
-        }
-      }
-    })
-
-    const getRouteOptions = {
-      pre: [
-        {
-          method: loadFormPreHandler
-        },
-        {
-          method: queryParamPreHandler
-        }
-      ]
-    }
-
-    server.route({
-      method: 'get',
-      path: '/{slug}/{path*}',
-      handler: getHandler,
-      options: {
-        ...getRouteOptions,
-        validate: {
-          params: Joi.object().keys({
-            slug: slugSchema,
-            path: pathSchema
-          })
-        }
-      }
-    })
-
-    server.route({
-      method: 'get',
-      path: '/preview/{state}/{slug}/{path*}',
-      handler: getHandler,
-      options: {
-        ...getRouteOptions,
-        validate: {
-          params: Joi.object().keys({
-            slug: slugSchema,
-            path: pathSchema,
-            state: stateSchema
-          })
-        }
-      }
-    })
-
     const postRouteOptions = {
       plugins: {
         'hapi-rate-limit': {
@@ -451,6 +380,77 @@ export const plugin = {
       pre: [{ method: loadFormPreHandler }, { method: handleFiles }]
     }
 
+    const getRouteOptions = {
+      pre: [
+        {
+          method: loadFormPreHandler
+        },
+        {
+          method: queryParamPreHandler
+        }
+      ]
+    }
+
+    server.route({
+      method: 'get',
+      path: '/{slug}',
+      handler: dispatchHandler,
+      options: {
+        ...dispatchRouteOptions,
+        validate: {
+          params: Joi.object().keys({
+            slug: slugSchema
+          })
+        }
+      }
+    })
+
+    server.route({
+      method: 'get',
+      path: '/{slug}/preview/{state}',
+      handler: dispatchHandler,
+      options: {
+        ...dispatchRouteOptions,
+        validate: {
+          params: Joi.object().keys({
+            slug: slugSchema,
+            state: stateSchema
+          })
+        }
+      }
+    })
+
+    server.route({
+      method: 'get',
+      path: '/{slug}/{path*}',
+      handler: getHandler,
+      options: {
+        ...getRouteOptions,
+        validate: {
+          params: Joi.object().keys({
+            slug: slugSchema,
+            path: pathSchema
+          })
+        }
+      }
+    })
+
+    server.route({
+      method: 'get',
+      path: '/{slug}/preview/{state}/{path*}',
+      handler: getHandler,
+      options: {
+        ...getRouteOptions,
+        validate: {
+          params: Joi.object().keys({
+            slug: slugSchema,
+            path: pathSchema,
+            state: stateSchema
+          })
+        }
+      }
+    })
+
     server.route({
       method: 'post',
       path: '/{slug}/{path*}',
@@ -468,7 +468,7 @@ export const plugin = {
 
     server.route({
       method: 'post',
-      path: '/preview/{state}/{slug}/{path*}',
+      path: '/{slug}/preview/{state}/{path*}',
       handler: postHandler,
       options: {
         ...postRouteOptions,
@@ -481,5 +481,6 @@ export const plugin = {
         }
       }
     })
+
   }
 }

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -1,3 +1,5 @@
+import { type FormModel } from './models/index.js'
+
 import { type InitialiseSessionOptions } from '~/src/server/plugins/initialiseSession/types.js'
 
 /**
@@ -74,4 +76,15 @@ export interface CookiesPolicy {
   essential: boolean
   analytics: 'on' | 'off'
   usage: boolean
+}
+
+declare module '@hapi/hapi' {
+  interface ServerApplicationState {
+    model?: FormModel
+    models: Map<string, FormModel>
+  }
+
+  interface RequestApplicationState {
+    model: FormModel
+  }
 }

--- a/src/server/plugins/views.ts
+++ b/src/server/plugins/views.ts
@@ -85,7 +85,7 @@ export default {
       navigation: request?.auth.isAuthenticated
         ? [{ text: 'Sign out', href: '/logout' }]
         : null,
-      previewMode: request?.path.startsWith(PREVIEW_PATH_PREFIX)
+      previewMode: request?.path.includes(PREVIEW_PATH_PREFIX)
         ? request.params.state
         : undefined
     })

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -161,16 +161,16 @@
     {{ govukFooter({
         meta: {
             items: [{
-                href: privacyPolicyUrl,
+                href: '/' + model.basePath + '/privacy',
                 text: 'Privacy'
             }, {
-                href: '/help/cookies',
+                href: '/' + model.basePath + '/cookies',
                 text: 'Cookies'
             }, {
-                href: '/help/accessibility-statement',
+                href: '/' + model.basePath + '/accessibility-statement',
                 text: 'Accessibility Statement'
             }, {
-                href: '/help/terms-and-conditions',
+                href: '/' + model.basePath + '/terms-and-conditions',
                 text: 'Terms and Conditions'
             }]
         }

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -161,16 +161,16 @@
     {{ govukFooter({
         meta: {
             items: [{
-                href: '/' + model.basePath + '/privacy',
+                href: ('/' + model.basePath + '/privacy') if model.basePath else '/help/privacy',
                 text: 'Privacy'
             }, {
-                href: '/' + model.basePath + '/cookies',
+                href: ('/' + model.basePath + '/cookies') if model.basePath else '/help/cookies',
                 text: 'Cookies'
             }, {
-                href: '/' + model.basePath + '/accessibility-statement',
+                href: ('/' + model.basePath + '/accessibility-statement') if model.basePath else '/help/accessibility-statement',
                 text: 'Accessibility Statement'
             }, {
-                href: '/' + model.basePath + '/terms-and-conditions',
+                href: ('/' + model.basePath + '/terms-and-conditions') if model.basePath else '/help/terms-and-conditions',
                 text: 'Terms and Conditions'
             }]
         }


### PR DESCRIPTION
This is a draft PR to keep track of the spike to reformat our URL structure. This includes the `slug` as well as `preview/{state}` in the URL for our help pages, which allows us then to contextualise the pages.