### PR TITLE
Upgrade GOV.UK Frontend to v5.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "dotenv": "^16.4.5",
         "expr-eval": "^2.0.2",
         "form-data": "^4.0.0",
-        "govuk-frontend": "^4.8.0",
+        "govuk-frontend": "^5.4.0",
         "hapi-pino": "^12.1.0",
         "hapi-pulse": "^3.0.1",
         "hapi-rate-limit": "^7.1.0",
@@ -7664,9 +7664,10 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
+      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "dotenv": "^16.4.5",
     "expr-eval": "^2.0.2",
     "form-data": "^4.0.0",
-    "govuk-frontend": "^4.8.0",
+    "govuk-frontend": "^5.4.0",
     "hapi-pino": "^12.1.0",
     "hapi-pulse": "^3.0.1",
     "hapi-rate-limit": "^7.1.0",

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -9,13 +9,13 @@ import {
   type FormSubmissionErrors
 } from '~/src/server/plugins/engine/types.js'
 
-function inputIsOverWordCount(input, maxWords) {
-  /**
-   * This validation is copied from the govuk-frontend library to match their client side behaviour
-   * the {@link https://github.com/alphagov/govuk-frontend/blob/e1612b13771fb7ca9a58ee85393aec94a1849335/src/govuk/components/character-count/character-count.js#L91 | govuk-frontend} library
-   */
-  const wordCount = input.match(/\S+/g).length || 0
-  return maxWords > wordCount
+/**
+ * Check if the input is over the word count
+ * @see GOV.UK Frontend {@link https://github.com/alphagov/govuk-frontend/blob/v5.4.0/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs#L343 | Character count `maxwords` implementation}
+ */
+function inputIsOverWordCount(input: string, maxWords: number) {
+  const tokens = input.match(/\S+/g) ?? []
+  return maxWords > tokens.length
 }
 
 export class MultilineTextField extends FormComponent {

--- a/src/server/plugins/engine/views/components/autocompletefield.html
+++ b/src/server/plugins/engine/views/components/autocompletefield.html
@@ -52,8 +52,8 @@
   </div>
 </div>
 
-<script src="/javascripts/accessible-autocomplete.min.js"></script>
-<script>
+<script type="module" src="/javascripts/accessible-autocomplete.min.js"></script>
+<script type="module">
   if (accessibleAutocomplete) {
     var selectEl = document.querySelector('#{{ component.model.id }}')
     accessibleAutocomplete.enhanceSelectElement({

--- a/src/server/plugins/views.ts
+++ b/src/server/plugins/views.ts
@@ -62,7 +62,7 @@ export default {
        */
       join(config.appDir, 'views'),
       join(config.appDir, 'plugins/engine/views'),
-      govukFrontendPath
+      join(govukFrontendPath, 'dist')
     ],
     isCached: !config.isDev,
     context: (request: Request | null) => ({

--- a/src/server/routes/public.ts
+++ b/src/server/routes/public.ts
@@ -21,7 +21,7 @@ export default [
         directory: {
           path: [
             join(config.publicDir, 'javascripts'),
-            join(govukFrontendPath, 'govuk'),
+            join(govukFrontendPath, 'dist/govuk'),
             join(accessibleAutocompletePath, 'dist')
           ]
         }
@@ -36,7 +36,7 @@ export default [
         directory: {
           path: [
             join(config.publicDir, 'stylesheets'),
-            join(govukFrontendPath, 'govuk'),
+            join(govukFrontendPath, 'dist/govuk'),
             join(accessibleAutocompletePath, 'dist')
           ]
         }
@@ -49,7 +49,7 @@ export default [
     options: {
       handler: {
         directory: {
-          path: join(govukFrontendPath, 'govuk/assets')
+          path: join(govukFrontendPath, 'dist/govuk/assets')
         }
       } satisfies HandlerDecorations
     }

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -39,14 +39,14 @@
         {% if feedbackLink %}
             {{ govukPhaseBanner({
                 tag: {
-                    text: phaseTag
+                    text: phaseTag | capitalize
                 },
                 html: 'This is a new service – your <a class="govuk-link" href=' + feedbackLink + '>feedback</a> will help us to improve it.'
             }) }}
         {% else %}
             {{ govukPhaseBanner({
                 tag: {
-                    text: phaseTag
+                    text: phaseTag | capitalize
                 }
             }) }}
         {% endif %}

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -66,12 +66,10 @@
 
 
 {% block bodyEnd %}
-  <script src="{{ assetPath }}/all.js"></script>
-
-  <script>
-    $(document).ready(function () {
-        GOVUKFrontend.initAll()
-    })
+  <script type="module" src="/javascripts/govuk-frontend.min.js"></script>
+  <script type="module">
+    import { initAll } from '/javascripts/govuk-frontend.min.js'
+    initAll()
   </script>
 {% endblock %}
 

--- a/test/cases/server/phase-banner.test.js
+++ b/test/cases/server/phase-banner.test.js
@@ -34,7 +34,7 @@ describe(`Phase banner`, () => {
 
     const $ = load(response.payload)
 
-    expect($('.govuk-phase-banner__content__tag').text().trim()).toBe('beta')
+    expect($('.govuk-phase-banner__content__tag').text().trim()).toBe('Beta')
   })
 
   test('shows the alpha tag if selected', async () => {
@@ -54,7 +54,7 @@ describe(`Phase banner`, () => {
 
     const $ = load(response.payload)
 
-    expect($('.govuk-phase-banner__content__tag').text().trim()).toBe('alpha')
+    expect($('.govuk-phase-banner__content__tag').text().trim()).toBe('Alpha')
   })
 
   test('does not show the phase banner if None', async () => {


### PR DESCRIPTION
This PR upgrades **forms-runner** to [GOV.UK Frontend v5.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.0)

I've reviewed all breaking changes from the [v5.0.0 release](https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0) and [**Changes to GOV.UK Frontend v5.0.0** guidance](https://frontend.design-system.service.gov.uk/changes-to-govuk-frontend-v5/#changes-to-gov-uk-frontend-v5-0-0)