### PR TITLE
Fix option `optionalText` for UK address component

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -25,8 +25,10 @@ export class DatePartsField extends FormComponent {
     super(def, model)
 
     const { name, options } = this
+
     const isRequired = !('required' in options && options.required === false)
-    const optionalText = 'optionalText' in options && options.optionalText
+    const hideOptional = 'optionalText' in options && options.optionalText
+
     this.children = new ComponentCollection(
       [
         {
@@ -36,7 +38,7 @@ export class DatePartsField extends FormComponent {
           schema: { min: 1, max: 31 },
           options: {
             required: isRequired,
-            optionalText,
+            optionalText: !isRequired && hideOptional,
             classes: 'govuk-input--width-2'
           },
           hint: ''
@@ -48,7 +50,7 @@ export class DatePartsField extends FormComponent {
           schema: { min: 1, max: 12 },
           options: {
             required: isRequired,
-            optionalText,
+            optionalText: !isRequired && hideOptional,
             classes: 'govuk-input--width-2'
           },
           hint: ''
@@ -60,7 +62,7 @@ export class DatePartsField extends FormComponent {
           schema: { min: 1000, max: 3000 },
           options: {
             required: isRequired,
-            optionalText,
+            optionalText: !isRequired && hideOptional,
             classes: 'govuk-input--width-4'
           },
           hint: ''

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -49,11 +49,14 @@ export class FormComponent extends ComponentBase {
 
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
     const options = this.options
-    const isOptional = options.required === false
-    const optionalPostfix =
-      isOptional && options.optionalText !== false ? optionalText : ''
 
-    const label = options.hideTitle ? '' : `${this.title}${optionalPostfix}`
+    const isRequired = !('required' in options && options.required === false)
+    const hideOptional = 'optionalText' in options && options.optionalText
+    const hideTitle = 'hideTitle' in options && options.hideTitle
+
+    const label = !hideTitle
+      ? `${this.title}${!isRequired && !hideOptional ? optionalText : ''}`
+      : ''
 
     const name = this.name
 

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -23,8 +23,11 @@ export class UkAddressField extends FormComponent {
   constructor(def: InputFieldsComponentsDef, model: FormModel) {
     super(def, model)
     const { name, options } = this
+
     const stateSchema = helpers.buildStateSchema('date', this)
+
     const isRequired = !('required' in options && options.required === false)
+    const hideOptional = 'optionalText' in options && options.optionalText
 
     const childrenList = [
       {
@@ -34,7 +37,8 @@ export class UkAddressField extends FormComponent {
         schema: { max: 100 },
         options: {
           autocomplete: 'address-line1',
-          required: isRequired
+          required: isRequired,
+          optionalText: !isRequired && hideOptional
         }
       },
       {
@@ -44,7 +48,8 @@ export class UkAddressField extends FormComponent {
         schema: { max: 100, allow: '' },
         options: {
           autocomplete: 'address-line2',
-          required: false
+          required: false,
+          optionalText: !isRequired && hideOptional
         }
       },
       {
@@ -55,7 +60,8 @@ export class UkAddressField extends FormComponent {
         options: {
           autocomplete: 'address-level2',
           classes: 'govuk-!-width-two-thirds',
-          required: isRequired
+          required: isRequired,
+          optionalText: !isRequired && hideOptional
         }
       },
       {
@@ -66,7 +72,8 @@ export class UkAddressField extends FormComponent {
         options: {
           autocomplete: 'postal-code',
           classes: 'govuk-input--width-10',
-          required: isRequired
+          required: isRequired,
+          optionalText: !isRequired && hideOptional
         }
       }
     ] satisfies ComponentDef[]


### PR DESCRIPTION
This PR fixes display of optional text on the UK address component

Both related bugs in the editor are now fixed:

* Ticking "Make UK address field optional" did not add "(optional)" to all fields
* Ticking "Hide '(optional)' text" did not remove "(optional)" from **Address line 2**