### PR TITLE
Add types on all component classes + review options

### DIFF
--- a/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.ts
@@ -1,10 +1,26 @@
+import { type AutocompleteFieldComponent } from '@defra/forms-model'
+
 import { SelectField } from '~/src/server/plugins/engine/components/SelectField.js'
+import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
+  type FormData,
   type FormSubmissionErrors,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
 
 export class AutocompleteField extends SelectField {
+  options: AutocompleteFieldComponent['options']
+  schema: AutocompleteFieldComponent['schema']
+
+  constructor(def: AutocompleteFieldComponent, model: FormModel) {
+    super(def, model)
+
+    const { schema, options } = def
+
+    this.options = options
+    this.schema = schema
+  }
+
   getDisplayStringFromState(state: FormSubmissionState): string {
     const { name, items } = this
     const value = state[name]

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -13,21 +13,21 @@ export class CheckboxesField extends SelectionControlField {
   constructor(def: ListComponentsDef, model: FormModel) {
     super(def, model)
 
-    let schema = joi.array().single().label(def.title.toLowerCase())
+    let formSchema = joi.array<string>().single().label(def.title.toLowerCase())
 
     if (def.options.required === false) {
       // null or empty string is valid for optional fields
-      schema = schema
+      formSchema = formSchema
         .empty(null)
         .items(joi[this.listType]().allow(...this.values, ''))
     } else {
-      schema = schema
+      formSchema = formSchema
         .items(joi[this.listType]().allow(...this.values))
         .required()
     }
 
-    this.formSchema = schema
-    this.stateSchema = schema
+    this.formSchema = formSchema
+    this.stateSchema = formSchema
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -1,4 +1,4 @@
-import { type ListComponentsDef } from '@defra/forms-model'
+import { type CheckboxesFieldComponent } from '@defra/forms-model'
 import joi from 'joi'
 
 import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
@@ -10,12 +10,17 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class CheckboxesField extends SelectionControlField {
-  constructor(def: ListComponentsDef, model: FormModel) {
+  options: CheckboxesFieldComponent['options']
+  schema: CheckboxesFieldComponent['schema']
+
+  constructor(def: CheckboxesFieldComponent, model: FormModel) {
     super(def, model)
 
-    let formSchema = joi.array<string>().single().label(def.title.toLowerCase())
+    const { options, schema, title } = def
 
-    if (def.options.required === false) {
+    let formSchema = joi.array<string>().single().label(title.toLowerCase())
+
+    if (options.required === false) {
       // null or empty string is valid for optional fields
       formSchema = formSchema
         .empty(null)
@@ -28,6 +33,8 @@ export class CheckboxesField extends SelectionControlField {
 
     this.formSchema = formSchema
     this.stateSchema = formSchema
+    this.options = options
+    this.schema = schema
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -3,7 +3,14 @@ import {
   type ContentComponentsDef,
   type InputFieldsComponentsDef
 } from '@defra/forms-model'
-import { type Schema as JoiSchema } from 'joi'
+import joi, {
+  type AlternativesSchema,
+  type ArraySchema,
+  type BooleanSchema,
+  type NumberSchema,
+  type ObjectSchema,
+  type StringSchema
+} from 'joi'
 
 import {
   type DataType,
@@ -23,6 +30,7 @@ export class ComponentBase {
   options: ComponentDef['options']
   hint?: InputFieldsComponentsDef['hint']
   content?: ContentComponentsDef['content']
+
   /**
    * This is passed onto webhooks, see {@link answerFromDetailItem}
    */
@@ -30,8 +38,8 @@ export class ComponentBase {
   model: FormModel
 
   /** joi schemas based on a component defined in the form JSON. This validates a user's answer and is generated from {@link ComponentDef} */
-  formSchema?: JoiSchema
-  stateSchema?: JoiSchema
+  formSchema: ComponentSchema = joi.string()
+  stateSchema: ComponentSchema = joi.string()
 
   constructor(def: ComponentDef, model: FormModel) {
     // component definition properties
@@ -61,4 +69,20 @@ export class ComponentBase {
   }
 }
 
-export type ComponentSchemaNested = Record<string, JoiSchema | undefined>
+export type ComponentSchema =
+  | AlternativesSchema<string | number>
+  | ArraySchema<string>
+  | ArraySchema<number>
+  | ArraySchema<boolean>
+  | BooleanSchema<string>
+  | NumberSchema<string>
+  | NumberSchema
+  | ObjectSchema
+  | StringSchema
+
+export type ComponentSchemaNested = Record<string, ComponentSchema | undefined>
+
+export type ComponentSchemaKeys = Record<
+  string,
+  ComponentSchema | ComponentSchemaNested | undefined
+>

--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -60,3 +60,5 @@ export class ComponentBase {
     }
   }
 }
+
+export type ComponentSchemaNested = Record<string, JoiSchema | undefined>

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -1,7 +1,10 @@
 import { type ComponentDef } from '@defra/forms-model'
 import joi, { type Schema as JoiSchema } from 'joi'
 
-import { type ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
+import {
+  type ComponentBase,
+  type ComponentSchemaNested
+} from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { type FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import * as Components from '~/src/server/plugins/engine/components/index.js'
 import { type ComponentCollectionViewModel } from '~/src/server/plugins/engine/components/types.js'
@@ -46,7 +49,7 @@ export class ComponentCollection {
   }
 
   getFormSchemaKeys() {
-    const keys = {}
+    const keys: ComponentSchemaNested = {}
 
     this.formItems.forEach((item) => {
       Object.assign(keys, item.getFormSchemaKeys())
@@ -56,7 +59,7 @@ export class ComponentCollection {
   }
 
   getStateSchemaKeys() {
-    const keys = {}
+    const keys: ComponentSchemaNested = {}
 
     this.formItems.forEach((item) => {
       Object.assign(keys, item.getStateSchemaKeys())

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -1,8 +1,9 @@
 import { type ComponentDef } from '@defra/forms-model'
-import joi, { type Schema as JoiSchema } from 'joi'
+import joi from 'joi'
 
 import {
   type ComponentBase,
+  type ComponentSchema,
   type ComponentSchemaNested
 } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { type FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
@@ -19,8 +20,8 @@ import {
 export class ComponentCollection {
   items: (ComponentBase | ComponentCollection | FormComponent)[]
   formItems: FormComponent /* | ConditionalFormComponent */[]
-  formSchema: JoiSchema
-  stateSchema: JoiSchema
+  formSchema: ComponentSchema
+  stateSchema: ComponentSchema
 
   constructor(componentDefs: ComponentDef[] = [], model: FormModel) {
     const components = componentDefs.map((def) => {

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -7,7 +7,10 @@ import { parseISO, format } from 'date-fns'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
-import * as helpers from '~/src/server/plugins/engine/components/helpers.js'
+import {
+  buildStateSchema,
+  getCustomDateValidator
+} from '~/src/server/plugins/engine/components/helpers.js'
 import { type DataType } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
@@ -70,7 +73,7 @@ export class DatePartsField extends FormComponent {
       model
     )
 
-    this.stateSchema = helpers.buildStateSchema('date', this)
+    this.stateSchema = buildStateSchema('date', this)
   }
 
   getFormSchemaKeys() {
@@ -83,7 +86,7 @@ export class DatePartsField extends FormComponent {
     let schema = this.stateSchema
 
     schema = schema.custom(
-      helpers.getCustomDateValidator(maxDaysInPast, maxDaysInFuture)
+      getCustomDateValidator(maxDaysInPast, maxDaysInFuture)
     )
 
     return { [this.name]: schema }

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -1,6 +1,6 @@
 import {
   ComponentType,
-  type InputFieldsComponentsDef
+  type DatePartsFieldFieldComponent
 } from '@defra/forms-model'
 import { parseISO, format } from 'date-fns'
 
@@ -20,15 +20,17 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class DatePartsField extends FormComponent {
+  options: DatePartsFieldFieldComponent['options']
+  schema: DatePartsFieldFieldComponent['schema']
   children: ComponentCollection
-  dataType = 'date' as DataType
+  dataType: DataType = 'date'
 
-  constructor(def: InputFieldsComponentsDef, model: FormModel) {
+  constructor(def: DatePartsFieldFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { name, options } = this
+    const { name, options, schema } = def
 
-    const isRequired = !('required' in options && options.required === false)
+    const isRequired = !('required' in options) || options.required !== false
     const hideOptional = 'optionalText' in options && options.optionalText
 
     this.children = new ComponentCollection(
@@ -73,6 +75,8 @@ export class DatePartsField extends FormComponent {
       model
     )
 
+    this.options = options
+    this.schema = schema
     this.stateSchema = buildStateSchema('date', this)
   }
 

--- a/src/server/plugins/engine/components/Details.ts
+++ b/src/server/plugins/engine/components/Details.ts
@@ -1,10 +1,25 @@
+import { type DetailsComponent } from '@defra/forms-model'
+
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
+import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type FormPayload,
   type FormSubmissionErrors
 } from '~/src/server/plugins/engine/types.js'
 
 export class Details extends ComponentBase {
+  options: DetailsComponent['options']
+  schema: DetailsComponent['schema']
+
+  constructor(def: DetailsComponent, model: FormModel) {
+    super(def, model)
+
+    const { schema, options } = def
+
+    this.options = options
+    this.schema = schema
+  }
+
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {
     const { options } = this
 

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -1,4 +1,4 @@
-import { type InputFieldsComponentsDef } from '@defra/forms-model'
+import { type EmailAddressFieldComponent } from '@defra/forms-model'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -8,9 +8,16 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class EmailAddressField extends FormComponent {
-  constructor(def: InputFieldsComponentsDef, model: FormModel) {
+  options: EmailAddressFieldComponent['options']
+  schema: EmailAddressFieldComponent['schema']
+
+  constructor(def: EmailAddressFieldComponent, model: FormModel) {
     super(def, model)
-    this.schema.email = true
+
+    const { schema, options } = def
+
+    this.options = options
+    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -1,10 +1,6 @@
 import { type InputFieldsComponentsDef } from '@defra/forms-model'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
-import {
-  getStateSchemaKeys,
-  getFormSchemaKeys
-} from '~/src/server/plugins/engine/components/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
@@ -15,14 +11,6 @@ export class EmailAddressField extends FormComponent {
   constructor(def: InputFieldsComponentsDef, model: FormModel) {
     super(def, model)
     this.schema.email = true
-  }
-
-  getFormSchemaKeys() {
-    return getFormSchemaKeys(this.name, 'string', this)
-  }
-
-  getStateSchemaKeys() {
-    return getStateSchemaKeys(this.name, 'string', this)
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -1,6 +1,7 @@
-import joi, { type Schema } from 'joi'
-
-import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
+import {
+  ComponentBase,
+  type ComponentSchemaKeys
+} from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
 import {
   type FormPayload,
@@ -87,12 +88,12 @@ export class FormComponent extends ComponentBase {
     }
   }
 
-  getFormSchemaKeys() {
-    return { [this.name]: joi.any() }
+  getFormSchemaKeys(): ComponentSchemaKeys {
+    return { [this.name]: this.formSchema }
   }
 
-  getStateSchemaKeys(): Record<string, Schema> {
-    return { [this.name]: joi.any() }
+  getStateSchemaKeys(): ComponentSchemaKeys {
+    return { [this.name]: this.formSchema }
   }
 
   getDisplayStringFromState(state) {

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -51,7 +51,7 @@ export class FormComponent extends ComponentBase {
 
     const viewModel = super.getViewModel(payload, errors)
 
-    const isRequired = !('required' in options && options.required === false)
+    const isRequired = !('required' in options) || options.required !== false
     const hideOptional = 'optionalText' in options && options.optionalText
     const label = `${title}${!isRequired && !hideOptional ? optionalText : ''}`
 

--- a/src/server/plugins/engine/components/Html.ts
+++ b/src/server/plugins/engine/components/Html.ts
@@ -1,10 +1,25 @@
+import { type HtmlComponent } from '@defra/forms-model'
+
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
+import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type FormPayload,
   type FormSubmissionErrors
 } from '~/src/server/plugins/engine/types.js'
 
 export class Html extends ComponentBase {
+  options: HtmlComponent['options']
+  schema: HtmlComponent['schema']
+
+  constructor(def: HtmlComponent, model: FormModel) {
+    super(def, model)
+
+    const { schema, options } = def
+
+    this.options = options
+    this.schema = schema
+  }
+
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {
     const { options } = this
 

--- a/src/server/plugins/engine/components/InsetText.ts
+++ b/src/server/plugins/engine/components/InsetText.ts
@@ -1,11 +1,26 @@
+import { type InsetTextComponent } from '@defra/forms-model'
+
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { type ViewModel } from '~/src/server/plugins/engine/components/types.js'
+import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type FormPayload,
   type FormSubmissionErrors
 } from '~/src/server/plugins/engine/types.js'
 
 export class InsetText extends ComponentBase {
+  options: InsetTextComponent['options']
+  schema: InsetTextComponent['schema']
+
+  constructor(def: InsetTextComponent, model: FormModel) {
+    super(def, model)
+
+    const { schema, options } = def
+
+    this.options = options
+    this.schema = schema
+  }
+
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors): ViewModel {
     return {
       ...super.getViewModel(payload, errors),

--- a/src/server/plugins/engine/components/List.ts
+++ b/src/server/plugins/engine/components/List.ts
@@ -1,7 +1,7 @@
 import {
-  type ListComponentsDef,
   type Item,
-  type List as ListType
+  type List as ListType,
+  type ListComponent
 } from '@defra/forms-model'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
@@ -12,14 +12,22 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class List extends ComponentBase {
+  schema: ListComponent['schema']
+  options: ListComponent['options']
   list?: ListType
+
   get items(): Item[] {
     return this.list?.items ?? []
   }
 
-  constructor(def: ListComponentsDef, model: FormModel) {
+  constructor(def: ListComponent, model: FormModel) {
     super(def, model)
-    this.list = model.getList(def.list)
+
+    const { list, options, schema } = def
+
+    this.list = model.getList(list)
+    this.options = options
+    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -35,22 +35,22 @@ export class ListFormComponent extends FormComponent {
     this.listType = this.list?.type ?? 'string'
     this.options = def.options
 
-    let schema = joi[this.listType]()
+    let formSchema = joi[this.listType]()
 
     /**
      * Only allow a user to answer with values that have been defined in the list
      */
     if (def.options.required === false) {
       // null or empty string is valid for optional fields
-      schema = schema.empty(null).valid(...this.values, '')
+      formSchema = formSchema.empty(null).valid(...this.values, '')
     } else {
-      schema = schema.valid(...this.values).required()
+      formSchema = formSchema.valid(...this.values).required()
     }
 
-    schema = schema.label(def.title.toLowerCase())
+    formSchema = formSchema.label(def.title.toLowerCase())
 
-    this.formSchema = schema
-    this.stateSchema = schema
+    this.formSchema = formSchema
+    this.stateSchema = formSchema
   }
 
   getDisplayStringFromState(state: FormSubmissionState): string | string[] {

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -3,7 +3,7 @@ import {
   type List,
   type Item
 } from '@defra/forms-model'
-import joi, { type Schema } from 'joi'
+import joi from 'joi'
 
 import { type FormModel } from '~/src/server/plugins/engine/components/../models/index.js'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
@@ -15,12 +15,11 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class ListFormComponent extends FormComponent {
-  list?: List
-  listType = 'string'
-  formSchema
-  stateSchema
   options: ListComponentsDef['options']
-  dataType = 'list' as DataType
+
+  list?: List
+  listType: List['type']
+  dataType: DataType = 'list'
 
   get items(): Item[] {
     return this.list?.items ?? []
@@ -52,14 +51,6 @@ export class ListFormComponent extends FormComponent {
 
     this.formSchema = schema
     this.stateSchema = schema
-  }
-
-  getFormSchemaKeys() {
-    return { [this.name]: this.formSchema as Schema }
-  }
-
-  getStateSchemaKeys() {
-    return { [this.name]: this.stateSchema as Schema }
   }
 
   getDisplayStringFromState(state: FormSubmissionState): string | string[] {

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -1,7 +1,4 @@
-import {
-  ComponentType,
-  type InputFieldsComponentsDef
-} from '@defra/forms-model'
+import { ComponentType, type MonthYearFieldComponent } from '@defra/forms-model'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
@@ -15,39 +12,46 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class MonthYearField extends FormComponent {
+  options: MonthYearFieldComponent['options']
+  schema: MonthYearFieldComponent['schema']
   children: ComponentCollection
-  dataType = 'monthYear' as DataType
+  dataType: DataType = 'monthYear'
 
-  constructor(def: InputFieldsComponentsDef, model: FormModel) {
+  constructor(def: MonthYearFieldComponent, model: FormModel) {
     super(def, model)
-    const options = this.options
+
+    const { name, options, schema } = def
+    const isRequired = options.required !== false
 
     this.children = new ComponentCollection(
       [
         {
           type: ComponentType.NumberField,
-          name: `${this.name}__month`,
+          name: `${name}__month`,
           title: 'Month',
           schema: { min: 1, max: 12 },
           options: {
-            required: options.required,
+            required: isRequired,
             classes: 'govuk-input--width-2',
             customValidationMessage: '{{label}} must be between 1 and 12'
           }
         },
         {
           type: ComponentType.NumberField,
-          name: `${this.name}__year`,
+          name: `${name}__year`,
           title: 'Year',
           schema: { min: 1000, max: 3000 },
           options: {
-            required: options.required,
+            required: isRequired,
             classes: 'govuk-input--width-4'
           }
         }
       ],
       model
     )
+
+    this.options = options
+    this.schema = schema
   }
 
   getFormSchemaKeys() {

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -2,7 +2,6 @@ import {
   ComponentType,
   type InputFieldsComponentsDef
 } from '@defra/forms-model'
-import { type Schema } from 'joi'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
@@ -57,7 +56,7 @@ export class MonthYearField extends FormComponent {
 
   getStateSchemaKeys() {
     return {
-      [this.name]: this.children.getStateSchemaKeys() as Schema
+      [this.name]: this.children.getStateSchemaKeys()
     }
   }
 

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -26,13 +26,12 @@ export class MultilineTextField extends FormComponent {
 
   constructor(def: MultilineTextFieldComponent, model: FormModel) {
     super(def, model)
-    this.options = def.options
-    this.schema = def.schema
 
-    const { maxWords, customValidationMessage } = def.options
-    const isRequired = def.options.required ?? true
+    const { schema, options, title } = def
 
-    let formSchema = Joi.string().label(def.title.toLowerCase())
+    const isRequired = options.required !== false
+
+    let formSchema = Joi.string().label(title.toLowerCase())
 
     if (isRequired) {
       formSchema = formSchema.required()
@@ -42,32 +41,35 @@ export class MultilineTextField extends FormComponent {
 
     formSchema = formSchema.ruleset
 
-    if (def.schema.max) {
-      formSchema = formSchema.max(def.schema.max)
+    if (schema.max) {
+      formSchema = formSchema.max(schema.max)
       this.isCharacterOrWordCount = true
     }
 
-    if (def.schema.min) {
-      formSchema = formSchema.min(def.schema.min)
+    if (schema.min) {
+      formSchema = formSchema.min(schema.min)
     }
 
-    if (maxWords ?? false) {
+    if (options.maxWords ?? false) {
       formSchema = formSchema.custom((value, helpers) => {
-        if (inputIsOverWordCount(value, maxWords)) {
+        if (inputIsOverWordCount(value, options.maxWords)) {
           helpers.error('string.maxWords')
         }
         return value
       }, 'max words validation')
+
       this.isCharacterOrWordCount = true
     }
 
-    if (customValidationMessage) {
+    if (options.customValidationMessage) {
       formSchema = formSchema.rule({
-        message: customValidationMessage
+        message: options.customValidationMessage
       })
     }
 
     this.formSchema = formSchema
+    this.options = options
+    this.schema = schema
   }
 
   getViewModel(

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -28,29 +28,31 @@ export class MultilineTextField extends FormComponent {
     super(def, model)
     this.options = def.options
     this.schema = def.schema
-    this.formSchema = Joi.string()
-    this.formSchema = this.formSchema.label(def.title.toLowerCase())
+
     const { maxWords, customValidationMessage } = def.options
     const isRequired = def.options.required ?? true
 
+    let formSchema = Joi.string().label(def.title.toLowerCase())
+
     if (isRequired) {
-      this.formSchema = this.formSchema.required()
+      formSchema = formSchema.required()
     } else {
-      this.formSchema = this.formSchema.allow('').allow(null)
+      formSchema = formSchema.allow('').allow(null)
     }
-    this.formSchema = this.formSchema.ruleset
+
+    formSchema = formSchema.ruleset
 
     if (def.schema.max) {
-      this.formSchema = this.formSchema.max(def.schema.max)
+      formSchema = formSchema.max(def.schema.max)
       this.isCharacterOrWordCount = true
     }
 
     if (def.schema.min) {
-      this.formSchema = this.formSchema.min(def.schema.min)
+      formSchema = formSchema.min(def.schema.min)
     }
 
     if (maxWords ?? false) {
-      this.formSchema = this.formSchema.custom((value, helpers) => {
+      formSchema = formSchema.custom((value, helpers) => {
         if (inputIsOverWordCount(value, maxWords)) {
           helpers.error('string.maxWords')
         }
@@ -60,10 +62,12 @@ export class MultilineTextField extends FormComponent {
     }
 
     if (customValidationMessage) {
-      this.formSchema = this.formSchema.rule({
+      formSchema = formSchema.rule({
         message: customValidationMessage
       })
     }
+
+    this.formSchema = formSchema
   }
 
   getViewModel(

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -1,5 +1,5 @@
 import { type MultilineTextFieldComponent } from '@defra/forms-model'
-import Joi, { type Schema, type StringSchema } from 'joi'
+import Joi from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type MultilineTextFieldViewModel } from '~/src/server/plugins/engine/components/types.js'
@@ -19,7 +19,6 @@ function inputIsOverWordCount(input: string, maxWords: number) {
 }
 
 export class MultilineTextField extends FormComponent {
-  formSchema: StringSchema
   options: MultilineTextFieldComponent['options']
   schema: MultilineTextFieldComponent['schema']
   customValidationMessage?: string
@@ -65,14 +64,6 @@ export class MultilineTextField extends FormComponent {
         message: customValidationMessage
       })
     }
-  }
-
-  getFormSchemaKeys() {
-    return { [this.name]: this.formSchema as Schema }
-  }
-
-  getStateSchemaKeys() {
-    return { [this.name]: this.formSchema as Schema }
   }
 
   getViewModel(

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -21,32 +21,38 @@ export class NumberField extends FormComponent {
     this.schemaOptions = def.schema
     this.options = def.options
     const { min, max } = def.schema
-    let schema = joi.number()
+    let formSchema = joi.number()
 
-    schema = schema.label(def.title.toLowerCase())
+    formSchema = formSchema.label(def.title.toLowerCase())
 
     if (def.schema.min && def.schema.max) {
-      schema = schema.$
+      formSchema = formSchema.$
     }
     if (def.schema.min ?? false) {
-      schema = schema.min(min)
+      formSchema = formSchema.min(min)
     }
 
     if (def.schema.max ?? false) {
-      schema = schema.max(max)
+      formSchema = formSchema.max(max)
     }
 
     if (def.options.customValidationMessage) {
-      schema = schema.rule({ message: def.options.customValidationMessage })
+      formSchema = formSchema.rule({
+        message: def.options.customValidationMessage
+      })
     }
 
     if (def.options.required === false) {
       const optionalSchema = joi
-        .alternatives()
-        .try(joi.string().allow(null).allow('').default('').optional(), schema)
-      this.schema = optionalSchema
+        .alternatives<string | number>()
+        .try(
+          joi.string().allow(null).allow('').default('').optional(),
+          formSchema
+        )
+
+      this.formSchema = optionalSchema
     } else {
-      this.schema = schema
+      this.formSchema = formSchema
     }
   }
 

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -1,7 +1,4 @@
-import {
-  type ComponentDef,
-  type NumberFieldComponent
-} from '@defra/forms-model'
+import { type NumberFieldComponent } from '@defra/forms-model'
 import joi from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
@@ -13,36 +10,34 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class NumberField extends FormComponent {
-  schemaOptions: NumberFieldComponent['schema']
   options: NumberFieldComponent['options']
+  schema: NumberFieldComponent['schema']
 
-  constructor(def: ComponentDef, model: FormModel) {
+  constructor(def: NumberFieldComponent, model: FormModel) {
     super(def, model)
-    this.schemaOptions = def.schema
-    this.options = def.options
-    const { min, max } = def.schema
-    let formSchema = joi.number()
 
-    formSchema = formSchema.label(def.title.toLowerCase())
+    const { options, schema, title } = def
 
-    if (def.schema.min && def.schema.max) {
+    let formSchema = joi.number().label(title.toLowerCase())
+
+    if (schema.min && schema.max) {
       formSchema = formSchema.$
     }
-    if (def.schema.min ?? false) {
-      formSchema = formSchema.min(min)
+    if (schema.min ?? false) {
+      formSchema = formSchema.min(schema.min)
     }
 
-    if (def.schema.max ?? false) {
-      formSchema = formSchema.max(max)
+    if (schema.max ?? false) {
+      formSchema = formSchema.max(schema.max)
     }
 
-    if (def.options.customValidationMessage) {
+    if (options.customValidationMessage) {
       formSchema = formSchema.rule({
-        message: def.options.customValidationMessage
+        message: options.customValidationMessage
       })
     }
 
-    if (def.options.required === false) {
+    if (options.required === false) {
       const optionalSchema = joi
         .alternatives<string | number>()
         .try(
@@ -54,6 +49,9 @@ export class NumberField extends FormComponent {
     } else {
       this.formSchema = formSchema
     }
+
+    this.options = options
+    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {
@@ -71,7 +69,7 @@ export class NumberField extends FormComponent {
       ...(options.suffix && viewModelSuffix)
     }
 
-    if (this.schemaOptions.precision) {
+    if (schema.precision) {
       viewModel.attributes.step = '0.' + '1'.padStart(schema.precision, '0')
     }
 

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -2,7 +2,7 @@ import {
   type ComponentDef,
   type NumberFieldComponent
 } from '@defra/forms-model'
-import joi, { type Schema } from 'joi'
+import joi from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -48,14 +48,6 @@ export class NumberField extends FormComponent {
     } else {
       this.schema = schema
     }
-  }
-
-  getFormSchemaKeys() {
-    return { [this.name]: this.schema as Schema }
-  }
-
-  getStateSchemaKeys() {
-    return { [this.name]: this.schema as Schema }
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/RadiosField.ts
+++ b/src/server/plugins/engine/components/RadiosField.ts
@@ -1,9 +1,18 @@
-import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
+import { type RadiosFieldComponent } from '@defra/forms-model'
 
-/**
- * @description sorry about the empty class...
- * Exported Components must follow the naming convention implemented in @defra/forms-model/components ComponentType.
- * In the Form JSON, components have a type property which is the name of the components, e.g. DatePartsField.
- * Components are loaded in the ComponentsCollection constructor.
- */
-export class RadiosField extends SelectionControlField {}
+import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
+import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+
+export class RadiosField extends SelectionControlField {
+  options: RadiosFieldComponent['options']
+  schema: RadiosFieldComponent['schema']
+
+  constructor(def: RadiosFieldComponent, model: FormModel) {
+    super(def, model)
+
+    const { schema, options } = def
+
+    this.options = options
+    this.schema = schema
+  }
+}

--- a/src/server/plugins/engine/components/SelectField.ts
+++ b/src/server/plugins/engine/components/SelectField.ts
@@ -1,14 +1,36 @@
-import { type SelectFieldComponent } from '@defra/forms-model'
+import {
+  type AutocompleteFieldComponent,
+  type SelectFieldComponent
+} from '@defra/forms-model'
 
 import { ListFormComponent } from '~/src/server/plugins/engine/components/ListFormComponent.js'
 import { type DataType } from '~/src/server/plugins/engine/components/types.js'
+import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type FormPayload,
   type FormSubmissionErrors
 } from '~/src/server/plugins/engine/types.js'
 
 export class SelectField extends ListFormComponent {
-  dataType = 'list' as DataType
+  options:
+    | SelectFieldComponent['options']
+    | AutocompleteFieldComponent['options']
+
+  schema: SelectFieldComponent['schema']
+  dataType: DataType = 'list'
+
+  constructor(
+    def: SelectFieldComponent | AutocompleteFieldComponent,
+    model: FormModel
+  ) {
+    super(def, model)
+
+    const { schema, options } = def
+
+    this.options = options
+    this.schema = schema
+  }
+
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {
     const options: SelectFieldComponent['options'] = this.options
     const viewModel = super.getViewModel(payload, errors)

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -17,25 +17,25 @@ export class TelephoneNumberField extends FormComponent {
 
     const { options = {}, schema = {} } = def
     const pattern = schema.regex ? new RegExp(schema.regex) : PATTERN
-    let componentSchema = joi.string()
+    let formSchema = joi.string()
 
     if (options.required === false) {
-      componentSchema = componentSchema.allow('').allow(null)
+      formSchema = formSchema.allow('').allow(null)
     }
-    componentSchema = componentSchema
+    formSchema = formSchema
       .pattern(pattern)
       .message(def.options.customValidationMessage ?? DEFAULT_MESSAGE)
       .label(def.title.toLowerCase())
 
     if (schema.max) {
-      componentSchema = componentSchema.max(schema.max)
+      formSchema = formSchema.max(schema.max)
     }
 
     if (schema.min) {
-      componentSchema = componentSchema.min(schema.min)
+      formSchema = formSchema.min(schema.min)
     }
 
-    this.schema = componentSchema
+    this.formSchema = formSchema
 
     addClassOptionIfNone(this.options, 'govuk-input--width-20')
   }

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -1,5 +1,5 @@
 import { type TelephoneNumberFieldComponent } from '@defra/forms-model'
-import joi, { type Schema } from 'joi'
+import joi from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { addClassOptionIfNone } from '~/src/server/plugins/engine/components/helpers.js'
@@ -38,14 +38,6 @@ export class TelephoneNumberField extends FormComponent {
     this.schema = componentSchema
 
     addClassOptionIfNone(this.options, 'govuk-input--width-20')
-  }
-
-  getFormSchemaKeys() {
-    return { [this.name]: this.schema as Schema }
-  }
-
-  getStateSchemaKeys() {
-    return { [this.name]: this.schema as Schema }
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -11,21 +11,27 @@ import {
 
 const PATTERN = /^[0-9\\\s+()-]*$/
 const DEFAULT_MESSAGE = 'Enter a telephone number in the correct format'
+
 export class TelephoneNumberField extends FormComponent {
+  options: TelephoneNumberFieldComponent['options']
+  schema: TelephoneNumberFieldComponent['schema']
+
   constructor(def: TelephoneNumberFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { options = {}, schema = {} } = def
+    const { schema, options, title } = def
+
     const pattern = schema.regex ? new RegExp(schema.regex) : PATTERN
     let formSchema = joi.string()
 
     if (options.required === false) {
       formSchema = formSchema.allow('').allow(null)
     }
+
     formSchema = formSchema
       .pattern(pattern)
-      .message(def.options.customValidationMessage ?? DEFAULT_MESSAGE)
-      .label(def.title.toLowerCase())
+      .message(options.customValidationMessage ?? DEFAULT_MESSAGE)
+      .label(title.toLowerCase())
 
     if (schema.max) {
       formSchema = formSchema.max(schema.max)
@@ -35,9 +41,11 @@ export class TelephoneNumberField extends FormComponent {
       formSchema = formSchema.min(schema.min)
     }
 
-    this.formSchema = formSchema
+    addClassOptionIfNone(options, 'govuk-input--width-20')
 
-    addClassOptionIfNone(this.options, 'govuk-input--width-20')
+    this.formSchema = formSchema
+    this.options = options
+    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -9,12 +9,13 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class TextField extends FormComponent {
+  options: TextFieldComponent['options']
+  schema: TextFieldComponent['schema']
+
   constructor(def: TextFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { options, schema = {} } = def
-    this.options = options
-    this.schema = schema
+    const { options, schema, title } = def
 
     let formSchema = joi.string().trim().required()
     if (options.required === false) {
@@ -43,6 +44,8 @@ export class TextField extends FormComponent {
     }
 
     this.formSchema = formSchema
+    this.options = options
+    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -21,9 +21,7 @@ export class TextField extends FormComponent {
       formSchema = formSchema.optional().allow('').allow(null)
     }
 
-    formSchema = formSchema.label(
-      (def.title.en ?? def.title ?? def.name).toLowerCase()
-    )
+    formSchema = formSchema.label(title.toLowerCase())
 
     if (schema.max) {
       formSchema = formSchema.max(schema.max)

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -1,5 +1,5 @@
 import { type TextFieldComponent } from '@defra/forms-model'
-import joi, { type Schema } from 'joi'
+import joi from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -9,9 +9,6 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class TextField extends FormComponent {
-  formSchema
-  stateSchema
-
   constructor(def: TextFieldComponent, model: FormModel) {
     super(def, model)
 
@@ -48,14 +45,6 @@ export class TextField extends FormComponent {
     }
 
     this.formSchema = componentSchema
-  }
-
-  getFormSchemaKeys() {
-    return { [this.name]: this.formSchema as Schema }
-  }
-
-  getStateSchemaKeys() {
-    return { [this.name]: this.formSchema as Schema }
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -16,35 +16,35 @@ export class TextField extends FormComponent {
     this.options = options
     this.schema = schema
 
-    let componentSchema = joi.string().trim().required()
+    let formSchema = joi.string().trim().required()
     if (options.required === false) {
-      componentSchema = componentSchema.optional().allow('').allow(null)
+      formSchema = formSchema.optional().allow('').allow(null)
     }
 
-    componentSchema = componentSchema.label(
+    formSchema = formSchema.label(
       (def.title.en ?? def.title ?? def.name).toLowerCase()
     )
 
     if (schema.max) {
-      componentSchema = componentSchema.max(schema.max)
+      formSchema = formSchema.max(schema.max)
     }
 
     if (schema.min) {
-      componentSchema = componentSchema.min(schema.min)
+      formSchema = formSchema.min(schema.min)
     }
 
     if (schema.regex) {
       const pattern = new RegExp(schema.regex)
-      componentSchema = componentSchema.pattern(pattern)
+      formSchema = formSchema.pattern(pattern)
     }
 
     if (options.customValidationMessage) {
-      componentSchema = componentSchema.messages({
+      formSchema = formSchema.messages({
         any: options.customValidationMessage
       })
     }
 
-    this.formSchema = componentSchema
+    this.formSchema = formSchema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -1,7 +1,7 @@
 import {
   ComponentType,
   type ComponentDef,
-  type InputFieldsComponentsDef
+  type UkAddressFieldComponent
 } from '@defra/forms-model'
 import joi from 'joi'
 
@@ -18,16 +18,17 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class UkAddressField extends FormComponent {
+  options: UkAddressFieldComponent['options']
+  schema: UkAddressFieldComponent['schema']
   formChildren: ComponentCollection
   stateChildren: ComponentCollection
 
-  constructor(def: InputFieldsComponentsDef, model: FormModel) {
+  constructor(def: UkAddressFieldComponent, model: FormModel) {
     super(def, model)
-    const { name, options } = this
 
-    const stateSchema = buildStateSchema('date', this)
+    const { name, options, schema } = def
 
-    const isRequired = !('required' in options && options.required === false)
+    const isRequired = !('required' in options) || options.required !== false
     const hideOptional = 'optionalText' in options && options.optionalText
 
     const childrenList = [
@@ -89,9 +90,11 @@ export class UkAddressField extends FormComponent {
 
     const formChildren = new ComponentCollection(childrenList, model)
 
+    this.options = options
+    this.schema = schema
     this.formChildren = formChildren
     this.stateChildren = stateChildren
-    this.stateSchema = stateSchema
+    this.stateSchema = buildStateSchema('date', this)
   }
 
   getFormSchemaKeys() {

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -7,7 +7,7 @@ import joi from 'joi'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
-import * as helpers from '~/src/server/plugins/engine/components/helpers.js'
+import { buildStateSchema } from '~/src/server/plugins/engine/components/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { type PageControllerBase } from '~/src/server/plugins/engine/pageControllers/index.js'
 import {
@@ -25,7 +25,7 @@ export class UkAddressField extends FormComponent {
     super(def, model)
     const { name, options } = this
 
-    const stateSchema = helpers.buildStateSchema('date', this)
+    const stateSchema = buildStateSchema('date', this)
 
     const isRequired = !('required' in options && options.required === false)
     const hideOptional = 'optionalText' in options && options.optionalText

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -50,6 +50,9 @@ export class YesNoField extends ListFormComponent {
 
     const { options, schema } = def
 
+    this.options = options
+    this.schema = schema
+
     this.formSchema = buildFormSchema(
       'boolean',
       this,
@@ -62,9 +65,6 @@ export class YesNoField extends ListFormComponent {
     )
 
     addClassOptionIfNone(options, 'govuk-radios--inline')
-
-    this.options = options
-    this.schema = schema
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -1,4 +1,4 @@
-import { type ListComponentsDef, type List } from '@defra/forms-model'
+import { type List, type YesNoFieldComponent } from '@defra/forms-model'
 
 import { ListFormComponent } from '~/src/server/plugins/engine/components/ListFormComponent.js'
 import {
@@ -18,6 +18,9 @@ import {
  * YesNoField is a radiosField with predefined values.
  */
 export class YesNoField extends ListFormComponent {
+  options: YesNoFieldComponent['options']
+  schema: YesNoFieldComponent['schema']
+
   list?: List = {
     name: '__yesNo',
     title: 'Yes/No',
@@ -42,10 +45,10 @@ export class YesNoField extends ListFormComponent {
     return [true, false]
   }
 
-  constructor(def: ListComponentsDef, model: FormModel) {
+  constructor(def: YesNoFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { options } = this
+    const { options, schema } = def
 
     this.formSchema = buildFormSchema(
       'boolean',
@@ -58,7 +61,10 @@ export class YesNoField extends ListFormComponent {
       false
     )
 
-    addClassOptionIfNone(this.options, 'govuk-radios--inline')
+    addClassOptionIfNone(options, 'govuk-radios--inline')
+
+    this.options = options
+    this.schema = schema
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -1,5 +1,4 @@
 import { type ListComponentsDef, type List } from '@defra/forms-model'
-import joi from 'joi'
 
 import { ListFormComponent } from '~/src/server/plugins/engine/components/ListFormComponent.js'
 import {
@@ -35,7 +34,6 @@ export class YesNoField extends ListFormComponent {
     ]
   }
 
-  itemsSchema = joi.boolean()
   get items() {
     return this.list?.items ?? []
   }

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -1,9 +1,12 @@
 import { type ListComponentsDef, type List } from '@defra/forms-model'
-import joi, { type Schema } from 'joi'
+import joi from 'joi'
 
 import { ListFormComponent } from '~/src/server/plugins/engine/components/ListFormComponent.js'
-import * as helpers from '~/src/server/plugins/engine/components/helpers.js'
-import { addClassOptionIfNone } from '~/src/server/plugins/engine/components/helpers.js'
+import {
+  addClassOptionIfNone,
+  buildFormSchema,
+  buildStateSchema
+} from '~/src/server/plugins/engine/components/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
@@ -46,22 +49,18 @@ export class YesNoField extends ListFormComponent {
 
     const { options } = this
 
-    this.formSchema = helpers
-      .buildFormSchema('boolean', this, options.required !== false)
-      .valid(true, false)
-    this.stateSchema = helpers
-      .buildStateSchema(this.list?.type, this)
-      .valid(true, false)
+    this.formSchema = buildFormSchema(
+      'boolean',
+      this,
+      options.required !== false
+    ).valid(true, false)
+
+    this.stateSchema = buildStateSchema(this.list?.type, this).valid(
+      true,
+      false
+    )
 
     addClassOptionIfNone(this.options, 'govuk-radios--inline')
-  }
-
-  getFormSchemaKeys() {
-    return { [this.name]: this.formSchema as Schema }
-  }
-
-  getStateSchemaKeys() {
-    return { [this.name]: this.stateSchema as Schema }
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/helpers.ts
+++ b/src/server/plugins/engine/components/helpers.ts
@@ -27,11 +27,7 @@ export function buildFormSchema(schemaType, component, isRequired = true) {
   }
 
   if (component.title) {
-    schema = schema.label(
-      typeof component.title === 'string'
-        ? component.title.toLowerCase()
-        : component.title.en.toLowerCase()
-    )
+    schema = schema.label(component.title.toLowerCase())
   }
 
   if (component.options.required === false) {
@@ -49,11 +45,7 @@ export function buildStateSchema(schemaType, component) {
   let schema = buildSchema(schemaType, component.schema)
 
   if (component.title) {
-    schema = schema.label(
-      typeof component.title === 'string'
-        ? component.title.toLowerCase()
-        : component.title.en.toLowerCase()
-    )
+    schema = schema.label(component.title.toLowerCase())
   }
 
   if (component.options.required !== false) {

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -155,7 +155,7 @@ export class FormModel {
             (page) => page.pageDef.repeatField
           )
 
-          let sectionSchema: joi.ObjectSchema | joi.ArraySchema = joi
+          let sectionSchema: joi.ObjectSchema | joi.ArraySchema<string> = joi
             .object()
             .required()
 
@@ -164,7 +164,7 @@ export class FormModel {
           })
 
           if (isRepeatable) {
-            sectionSchema = joi.array().items(sectionSchema)
+            sectionSchema = joi.array<string>().items(sectionSchema)
           }
 
           schema = schema.append({

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -311,16 +311,9 @@ function getFormSubmissionData(relevantPages, details, model) {
       return fields
     })
 
-    let pageTitle = page.title
-
-    if (pageTitle) {
-      pageTitle = page.title.en ?? page.title
-    }
-
     return {
       category: page.section?.name,
-      question:
-        pageTitle ?? page.components.formItems.map((item) => item.title),
+      question: page.title,
       fields,
       index
     }

--- a/test/cases/server/plugins/engine/ListFormComponent.test.ts
+++ b/test/cases/server/plugins/engine/ListFormComponent.test.ts
@@ -58,7 +58,11 @@ describe('ListFormComponent', () => {
     const component = new ListFormComponent(componentDefinition, formModel)
 
     it('is required by default', () => {
-      expect(component.formSchema.describe().flags.presence).toBe('required')
+      expect(component.formSchema.describe().flags).toEqual(
+        expect.objectContaining({
+          presence: 'required'
+        })
+      )
     })
 
     it('allows the items defined in the List object with the correct type', () => {
@@ -78,8 +82,10 @@ describe('ListFormComponent', () => {
         },
         formModel
       )
-      expect(component.formSchema.describe().flags.presence).not.toBe(
-        'required'
+      expect(component.formSchema.describe().flags).not.toEqual(
+        expect.objectContaining({
+          presence: 'required'
+        })
       )
     })
 

--- a/test/cases/server/plugins/engine/MonthYearField.test.ts
+++ b/test/cases/server/plugins/engine/MonthYearField.test.ts
@@ -1,5 +1,5 @@
 import { type ComponentDef, ComponentType } from '@defra/forms-model'
-import joi from 'joi'
+import joi, { type ObjectSchema } from 'joi'
 
 import { MonthYearField } from '~/src/server/plugins/engine/components/index.js'
 import { messages } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
@@ -7,7 +7,7 @@ import { messages } from '~/src/server/plugins/engine/pageControllers/validation
 /**
  * This replicates {@link PageControllerBase.validate}
  */
-const validate = (schema, value) => {
+const validate = (schema: ObjectSchema, value: object) => {
   return schema.validate(value, { messages })
 }
 
@@ -36,14 +36,14 @@ describe('Month Year Field', () => {
       validate(schema, {
         myComponent__year: 2000,
         myComponent__month: 0
-      }).error.message
+      }).error?.message
     ).toContain('must be between 1 and 12')
 
     expect(
       validate(schema, {
         myComponent__year: 1,
         myComponent__month: 12
-      }).error.message
+      }).error?.message
     ).toContain('must be 1000 or higher')
 
     expect(

--- a/test/cases/server/plugins/engine/MultilineTextField.test.ts
+++ b/test/cases/server/plugins/engine/MultilineTextField.test.ts
@@ -22,7 +22,7 @@ describe('Multiline text field', () => {
     const { formSchema } = multilineTextField
     expect(formSchema.validate('a').error).toBeUndefined()
 
-    expect(formSchema.validate('too many').error.message).toBe(
+    expect(formSchema.validate('too many').error?.message).toBe(
       'This is a custom error'
     )
   })
@@ -44,15 +44,15 @@ describe('Multiline text field', () => {
 
     expect(formSchema.validate('yolk', validationOptions).error).toBeUndefined()
 
-    expect(formSchema.validate('egg', validationOptions).error.message).toBe(
+    expect(formSchema.validate('egg', validationOptions).error?.message).toBe(
       'my component must be 4 characters or more'
     )
     expect(
-      formSchema.validate('scrambled', validationOptions).error.message
+      formSchema.validate('scrambled', validationOptions).error?.message
     ).toBe('my component must be 5 characters or less')
 
     expect(
-      formSchema.validate('scrambled', validationOptions).error.message
+      formSchema.validate('scrambled', validationOptions).error?.message
     ).toBe('my component must be 5 characters or less')
   })
 
@@ -68,7 +68,7 @@ describe('Multiline text field', () => {
     const multilineTextField = new MultilineTextField(def, {})
     const { formSchema } = multilineTextField
 
-    expect(formSchema.validate('', validationOptions).error.message).toBe(
+    expect(formSchema.validate('', validationOptions).error?.message).toBe(
       'Enter my component'
     )
     expect(formSchema.validate('benedict').error).toBeUndefined()

--- a/test/cases/server/plugins/engine/TelephoneNumberField.test.ts
+++ b/test/cases/server/plugins/engine/TelephoneNumberField.test.ts
@@ -16,7 +16,7 @@ describe('Telephone number field', () => {
       schema: {}
     }
     const telephoneNumberField = new TelephoneNumberField(def, {})
-    const { schema } = telephoneNumberField
+    const { formSchema: schema } = telephoneNumberField
 
     expect(schema.validate('not a phone').error.message).toBe(
       'This is a custom error'
@@ -41,7 +41,7 @@ describe('Telephone number field', () => {
       }
     }
     const telephoneNumberField = new TelephoneNumberField(def, {})
-    const { schema } = telephoneNumberField
+    const { formSchema: schema } = telephoneNumberField
 
     expect(schema.validate('1234').error).toBeUndefined()
     expect(schema.validate('12345').error).toBeUndefined()
@@ -66,7 +66,7 @@ describe('Telephone number field', () => {
       schema: {}
     }
     const telephoneNumberField = new TelephoneNumberField(def, {})
-    const { schema } = telephoneNumberField
+    const { formSchema: schema } = telephoneNumberField
 
     expect(schema.validate('not a phone').error.message).toBe(
       'Enter a telephone number in the correct format'

--- a/test/cases/server/plugins/engine/TelephoneNumberField.test.ts
+++ b/test/cases/server/plugins/engine/TelephoneNumberField.test.ts
@@ -18,7 +18,7 @@ describe('Telephone number field', () => {
     const telephoneNumberField = new TelephoneNumberField(def, {})
     const { formSchema: schema } = telephoneNumberField
 
-    expect(schema.validate('not a phone').error.message).toBe(
+    expect(schema.validate('not a phone').error?.message).toBe(
       'This is a custom error'
     )
     expect(schema.validate('').error).toBeUndefined()
@@ -45,13 +45,13 @@ describe('Telephone number field', () => {
 
     expect(schema.validate('1234').error).toBeUndefined()
     expect(schema.validate('12345').error).toBeUndefined()
-    expect(schema.validate('1').error.message).toContain(
+    expect(schema.validate('1').error?.message).toContain(
       'must be at least 3 characters long'
     )
-    expect(schema.validate('12-3').error.message).toContain(
+    expect(schema.validate('12-3').error?.message).toContain(
       'Enter a telephone number in the correct format'
     )
-    expect(schema.validate('1  1').error.message).toContain(
+    expect(schema.validate('1  1').error?.message).toContain(
       'Enter a telephone number in the correct format'
     )
   })
@@ -68,7 +68,7 @@ describe('Telephone number field', () => {
     const telephoneNumberField = new TelephoneNumberField(def, {})
     const { formSchema: schema } = telephoneNumberField
 
-    expect(schema.validate('not a phone').error.message).toBe(
+    expect(schema.validate('not a phone').error?.message).toBe(
       'Enter a telephone number in the correct format'
     )
   })

--- a/test/cases/server/plugins/engine/checkboxesfield.test.ts
+++ b/test/cases/server/plugins/engine/checkboxesfield.test.ts
@@ -57,7 +57,11 @@ describe('CheckboxesField', () => {
     const component = new CheckboxesField(componentDefinition, formModel)
 
     it('is required by default', () => {
-      expect(component.formSchema.describe().flags.presence).toBe('required')
+      expect(component.formSchema.describe().flags).toEqual(
+        expect.objectContaining({
+          presence: 'required'
+        })
+      )
     })
     it('allows the items defined in the List object with the correct type', () => {
       expect(component.formSchema.describe().items).toEqual(
@@ -84,8 +88,10 @@ describe('CheckboxesField', () => {
         },
         formModel
       )
-      expect(component.formSchema.describe().flags.presence).not.toBe(
-        'required'
+      expect(component.formSchema.describe().flags).not.toEqual(
+        expect.objectContaining({
+          presence: 'required'
+        })
       )
     })
     it('validates correctly', () => {

--- a/test/cases/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/test/cases/server/plugins/engine/components/AutocompleteField.test.ts
@@ -65,7 +65,11 @@ describe('AutocompleteField', () => {
     const component = new AutocompleteField(componentDefinition, formModel)
 
     it('is required by default', () => {
-      expect(component.formSchema.describe().flags.presence).toBe('required')
+      expect(component.formSchema.describe().flags).toEqual(
+        expect.objectContaining({
+          presence: 'required'
+        })
+      )
     })
 
     it('validates correctly', () => {

--- a/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
+++ b/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
@@ -72,7 +72,7 @@ describe('ListFormComponent', () => {
     )
 
     it('schema validates correctly when the field is optional', () => {
-      const schema = optionalComponent.formSchema
+      const { formSchema: schema } = optionalComponent
 
       expect(schema.validate('1').error).toBeUndefined()
       expect(schema.validate('2').error).toBeUndefined()

--- a/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
+++ b/test/cases/server/plugins/engine/components/ListFormComponents.test.ts
@@ -80,9 +80,9 @@ describe('ListFormComponent', () => {
       expect(schema.validate(null).error).toBeUndefined()
 
       const errorMessage = '"turnaround?" must be one of [1, 2, ]'
-      expect(schema.validate(10).error.message).toEqual(errorMessage)
-      expect(schema.validate('ten').error.message).toEqual(errorMessage)
-      expect(schema.validate(2).error.message).toEqual(errorMessage)
+      expect(schema.validate(10).error?.message).toEqual(errorMessage)
+      expect(schema.validate('ten').error?.message).toEqual(errorMessage)
+      expect(schema.validate(2).error?.message).toEqual(errorMessage)
     })
   })
 })

--- a/test/cases/server/plugins/engine/components/SelectField.test.ts
+++ b/test/cases/server/plugins/engine/components/SelectField.test.ts
@@ -66,7 +66,11 @@ describe('SelectField', () => {
     const component = new SelectField(componentDefinition, formModel)
 
     it('is required by default', () => {
-      expect(component.formSchema.describe().flags.presence).toBe('required')
+      expect(component.formSchema.describe().flags).toEqual(
+        expect.objectContaining({
+          presence: 'required'
+        })
+      )
     })
 
     it('validates correctly', () => {

--- a/test/cases/server/plugins/engine/components/TextField.test.ts
+++ b/test/cases/server/plugins/engine/components/TextField.test.ts
@@ -22,14 +22,20 @@ describe('TextField', () => {
     const component = new TextField(componentDefinition, formModel)
 
     it('is required by default', () => {
-      expect(component.formSchema.describe().flags.presence).toBe('required')
+      expect(component.formSchema.describe().flags).toEqual(
+        expect.objectContaining({
+          presence: 'required'
+        })
+      )
     })
 
     it('is not required when explicitly configured', () => {
       const component = TextComponent({ options: { required: false } })
 
-      expect(component.formSchema.describe().flags.presence).not.toBe(
-        'required'
+      expect(component.formSchema.describe().flags).not.toEqual(
+        expect.objectContaining({
+          presence: 'required'
+        })
       )
     })
 

--- a/test/cases/server/plugins/engine/numberField.test.ts
+++ b/test/cases/server/plugins/engine/numberField.test.ts
@@ -18,7 +18,7 @@ describe('Number field', () => {
       schema: { max: 30 }
     }
     const numberField = new NumberField(def)
-    const { schema } = numberField
+    const { formSchema: schema } = numberField
 
     expect(schema.validate(40, { messages }).error.message).toContain(
       'must be 30 or lower'
@@ -33,7 +33,7 @@ describe('Number field', () => {
       schema: { min: 30 }
     }
     const numberField = new NumberField(def)
-    const { schema } = numberField
+    const { formSchema: schema } = numberField
 
     expect(schema.validate(20, { messages }).error.message).toContain(
       'must be 30 or higher'

--- a/test/cases/server/plugins/engine/numberField.test.ts
+++ b/test/cases/server/plugins/engine/numberField.test.ts
@@ -20,7 +20,7 @@ describe('Number field', () => {
     const numberField = new NumberField(def)
     const { formSchema: schema } = numberField
 
-    expect(schema.validate(40, { messages }).error.message).toContain(
+    expect(schema.validate(40, { messages }).error?.message).toContain(
       'must be 30 or lower'
     )
 
@@ -35,7 +35,7 @@ describe('Number field', () => {
     const numberField = new NumberField(def)
     const { formSchema: schema } = numberField
 
-    expect(schema.validate(20, { messages }).error.message).toContain(
+    expect(schema.validate(20, { messages }).error?.message).toContain(
       'must be 30 or higher'
     )
 


### PR DESCRIPTION
This PR adds the correct types now we're tightening up `@defra/forms-model`

Most component classes set two main types of schema:

```js
this.formSchema = XXX
this.stateSchema = XXX
```

But some overwrote `this.schema` (from **forms-designer**) so this has been resolved

```patch
-   this.schema = formSchema
+   this.formSchema = formSchema
```

## Mismatched properties
Similarly some properties were added to components that no longer support them

E.g. The Yes/No component no longer has a nested list so we must guard for it:

```js
if ('list' in def) {
  this.list = model.getList(def.list)
  this.listType = this.list?.type ?? 'string'
}
```

I've not fixed everything, but I'll follow up in another PR