### PR TITLE
Only allow `hideTitle` to remove UK address title

### DIFF
--- a/src/server/forms/cph-demo.json
+++ b/src/server/forms/cph-demo.json
@@ -44,7 +44,7 @@
       "components": [
         {
           "name": "hpmkrN",
-          "options": { "hideTitle": true },
+          "options": {},
           "type": "UkAddressField",
           "title": "Address",
           "schema": {}
@@ -58,7 +58,7 @@
       "components": [
         {
           "name": "fMHViw",
-          "options": { "hideTitle": true },
+          "options": {},
           "type": "TelephoneNumberField",
           "hint": "Enter a telephone number so the Rural Payments Agency (RPA) can contact you if they need to discuss your application.",
           "title": "Telephone number",
@@ -73,7 +73,7 @@
       "components": [
         {
           "name": "MyGRlh",
-          "options": { "hideTitle": true, "required": false },
+          "options": { "required": false },
           "type": "TelephoneNumberField",
           "title": "Second telephone number",
           "schema": {}
@@ -87,7 +87,7 @@
       "components": [
         {
           "name": "uZcVcc",
-          "options": { "hideTitle": true },
+          "options": {},
           "type": "EmailAddressField",
           "title": "Email address",
           "hint": "RPA will email your CPH number to you.",
@@ -125,7 +125,7 @@
       "components": [
         {
           "name": "CMTiOK",
-          "options": { "hideTitle": true },
+          "options": {},
           "type": "YesNoField",
           "title": "Is your business address the same as your home address?",
           "hint": "If you do not have a business, select 'yes'.",
@@ -314,7 +314,7 @@
       "components": [
         {
           "name": "nTEdlT",
-          "options": { "hideTitle": true },
+          "options": {},
           "type": "TextField",
           "title": "What do you do?",
           "schema": {}
@@ -552,7 +552,7 @@
         },
         {
           "name": "PXRMtw",
-          "options": { "hideTitle": true },
+          "options": {},
           "type": "UkAddressField",
           "title": "What's the address where you'll keep livestock or use animal by-products?"
         }

--- a/src/server/forms/report-a-terrorist.json
+++ b/src/server/forms/report-a-terrorist.json
@@ -23,9 +23,7 @@
         {
           "type": "RadiosField",
           "title": "Do you have a link to the material?",
-          "options": {
-            "hideTitle": true
-          },
+          "options": {},
           "name": "doyouhavealink",
           "schema": {},
           "list": "HTbt4V"

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -105,7 +105,7 @@ export class ComponentCollection {
   ): ComponentCollectionViewModel {
     const result = this.items.map((item) => {
       return {
-        type: item.type,
+        type: 'type' in item ? item.type : undefined,
         isFormComponent: 'isFormComponent' in item && item.isFormComponent,
         model: item.getViewModel(formData, errors)
       }

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -121,8 +121,6 @@ export class DatePartsField extends FormComponent {
   }
 
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
-    const { options } = this
-
     const viewModel = super.getViewModel(formData, errors)
 
     // Use the component collection to generate the subitems
@@ -147,12 +145,10 @@ export class DatePartsField extends FormComponent {
 
     let { fieldset, label } = viewModel
 
-    if (!('hideTitle' in options && options.hideTitle)) {
-      fieldset ??= {
-        legend: {
-          text: label.text,
-          classes: 'govuk-fieldset__legend--m'
-        }
+    fieldset ??= {
+      legend: {
+        text: label.text,
+        classes: 'govuk-fieldset__legend--m'
       }
     }
 

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -53,11 +53,7 @@ export class FormComponent extends ComponentBase {
 
     const isRequired = !('required' in options && options.required === false)
     const hideOptional = 'optionalText' in options && options.optionalText
-    const hideTitle = 'hideTitle' in options && options.hideTitle
-
-    const label = !hideTitle
-      ? `${title}${!isRequired && !hideOptional ? optionalText : ''}`
-      : ''
+    const label = `${title}${!isRequired && !hideOptional ? optionalText : ''}`
 
     if (hint) {
       viewModel.hint = {

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -86,7 +86,7 @@ export class MonthYearField extends FormComponent {
   }
 
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
-    const { children, options } = this
+    const { children } = this
 
     const viewModel = super.getViewModel(formData, errors)
 
@@ -109,12 +109,10 @@ export class MonthYearField extends FormComponent {
 
     let { fieldset, label } = viewModel
 
-    if (!('hideTitle' in options && options.hideTitle)) {
-      fieldset ??= {
-        legend: {
-          text: label.text,
-          classes: 'govuk-fieldset__legend--m'
-        }
+    fieldset ??= {
+      legend: {
+        text: label.text,
+        classes: 'govuk-fieldset__legend--m'
       }
     }
 

--- a/src/server/plugins/engine/components/SelectionControlField.ts
+++ b/src/server/plugins/engine/components/SelectionControlField.ts
@@ -15,12 +15,10 @@ export class SelectionControlField extends ListFormComponent {
     const viewModel = super.getViewModel(formData, errors)
     let { fieldset, items, label } = viewModel
 
-    if (!('hideTitle' in options && options.hideTitle)) {
-      fieldset ??= {
-        legend: {
-          text: label.text,
-          classes: 'govuk-fieldset__legend--m'
-        }
+    fieldset ??= {
+      legend: {
+        text: label.text,
+        classes: 'govuk-fieldset__legend--m'
       }
     }
 

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -9,6 +9,7 @@ import { ComponentCollection } from '~/src/server/plugins/engine/components/Comp
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import * as helpers from '~/src/server/plugins/engine/components/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
+import { type PageControllerBase } from '~/src/server/plugins/engine/pageControllers/index.js'
 import {
   type FormData,
   type FormPayload,
@@ -156,12 +157,18 @@ export class UkAddressField extends FormComponent {
     const viewModel = super.getViewModel(formData, errors)
     let { children, fieldset, label } = viewModel
 
-    if (!('hideTitle' in options && options.hideTitle)) {
-      fieldset ??= {
-        legend: {
-          text: label.text,
-          classes: 'govuk-fieldset__legend--m'
-        }
+    fieldset ??= {
+      legend: {
+        text: label.text,
+
+        /**
+         * For screen readers, only hide legend visually. This can be overridden
+         * by single component {@link PageControllerBase | `showTitle` handling}
+         */
+        classes:
+          'hideTitle' in options && options.hideTitle
+            ? 'govuk-visually-hidden'
+            : 'govuk-fieldset__legend--m'
       }
     }
 

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -71,17 +71,15 @@ export class YesNoField extends ListFormComponent {
   }
 
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
-    const { name, options } = this
+    const { name } = this
 
     const viewModel = super.getViewModel(formData, errors)
     let { fieldset, items, label } = viewModel
 
-    if (!('hideTitle' in options && options.hideTitle)) {
-      fieldset ??= {
-        legend: {
-          text: label.text,
-          classes: 'govuk-fieldset__legend--m'
-        }
+    fieldset ??= {
+      legend: {
+        text: label.text,
+        classes: 'govuk-fieldset__legend--m'
       }
     }
 

--- a/src/server/plugins/engine/components/types.ts
+++ b/src/server/plugins/engine/components/types.ts
@@ -1,3 +1,5 @@
+import { type ComponentType } from '@defra/forms-model'
+
 export interface Label {
   text: string
   classes?: string
@@ -65,11 +67,18 @@ export type MultilineTextFieldViewModel = {
   maxwords?: number
 } & ViewModel
 
-export type ComponentCollectionViewModel = {
-  type: string
-  isFormComponent: boolean
-  model: ViewModel
-}[]
+export type ComponentCollectionViewModel = (
+  | {
+      type: ComponentType
+      isFormComponent: true
+      model: ViewModel
+    }
+  | {
+      type: undefined
+      isFormComponent: false
+      model: ViewModel
+    }
+)[]
 
 export type DataType =
   | 'list'

--- a/src/server/plugins/engine/views/components/ukaddressfield.html
+++ b/src/server/plugins/engine/views/components/ukaddressfield.html
@@ -2,7 +2,11 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 
 {% macro UkAddressField(component) %}
-  {% call govukFieldset(component.model.fieldset) %}
-    {{ componentList(component.model.children) }}
-  {% endcall %}
+  {% set fieldset = component.model.fieldset %}
+  {% set addressFieldHtml = componentList(component.model.children) %}
+
+  {{ govukFieldset({
+    legend: fieldset.legend,
+    html: addressFieldHtml
+  }) if fieldset else addressFieldHtml }}
 {% endmacro %}


### PR DESCRIPTION
This PR restricts the `hideTitle` feature to prevent an accessibility bug

Once merged, only UK addresses can manually hide the (optional) component title

For more information see the related **forms-designer** PR:

* https://github.com/DEFRA/forms-designer/pull/294

Resolves [ticket #402887](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/402887)

## Accessibility issue
When the `hideTitle` option is enabled, we currently blank the label text which:

1. Removes the `<legend>` element from radios, checkboxes etc
2. Removes the `<label>` element from text inputs etc

https://github.com/DEFRA/forms-runner/blob/93baa629b39e0b2491387ad65a7d8e7aadb24812/src/server/plugins/engine/components/FormComponent.ts#L79-L81

This intentionally removes text that can be announced by assistive software

# Before

How do we spot this bug? When `hideTitle` was ticked for:

## Single component pages
Both the page title `<h1>` and component title `<legend>` are removed

<img width="684" alt="Page title and legend hidden" src="https://github.com/DEFRA/forms-runner/assets/415517/68c0e889-1dbb-48dd-b945-e2c0cee14ae1">

## Multiple component pages
The page title `<h1>` is visible but component title `<legend>` is removed

<img width="704" alt="Page title not legend" src="https://github.com/DEFRA/forms-runner/assets/415517/561a6f88-af76-4e81-a56e-0beb309a35ad">

# After

The component title `<legend>` should be nested inside the form group

<img width="670" alt="Page title as legend" src="https://github.com/DEFRA/forms-runner/assets/415517/5d8bfb07-da01-4885-bd5d-0bf4d00508a1">