### PR TITLE
Default forms to `application/x-www-form-urlencoded`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "date-fns": "^3.6.0",
         "dotenv": "^16.4.5",
         "expr-eval": "^2.0.2",
-        "form-data": "^4.0.0",
         "govuk-frontend": "^5.4.0",
         "hapi-pino": "^12.1.0",
         "hapi-pulse": "^3.0.1",
@@ -5083,11 +5082,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
     "node_modules/atob": {
       "version": "2.1.2",
       "license": "(MIT OR Apache-2.0)",
@@ -6247,17 +6241,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "5.1.0",
       "license": "MIT",
@@ -6911,14 +6894,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -8385,18 +8360,6 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -11516,6 +11479,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "devOptional": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "date-fns": "^3.6.0",
     "dotenv": "^16.4.5",
     "expr-eval": "^2.0.2",
-    "form-data": "^4.0.0",
     "govuk-frontend": "^5.4.0",
     "hapi-pino": "^12.1.0",
     "hapi-pulse": "^3.0.1",

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -41,10 +41,14 @@ export class CheckboxesField extends SelectionControlField {
 
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
     const viewModel = super.getViewModel(formData, errors)
-    const formDataItems = (formData[this.name] ?? '').split(',')
+
+    // Handle single (string) or multiple (array) values
+    const formDataItems =
+      this.name in formData ? [formData[this.name]].flat() : []
+
     viewModel.items = (viewModel.items ?? []).map((item) => ({
       ...item,
-      checked: !!formDataItems.find((i) => `${item.value}` === i)
+      checked: formDataItems.some((i) => `${item.value}` === i)
     }))
 
     return viewModel

--- a/src/server/plugins/engine/pageControllers/HomePageController.ts
+++ b/src/server/plugins/engine/pageControllers/HomePageController.ts
@@ -1,13 +1,13 @@
-import { type Request, type ResponseToolkit } from '@hapi/hapi'
+import { type RouteOptions } from '@hapi/hapi'
 
 import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 
 export class HomePageController extends PageController {
-  get getRouteOptions() {
+  get getRouteOptions(): RouteOptions {
     return {
       ext: {
         onPostHandler: {
-          method: (_request: Request, h: ResponseToolkit) => {
+          method(_request, h) {
             return h.continue
           }
         }
@@ -15,11 +15,11 @@ export class HomePageController extends PageController {
     }
   }
 
-  get postRouteOptions() {
+  get postRouteOptions(): RouteOptions {
     return {
       ext: {
         onPostHandler: {
-          method: (_request: Request, h: ResponseToolkit) => {
+          method(_request, h) {
             return h.continue
           }
         }

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -28,7 +28,6 @@ export class PageController extends PageControllerBase {
   get postRouteOptions(): RouteOptions {
     return {
       payload: {
-        output: 'stream',
         parse: true,
         maxBytes: Number.MAX_SAFE_INTEGER,
         failAction: 'ignore'

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -1,4 +1,8 @@
-import { type Request, type ResponseToolkit } from '@hapi/hapi'
+import {
+  type Request,
+  type ResponseToolkit,
+  type RouteOptions
+} from '@hapi/hapi'
 
 import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 
@@ -6,13 +10,11 @@ export class PageController extends PageControllerBase {
   /**
    * {@link https://hapi.dev/api/?v=20.1.2#route-options}
    */
-  get getRouteOptions(): {
-    ext: any
-  } {
+  get getRouteOptions(): RouteOptions {
     return {
       ext: {
         onPostHandler: {
-          method: (_request: Request, h: ResponseToolkit) => {
+          method(_request: Request, h: ResponseToolkit) {
             return h.continue
           }
         }
@@ -23,10 +25,7 @@ export class PageController extends PageControllerBase {
   /**
    * {@link https://hapi.dev/api/?v=20.1.2#route-options}
    */
-  get postRouteOptions(): {
-    payload?: any
-    ext: any
-  } {
+  get postRouteOptions(): RouteOptions {
     return {
       payload: {
         output: 'stream',
@@ -36,7 +35,7 @@ export class PageController extends PageControllerBase {
       },
       ext: {
         onPostHandler: {
-          method: async (_request: Request, h: ResponseToolkit) => {
+          method(_request: Request, h: ResponseToolkit) {
             return h.continue
           }
         }

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -14,9 +14,7 @@ import {
 import { merge, reach } from '@hapi/hoek'
 import { format, parseISO } from 'date-fns'
 import { type ValidationResult, type ObjectSchema } from 'joi'
-import nunjucks from 'nunjucks'
 
-import config from '~/src/server/config.js'
 import { CheckboxesField } from '~/src/server/plugins/engine/components/CheckboxesField.js'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { RadiosField } from '~/src/server/plugins/engine/components/RadiosField.js'

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -9,7 +9,9 @@ import {
 import {
   type Request,
   type ResponseObject,
-  type ResponseToolkit
+  type ResponseToolkit,
+  type RouteOptions,
+  type ServerRoute
 } from '@hapi/hapi'
 import { merge, reach } from '@hapi/hoek'
 import { format, parseISO } from 'date-fns'
@@ -722,7 +724,7 @@ export class PageControllerBase {
       path: this.path,
       options: this.getRouteOptions,
       handler: this.makeGetRouteHandler()
-    }
+    } satisfies ServerRoute
   }
 
   makePostRoute() {
@@ -731,7 +733,7 @@ export class PageControllerBase {
       path: this.path,
       options: this.postRouteOptions,
       handler: this.makePostRouteHandler()
-    }
+    } satisfies ServerRoute
   }
 
   findPageByPath(path: string) {
@@ -772,14 +774,14 @@ export class PageControllerBase {
   /**
    * {@link https://hapi.dev/api/?v=20.1.2#route-options}
    */
-  get getRouteOptions() {
+  get getRouteOptions(): RouteOptions {
     return {}
   }
 
   /**
    * {@link https://hapi.dev/api/?v=20.1.2#route-options}
    */
-  get postRouteOptions() {
+  get postRouteOptions(): RouteOptions {
     return {}
   }
 

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -1,5 +1,9 @@
 import Boom from '@hapi/boom'
-import { type Request, type ResponseToolkit } from '@hapi/hapi'
+import {
+  type Request,
+  type ResponseToolkit,
+  type RouteOptions
+} from '@hapi/hapi'
 import { format } from 'date-fns'
 import nunjucks from 'nunjucks'
 
@@ -212,11 +216,11 @@ export class SummaryPageController extends PageController {
     return undefined
   }
 
-  get postRouteOptions() {
+  get postRouteOptions(): RouteOptions {
     return {
       ext: {
         onPreHandler: {
-          method: (request: Request, h: ResponseToolkit) => {
+          method(request, h) {
             return h.continue
           }
         }

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -4,6 +4,7 @@ import {
   type PluginSpecificConfiguration,
   type Request,
   type ResponseToolkit,
+  type RouteOptions,
   type Server
 } from '@hapi/hapi'
 import { isEqual } from 'date-fns'
@@ -216,7 +217,7 @@ export const plugin = {
       }
     }
 
-    const dispatchRouteOptions = {
+    const dispatchRouteOptions: RouteOptions = {
       pre: [
         {
           method: loadFormPreHandler
@@ -256,7 +257,7 @@ export const plugin = {
       }
     })
 
-    const getRouteOptions = {
+    const getRouteOptions: RouteOptions = {
       pre: [
         {
           method: loadFormPreHandler

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -306,9 +306,7 @@ export const plugin = {
         }
       } as PluginSpecificConfiguration,
       payload: {
-        output: 'stream',
         parse: true,
-        multipart: { output: 'stream' },
         failAction: (request: Request, h: ResponseToolkit) => {
           request.server.plugins.crumb.generate?.(request, h)
           return h.continue

--- a/test/cases/server/dynamic.test.js
+++ b/test/cases/server/dynamic.test.js
@@ -2,7 +2,6 @@ import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { load } from 'cheerio'
-import FormData from 'form-data'
 
 import createServer from '~/src/server/index.js'
 import { CacheService } from '~/src/server/services/cacheService.js'
@@ -58,17 +57,10 @@ const state = {
  * @returns {import('@hapi/hapi').ServerInjectOptions}
  */
 const postOptions = (path, form) => {
-  const formData = new FormData()
-
-  Object.entries(form).forEach(([key, value]) => {
-    formData.append(key, value)
-  })
-
   return {
     method: 'POST',
     url: path,
-    headers: formData.getHeaders(),
-    payload: formData.getBuffer()
+    payload: form
   }
 }
 

--- a/test/cases/server/plugins/engine/conditions/checkboxes.test.js
+++ b/test/cases/server/plugins/engine/conditions/checkboxes.test.js
@@ -1,8 +1,6 @@
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import FormData from 'form-data'
-
 import createServer from '~/src/server/index.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
@@ -51,13 +49,12 @@ describe('Checkboxes based conditions', () => {
   })
 
   test('Testing POST /checkboxes/first-page with nothing checked redirects correctly', async () => {
-    const form = new FormData()
+    const form = {}
 
     const res = await server.inject({
       method: 'POST',
       url: '/checkboxes/first-page',
-      headers: form.getHeaders(),
-      payload: form.getBuffer()
+      payload: form
     })
 
     expect(res.statusCode).toEqual(redirectStatusCode)
@@ -65,14 +62,14 @@ describe('Checkboxes based conditions', () => {
   })
 
   test('Testing POST /checkboxes/first-page with "other" checked redirects correctly', async () => {
-    const form = new FormData()
-    form.append(key, 'other')
+    const form = {
+      [key]: 'other'
+    }
 
     const res = await server.inject({
       method: 'POST',
       url: '/checkboxes/first-page',
-      headers: form.getHeaders(),
-      payload: form.getBuffer()
+      payload: form
     })
 
     expect(res.statusCode).toEqual(redirectStatusCode)

--- a/test/cases/server/plugins/engine/conditions/radios.test.js
+++ b/test/cases/server/plugins/engine/conditions/radios.test.js
@@ -1,8 +1,6 @@
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import FormData from 'form-data'
-
 import createServer from '~/src/server/index.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
@@ -51,13 +49,12 @@ describe('Radio based conditions', () => {
   })
 
   test('Testing POST /radios/first-page with nothing checked redirects correctly', async () => {
-    const form = new FormData()
+    const form = {}
 
     const res = await server.inject({
       method: 'POST',
       url: '/radios/first-page',
-      headers: form.getHeaders(),
-      payload: form.getBuffer()
+      payload: form
     })
 
     expect(res.statusCode).toEqual(redirectStatusCode)
@@ -65,14 +62,14 @@ describe('Radio based conditions', () => {
   })
 
   test('Testing POST /radios/first-page with "other" checked redirects correctly', async () => {
-    const form = new FormData()
-    form.append(key, 'other')
+    const form = {
+      [key]: 'other'
+    }
 
     const res = await server.inject({
       method: 'POST',
       url: '/radios/first-page',
-      headers: form.getHeaders(),
-      payload: form.getBuffer()
+      payload: form
     })
 
     expect(res.statusCode).toEqual(redirectStatusCode)

--- a/test/cases/server/plugins/engine/conditions/text.test.js
+++ b/test/cases/server/plugins/engine/conditions/text.test.js
@@ -1,8 +1,6 @@
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import FormData from 'form-data'
-
 import createServer from '~/src/server/index.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
@@ -42,13 +40,12 @@ describe('TextField based conditions', () => {
   })
 
   test('Testing POST /text/first-page with an nothing string redirects correctly', async () => {
-    const form = new FormData()
+    const form = {}
 
     const res = await server.inject({
       method: 'POST',
       url: '/text/first-page',
-      headers: form.getHeaders(),
-      payload: form.getBuffer()
+      payload: form
     })
 
     expect(res.statusCode).toEqual(redirectStatusCode)
@@ -56,14 +53,14 @@ describe('TextField based conditions', () => {
   })
 
   test('Testing POST /text/first-page with an empty string redirects correctly', async () => {
-    const form = new FormData()
-    form.append(key, '')
+    const form = {
+      [key]: ''
+    }
 
     const res = await server.inject({
       method: 'POST',
       url: '/text/first-page',
-      headers: form.getHeaders(),
-      payload: form.getBuffer()
+      payload: form
     })
 
     expect(res.statusCode).toEqual(redirectStatusCode)
@@ -71,14 +68,14 @@ describe('TextField based conditions', () => {
   })
 
   test('Testing POST /text/first-page with an string "other" redirects correctly', async () => {
-    const form = new FormData()
-    form.append(key, 'other')
+    const form = {
+      [key]: 'other'
+    }
 
     const res = await server.inject({
       method: 'POST',
       url: '/text/first-page',
-      headers: form.getHeaders(),
-      payload: form.getBuffer()
+      payload: form
     })
 
     expect(res.statusCode).toEqual(redirectStatusCode)

--- a/test/cases/server/plugins/engine/journey.test.js
+++ b/test/cases/server/plugins/engine/journey.test.js
@@ -1,8 +1,6 @@
 import { dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import FormData from 'form-data'
-
 import createServer from '~/src/server/index.js'
 import { sendNotification } from '~/src/server/utils/notify.js'
 import { getSessionCookie } from '~/test/cases/server/utils/get-session-cookie.js'
@@ -87,32 +85,30 @@ describe('Submission journey test', () => {
   test('POST /summary returns 302', async () => {
     const sender = jest.mocked(sendNotification)
 
-    const form = new FormData()
-    form.append('textField', 'Text field')
-    form.append('multilineTextField', 'Multiline text field')
-    form.append('numberField', '1')
-    form.append('datePartsField__day', '12')
-    form.append('datePartsField__month', '12')
-    form.append('datePartsField__year', '2012')
-    form.append('yesNoField', 'true')
-    form.append('emailAddressField', 'user@email.com')
-    form.append('telephoneNumberField', '+447900000000')
-    form.append('addressField__addressLine1', 'Address line 1')
-    form.append('addressField__addressLine2', 'Address line 2')
-    form.append('addressField__town', 'Town or city')
-    form.append('addressField__postcode', 'CW1 1AB')
-    form.append('radiosField', 'privateLimitedCompany')
-    form.append('selectField', '910400000')
-    form.append('checkboxesField', 'Arabian')
-    form.append('checkboxesField', 'Shire')
-    form.append('checkboxesField', 'Race')
+    const form = {
+      textField: 'Text field',
+      multilineTextField: 'Multiline text field',
+      numberField: '1',
+      datePartsField__day: '12',
+      datePartsField__month: '12',
+      datePartsField__year: '2012',
+      yesNoField: 'true',
+      emailAddressField: 'user@email.com',
+      telephoneNumberField: '+447900000000',
+      addressField__addressLine1: 'Address line 1',
+      addressField__addressLine2: 'Address line 2',
+      addressField__town: 'Town or city',
+      addressField__postcode: 'CW1 1AB',
+      radiosField: 'privateLimitedCompany',
+      selectField: '910400000',
+      checkboxesField: ['Arabian', 'Shire', 'Race']
+    }
 
     // POST the form data to set the state
     const res = await server.inject({
       method: 'POST',
       url: '/components/all-components',
-      headers: form.getHeaders(),
-      payload: form.getBuffer()
+      payload: form
     })
 
     expect(res.statusCode).toEqual(redirectStatusCode)
@@ -131,12 +127,11 @@ describe('Submission journey test', () => {
     // POST the summary form and assert
     // the mock sendNotification contains
     // the correct personalisation data
-    const summaryForm = new FormData()
     const submitRes = await server.inject({
       method: 'POST',
       url: '/components/summary',
-      headers: { ...summaryForm.getHeaders(), cookie },
-      payload: summaryForm.getBuffer()
+      headers: { cookie },
+      payload: {}
     })
 
     expect(sender).toHaveBeenCalledWith({


### PR DESCRIPTION
This PR simplifies our request payloads to the default [**form POST** `application/x-www-form-urlencoded`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST)

We can look at specific file upload handling via `multipart/form-data` in future

**Note:** Form payloads are now always objects

```patch
      payload: {
-       output: 'stream',
        parse: true,
-       multipart: { output: 'stream' },
        failAction: (request: Request, h: ResponseToolkit) => {
```