### PR TITLE
Fix trailing empty spaces in accessibility statement

### DIFF
--- a/src/server/views/help/accessibility-statement.html
+++ b/src/server/views/help/accessibility-statement.html
@@ -8,21 +8,21 @@
       <h1 class="govuk-heading-l">Accessibility statement for this form</h1>
       <p class="govuk-body">This accessibility statement applies to online forms with a URL that starts with
         https://submit-forms-to-defra.service.gov.uk.</p>
-      
+
       <h2 class="govuk-heading-m">Technical information about this website’s accessibility</h2>
       <p class="govuk-body">Defra is committed to making its forms accessible, in accordance with the Public Sector Bodies
         (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
-      
+
       <h2 class="govuk-heading-m">Compliance status</h2>
       <p class="govuk-body">Forms created by Defra are fully compliant with the Web Content Accessibility Guidelines
         (WCAG) version 2.2 AA standard.</p>
-      
+
       <h2 class="govuk-heading-m">How accessible this website is</h2>
       <p class="govuk-body">This section lists accessibility issues with content found in Defra forms.</p>
-      
+
       <h3 class="govuk-heading-s">Non-compliance with the accessibility regulations</h3>
       <p class="govuk-body">Defra forms do not have accessibility issues that fail the WCAG 2.2 accessibility regulations.</p>
-  
+
       <h3 class="govuk-heading-s">Content that’s not within the scope of the accessibility regulations</h3>
       <p class="govuk-body">The accessibility issues listed in this section do not fail the accessibility regulations. We
         plan to fix them as soon as possible.</p>
@@ -35,18 +35,18 @@
         <li>Section titles in some forms are formatted as H2 level headings. These headings are shown before page titles
           which are formatted as H1 level headings (skipped heading hierarchy).</li>
       </ul>
-  
+
       <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
       <p class="govuk-body">This statement was prepared on 24 June 2024. It was last reviewed on 26 June 2024.</p>
       <p class="govuk-body">The Defra Accessibility team tested 2 online forms against the WCAG 2.2 AA standard on 17 June
         2024. The tests were done using automated testing tools.</p>
       <p class="govuk-body">We will commission a full accessibility audit of forms created by Defra before April 2025.</p>
-  
+
       <h2 class="govuk-heading-m">Feedback and contact information</h2>
       <p class="govuk-body">If you find any problems not listed on this page or think we’re not meeting accessibility
         requirements, email the Defra forms service team on <a class="govuk-link"
           href="mailto:defraforms@defra.gov.uk">defraforms@defra.gov.uk</a>.</p>
-  
+
       <h2 class="govuk-heading-m">Enforcement procedure</h2>
       <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector
         Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility
@@ -56,4 +56,3 @@
     </div>
   </div>
 {% endblock %}
-


### PR DESCRIPTION
This one's turning our EditorConfig checks red, quick fix to remove trailing spaces