### PR TITLE
Use medium heading on single component pages after content

### DIFF
--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -155,30 +155,37 @@ export class PageControllerBase {
     )
 
     // Single form component? Hide title and customise label or legend instead
-    if (formComponents.length === 1 && formComponents[0] === components[0]) {
+    if (formComponents.length === 1) {
       const { model } = formComponents[0]
       const { fieldset, label } = model
+
+      // Set as page heading when not following other content
+      const isPageHeading = formComponents[0] === components[0]
 
       // Check for legend or label
       const labelOrLegend = fieldset?.legend ?? label
 
       // Use legend or label as page heading
       if (labelOrLegend) {
-        labelOrLegend.isPageHeading = true
+        const size = isPageHeading ? 'l' : 'm'
 
         labelOrLegend.classes =
           labelOrLegend === label
-            ? 'govuk-label--l'
-            : 'govuk-fieldset__legend--l'
+            ? `govuk-label--${size}`
+            : `govuk-fieldset__legend--${size}`
 
-        if (pageTitle) {
-          labelOrLegend.text = pageTitle
+        if (isPageHeading) {
+          labelOrLegend.isPageHeading = isPageHeading
+
+          if (pageTitle) {
+            labelOrLegend.text = pageTitle
+          }
+
+          pageTitle = pageTitle || labelOrLegend.text
         }
-
-        pageTitle = pageTitle || labelOrLegend.text
       }
 
-      showTitle = false
+      showTitle = !isPageHeading
     }
 
     return {


### PR DESCRIPTION
This PR widens our "single component page" checks to include both:

1. **Pages with a single form component at the top**
  Form component label or legend becomes a large heading + replaces the page title

2. **Pages with a single form component following other content**
  Form component label or legend becomes a medium heading

Previously only 1) was included

# Before

<img width="707" alt="Component without bold heading, before" src="https://github.com/DEFRA/forms-runner/assets/415517/365d5b82-3077-4359-a00b-c5755678e56e">

# After

<img width="696" alt="Component with bold heading, after" src="https://github.com/DEFRA/forms-runner/assets/415517/6916e368-ad2e-4ad3-99da-b23c3c1eb8a8">
