### PR TITLE
Fix hard coded `<input>` widths

### DIFF
--- a/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.ts
@@ -1,16 +1,7 @@
-import { type ListComponentsDef } from '@defra/forms-model'
-
 import { SelectField } from '~/src/server/plugins/engine/components/SelectField.js'
-import { addClassOptionIfNone } from '~/src/server/plugins/engine/components/helpers.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { type FormSubmissionState } from '~/src/server/plugins/engine/types.js'
 
 export class AutocompleteField extends SelectField {
-  constructor(def: ListComponentsDef, model: FormModel) {
-    super(def, model)
-    addClassOptionIfNone(this.options, 'govuk-input--width-20')
-  }
-
   getDisplayStringFromState(state: FormSubmissionState): string {
     const { name, items } = this
     const value = state[name]

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -3,8 +3,7 @@ import { type InputFieldsComponentsDef } from '@defra/forms-model'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import {
   getStateSchemaKeys,
-  getFormSchemaKeys,
-  addClassOptionIfNone
+  getFormSchemaKeys
 } from '~/src/server/plugins/engine/components/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
@@ -16,7 +15,6 @@ export class EmailAddressField extends FormComponent {
   constructor(def: InputFieldsComponentsDef, model: FormModel) {
     super(def, model)
     this.schema.email = true
-    addClassOptionIfNone(this.options, 'govuk-input--width-20')
   }
 
   getFormSchemaKeys() {

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -37,7 +37,7 @@ export class TelephoneNumberField extends FormComponent {
 
     this.schema = componentSchema
 
-    addClassOptionIfNone(this.options, 'govuk-input--width-10')
+    addClassOptionIfNone(this.options, 'govuk-input--width-20')
   }
 
   getFormSchemaKeys() {

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -2,7 +2,6 @@ import { type TextFieldComponent } from '@defra/forms-model'
 import joi, { type Schema } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
-import { addClassOptionIfNone } from '~/src/server/plugins/engine/components/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormData,
@@ -19,8 +18,6 @@ export class TextField extends FormComponent {
     const { options, schema = {} } = def
     this.options = options
     this.schema = schema
-
-    addClassOptionIfNone(this.options, 'govuk-input--width-20')
 
     let componentSchema = joi.string().required()
     if (options.required === false) {

--- a/src/server/plugins/engine/components/types.ts
+++ b/src/server/plugins/engine/components/types.ts
@@ -1,6 +1,6 @@
 export interface Label {
   text: string
-  classes: string
+  classes?: string
   html?: string
   isPageHeading?: boolean
 }

--- a/test/cases/server/plugins/engine/conditions/text.test.js
+++ b/test/cases/server/plugins/engine/conditions/text.test.js
@@ -37,7 +37,7 @@ describe('TextField based conditions', () => {
     expect(res.statusCode).toEqual(okStatusCode)
     expect(res.headers['content-type']).toContain(htmlContentType)
     expect(res.result).toContain(
-      `<input class="govuk-input govuk-input--width-20" id="${key}" name="${key}" type="text">`
+      `<input class="govuk-input" id="${key}" name="${key}" type="text">`
     )
   })
 


### PR DESCRIPTION
This PR removes the hard-coded `govuk-input--width-20` class from:

* Text inputs (including UK address fields)
* Email addresses
* Autocompletes

But switches to ~`govuk-input--width-10`~ `govuk-input--width-20` for the [**Telephone number** pattern](https://design-system.service.gov.uk/patterns/telephone-numbers/)