### PR TITLE
Ensure page heading `<legend>` elements display correctly

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -121,6 +121,8 @@ export class DatePartsField extends FormComponent {
   }
 
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
+    const { options } = this
+
     const viewModel = super.getViewModel(formData, errors)
 
     // Use the component collection to generate the subitems
@@ -143,12 +145,21 @@ export class DatePartsField extends FormComponent {
     const firstError = errors?.errorList[0]
     const errorMessage = firstError && { text: firstError.text }
 
+    let { fieldset, label } = viewModel
+
+    if (!('hideTitle' in options && options.hideTitle)) {
+      fieldset ??= {
+        legend: {
+          text: label.text,
+          classes: 'govuk-fieldset__legend--m'
+        }
+      }
+    }
+
     return {
       ...viewModel,
       errorMessage,
-      fieldset: {
-        legend: viewModel.label
-      },
+      fieldset,
       items: componentViewModels
     }
   }

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -2,7 +2,6 @@ import joi, { type Schema } from 'joi'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
-import { type ViewModel } from '~/src/server/plugins/engine/components/types.js'
 import {
   type FormSubmissionState,
   type FormSubmissionErrors,
@@ -48,31 +47,21 @@ export class FormComponent extends ComponentBase {
   }
 
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
-    const options = this.options
+    const { hint, name, options, title } = this
+
+    const viewModel = super.getViewModel(formData, errors)
 
     const isRequired = !('required' in options && options.required === false)
     const hideOptional = 'optionalText' in options && options.optionalText
     const hideTitle = 'hideTitle' in options && options.hideTitle
 
     const label = !hideTitle
-      ? `${this.title}${!isRequired && !hideOptional ? optionalText : ''}`
+      ? `${title}${!isRequired && !hideOptional ? optionalText : ''}`
       : ''
 
-    const name = this.name
-
-    const viewModel: ViewModel = {
-      ...super.getViewModel(formData, errors),
-      label: {
-        text: label
-      },
-      id: name,
-      name,
-      value: formData[name]
-    }
-
-    if (this.hint) {
+    if (hint) {
       viewModel.hint = {
-        html: this.hint
+        html: hint
       }
     }
 
@@ -92,7 +81,15 @@ export class FormComponent extends ComponentBase {
       }
     })
 
-    return viewModel
+    return {
+      ...viewModel,
+      label: {
+        text: label
+      },
+      id: name,
+      name,
+      value: formData[name]
+    }
   }
 
   getFormSchemaKeys() {

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -86,10 +86,12 @@ export class MonthYearField extends FormComponent {
   }
 
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
+    const { children, options } = this
+
     const viewModel = super.getViewModel(formData, errors)
 
     // Use the component collection to generate the subitems
-    const componentViewModels = this.children
+    const componentViewModels = children
       .getViewModel(formData, errors)
       .map((vm) => vm.model)
 
@@ -105,11 +107,20 @@ export class MonthYearField extends FormComponent {
       }
     })
 
+    let { fieldset, label } = viewModel
+
+    if (!('hideTitle' in options && options.hideTitle)) {
+      fieldset ??= {
+        legend: {
+          text: label.text,
+          classes: 'govuk-fieldset__legend--m'
+        }
+      }
+    }
+
     return {
       ...viewModel,
-      fieldset: {
-        legend: viewModel.label
-      },
+      fieldset,
       items: componentViewModels
     }
   }

--- a/src/server/plugins/engine/components/SelectionControlField.ts
+++ b/src/server/plugins/engine/components/SelectionControlField.ts
@@ -10,15 +10,21 @@ import {
  */
 export class SelectionControlField extends ListFormComponent {
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
-    const { name, items } = this
-    const options = this.options
-    const viewModel = super.getViewModel(formData, errors)
+    const { name, options } = this
 
-    viewModel.fieldset = {
-      legend: viewModel.label
+    const viewModel = super.getViewModel(formData, errors)
+    let { fieldset, items, label } = viewModel
+
+    if (!('hideTitle' in options && options.hideTitle)) {
+      fieldset ??= {
+        legend: {
+          text: label.text,
+          classes: 'govuk-fieldset__legend--m'
+        }
+      }
     }
 
-    viewModel.items = items.map((item) => {
+    items = items?.map((item) => {
       const itemModel: ListItem = {
         text: item.text,
         value: item.value,
@@ -42,6 +48,11 @@ export class SelectionControlField extends ListFormComponent {
       // FIXME:- add this back when GDS fix accessibility issues involving conditional reveal fields
       // return super.addConditionalComponents(item, itemModel, formData, errors);
     })
-    return viewModel
+
+    return {
+      ...viewModel,
+      fieldset,
+      items
+    }
   }
 }

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -151,15 +151,26 @@ export class UkAddressField extends FormComponent {
   }
 
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
-    const viewModel = {
-      ...super.getViewModel(formData, errors),
-      children: this.formChildren.getViewModel(formData, errors)
+    const { formChildren, options } = this
+
+    const viewModel = super.getViewModel(formData, errors)
+    let { children, fieldset, label } = viewModel
+
+    if (!('hideTitle' in options && options.hideTitle)) {
+      fieldset ??= {
+        legend: {
+          text: label.text,
+          classes: 'govuk-fieldset__legend--m'
+        }
+      }
     }
 
-    viewModel.fieldset = {
-      legend: viewModel.label
-    }
+    children = formChildren.getViewModel(formData, errors)
 
-    return viewModel
+    return {
+      ...viewModel,
+      fieldset,
+      children
+    }
   }
 }

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -71,17 +71,30 @@ export class YesNoField extends ListFormComponent {
   }
 
   getViewModel(formData: FormData, errors?: FormSubmissionErrors) {
-    const viewModel = super.getViewModel(formData, errors)
+    const { name, options } = this
 
-    viewModel.fieldset = {
-      legend: viewModel.label
+    const viewModel = super.getViewModel(formData, errors)
+    let { fieldset, items, label } = viewModel
+
+    if (!('hideTitle' in options && options.hideTitle)) {
+      fieldset ??= {
+        legend: {
+          text: label.text,
+          classes: 'govuk-fieldset__legend--m'
+        }
+      }
     }
-    viewModel.items = this.items.map(({ text, value }) => ({
+
+    items = items?.map(({ text, value }) => ({
       text,
       value,
-      checked: `${value}` === `${formData[this.name]}`
+      checked: `${value}` === `${formData[name]}`
     }))
 
-    return viewModel
+    return {
+      ...viewModel,
+      fieldset,
+      items
+    }
   }
 }

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -133,7 +133,10 @@ export class PageControllerBase {
     phaseTag?: string | undefined
   } {
     let showTitle = true
-    let pageTitle = this.title
+
+    let { title: pageTitle, section } = this
+    let sectionTitle = section?.hideTitle !== true ? section?.title : ''
+
     const serviceUrl = `/${this.model.basePath}`
 
     if (config.allowUserTemplates) {
@@ -141,21 +144,18 @@ export class PageControllerBase {
         ...formData
       })
     }
-    let sectionTitle = !this.section?.hideTitle && this.section?.title
+
     if (sectionTitle && iteration !== undefined) {
       sectionTitle = `${sectionTitle} ${iteration}`
     }
+
     const components = this.components.getViewModel(formData, errors)
+    const formComponents = components.filter(
+      ({ isFormComponent }) => isFormComponent
+    )
 
-    const formComponents = components.filter((c) => c.isFormComponent)
-    const hasSingleFormComponent = formComponents.length === 1
-    const singleFormComponent = hasSingleFormComponent
-      ? formComponents[0]
-      : null
-    const singleFormComponentIsFirst =
-      singleFormComponent && singleFormComponent === components[0]
-
-    if (singleFormComponent && singleFormComponentIsFirst) {
+    // Single form component? Hide title and customise label or legend instead
+    if (formComponents.length === 1 && formComponents[0] === components[0]) {
       const { model } = formComponents[0]
       const { fieldset, label } = model
 

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -156,15 +156,28 @@ export class PageControllerBase {
       singleFormComponent && singleFormComponent === components[0]
 
     if (singleFormComponent && singleFormComponentIsFirst) {
-      const label = singleFormComponent.model.label
+      const { model } = formComponents[0]
+      const { fieldset, label } = model
 
-      if (pageTitle) {
-        label.text = pageTitle
+      // Check for legend or label
+      const labelOrLegend = fieldset?.legend ?? label
+
+      // Use legend or label as page heading
+      if (labelOrLegend) {
+        labelOrLegend.isPageHeading = true
+
+        labelOrLegend.classes =
+          labelOrLegend === label
+            ? 'govuk-label--l'
+            : 'govuk-fieldset__legend--l'
+
+        if (pageTitle) {
+          labelOrLegend.text = pageTitle
+        }
+
+        pageTitle = pageTitle || labelOrLegend.text
       }
 
-      label.isPageHeading = true
-      label.classes = 'govuk-label--l'
-      pageTitle = pageTitle || label.text
       showTitle = false
     }
 

--- a/src/server/plugins/engine/views/components/ukaddressfield.html
+++ b/src/server/plugins/engine/views/components/ukaddressfield.html
@@ -2,9 +2,7 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 
 {% macro UkAddressField(component) %}
-  {% call govukFieldset({
-    legend: component.model.label
-  }) %}
+  {% call govukFieldset(component.model.fieldset) %}
     {{ componentList(component.model.children) }}
   {% endcall %}
 {% endmacro %}

--- a/test/cases/server/plugins/engine/datepartsfield.test.ts
+++ b/test/cases/server/plugins/engine/datepartsfield.test.ts
@@ -17,7 +17,8 @@ describe('Date parts field', () => {
 
     expect(returned.fieldset).toEqual({
       legend: {
-        text: def.title
+        text: def.title,
+        classes: 'govuk-fieldset__legend--m'
       }
     })
     expect(returned.items).toEqual([
@@ -41,7 +42,8 @@ describe('Date parts field', () => {
 
     expect(returned.fieldset).toEqual({
       legend: {
-        text: `${def.title} (optional)`
+        text: `${def.title} (optional)`,
+        classes: 'govuk-fieldset__legend--m'
       }
     })
     expect(returned.items).toEqual([


### PR DESCRIPTION
This PR ensures page headings for components with `<legend>` elements display correctly

I've included screenshots below for comparison

Resolves [ticket #402092](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/402092)

# Single component pages

## Before

<img width="697" alt="Single component, before" src="https://github.com/DEFRA/forms-runner/assets/415517/09807943-e6d5-4b04-9a19-660e1150be40">

## After

<img width="688" alt="Single component, after" src="https://github.com/DEFRA/forms-runner/assets/415517/c8157e5f-c048-46c7-bbe0-5747759610bf">

# Multiple component pages

## Before

<img width="708" alt="Multiple components, before" src="https://github.com/DEFRA/forms-runner/assets/415517/69b7dd67-be84-438a-8445-381d3721f85b">

## After

<img width="691" alt="Multiple components, after" src="https://github.com/DEFRA/forms-runner/assets/415517/9eb0dc32-19de-4e3d-ac13-73efa2d8749d">

