### PR TITLE
Fix secure cookies being set in development

### DIFF
--- a/src/server/plugins/crumb.ts
+++ b/src/server/plugins/crumb.ts
@@ -13,10 +13,7 @@ export const configureCrumbPlugin = (
       logUnauthorized: true,
       enforce: routeConfig?.enforceCsrf ?? config?.enforceCsrf,
       cookieOptions: {
-        path: '/',
         isSecure: !config.isDev,
-        isHttpOnly: true,
-        isSameSite: 'Strict'
       },
       skip: (request: any) => {
         const skippedRoutes = ['/session']

--- a/src/server/plugins/crumb.ts
+++ b/src/server/plugins/crumb.ts
@@ -13,7 +13,7 @@ export const configureCrumbPlugin = (
       logUnauthorized: true,
       enforce: routeConfig?.enforceCsrf ?? config?.enforceCsrf,
       cookieOptions: {
-        isSecure: !config.isDev,
+        isSecure: config.isProd
       },
       skip: (request: any) => {
         const skippedRoutes = ['/session']

--- a/src/server/plugins/session.ts
+++ b/src/server/plugins/session.ts
@@ -21,7 +21,7 @@ export default {
     // storeBlank: false,
     cookieOptions: {
       password: config.sessionCookiePassword,
-      isSecure: !!config.isDev
+      isSecure: config.isProd
     }
   }
 }

--- a/src/server/plugins/session.ts
+++ b/src/server/plugins/session.ts
@@ -21,8 +21,7 @@ export default {
     // storeBlank: false,
     cookieOptions: {
       password: config.sessionCookiePassword,
-      isSecure: !!config.isDev,
-      isHttpOnly: true
+      isSecure: !!config.isDev
     }
   }
 }


### PR DESCRIPTION
This PR ensures cookies work over ~`https://`~ `http://` in development

Chrome must be happy with `Secure; HttpOnly;` via http://localhost:3000