### PR TITLE
Remove unused "Allow pre-population" feature

### DIFF
--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -1,5 +1,4 @@
 import { type ComponentDef } from '@defra/forms-model'
-import { merge } from '@hapi/hoek'
 import joi, { type Schema as JoiSchema } from 'joi'
 
 import { type ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
@@ -17,7 +16,6 @@ import {
 export class ComponentCollection {
   items: (ComponentBase | ComponentCollection | FormComponent)[]
   formItems: FormComponent /* | ConditionalFormComponent */[]
-  prePopulatedItems: Record<string, JoiSchema>
   formSchema: JoiSchema
   stateSchema: JoiSchema
 
@@ -45,7 +43,6 @@ export class ComponentCollection {
       .keys({ crumb: joi.string().optional().allow('') })
 
     this.stateSchema = joi.object().keys(this.getStateSchemaKeys()).required()
-    this.prePopulatedItems = this.getPrePopulatedItems()
   }
 
   getFormSchemaKeys() {
@@ -66,16 +63,6 @@ export class ComponentCollection {
     })
 
     return keys
-  }
-
-  getPrePopulatedItems() {
-    return this.formItems
-      .filter(
-        ({ options }) =>
-          'allowPrePopulation' in options && options.allowPrePopulation
-      )
-      .map((item) => item.getStateSchemaKeys())
-      .reduce((acc, curr) => merge(acc, curr), {})
   }
 
   getFormDataFromState(state: FormSubmissionState): FormData {

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -1,6 +1,4 @@
 import { type Request, type ResponseToolkit } from '@hapi/hapi'
-import { reach } from '@hapi/hoek'
-import set from 'lodash/set.js'
 
 import { RelativeUrl } from '~/src/server/plugins/engine/feedback/index.js'
 
@@ -80,23 +78,4 @@ export function redirectTo(
 
 export const idFromFilename = (filename: string) => {
   return filename.replace(/govsite\.|\.json|/gi, '')
-}
-
-export function getValidStateFromQueryParameters(
-  prePopFields: Record<string, string>,
-  queryParameters: Record<string, string>,
-  state: Record<string, unknown> = {}
-) {
-  return Object.entries(queryParameters).reduce((acc, [key, value]) => {
-    if (reach(prePopFields, key) === undefined || reach(state, key)) {
-      return acc
-    }
-
-    const result = reach(prePopFields, key).validate(value)
-    if (result.error) {
-      return acc
-    }
-    set(acc, key, value)
-    return acc
-  }, {})
 }

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -55,7 +55,6 @@ export class FormModel {
   basePath: string
   conditions: Partial<Record<string, ExecutableCondition>>
   fieldsForContext: ComponentCollection
-  fieldsForPrePopulation: Record<string, any>
   pages: PageControllerClass[]
   startPage?: PageControllerClass
   specialPages?: FormDefinition['specialPages']
@@ -122,7 +121,6 @@ export class FormModel {
     })
 
     this.fieldsForContext = new ComponentCollection(exposedComponentDefs, this)
-    this.fieldsForPrePopulation = {}
     this.pages = def.pages.map((pageDef) => this.makePage(pageDef))
 
     // All models get an Application Status page

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -15,6 +15,7 @@ import {
 } from '@hapi/hapi'
 import { merge, reach } from '@hapi/hoek'
 import { format, parseISO } from 'date-fns'
+import joi from 'joi'
 import { type ValidationResult, type ObjectSchema } from 'joi'
 
 import { config } from '~/src/config/index.js'
@@ -91,20 +92,6 @@ export class PageControllerBase {
     const conditionalFormComponents = components.formItems.filter(
       (c: any) => c.conditionalComponents
     )
-
-    const fieldsForPrePopulation = components.prePopulatedItems
-
-    if (this.section) {
-      this.model.fieldsForPrePopulation[this.section.name] = {
-        ...(this.model.fieldsForPrePopulation[this.section.name] ?? {}),
-        ...fieldsForPrePopulation
-      }
-    } else {
-      this.model.fieldsForPrePopulation = {
-        ...this.model.fieldsForPrePopulation,
-        ...fieldsForPrePopulation
-      }
-    }
 
     this.components = components
     this.hasFormComponents = !!components.formItems.length

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -12,10 +12,7 @@ import { isEqual } from 'date-fns'
 import Joi from 'joi'
 
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
-import {
-  getValidStateFromQueryParameters,
-  redirectTo
-} from '~/src/server/plugins/engine/helpers.js'
+import { redirectTo } from '~/src/server/plugins/engine/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   getFormDefinition,
@@ -69,33 +66,6 @@ export const plugin = {
     // (for testing purposes) through `server.app.models`
     const itemCache = new Map<string, { model: FormModel; updatedAt: Date }>()
     server.app.models = itemCache
-
-    const queryParamPreHandler = async (
-      request: Request,
-      h: ResponseToolkit
-    ) => {
-      const { query } = request
-      const model = request.app.model
-      const prePopFields = model?.fieldsForPrePopulation ?? {}
-      const queryKeysLength = Object.keys(query).length
-      const prePopFieldsKeysLength = Object.keys(prePopFields).length
-
-      if (queryKeysLength === 0 || prePopFieldsKeysLength === 0) {
-        return h.continue
-      }
-
-      const { cacheService } = request.services([])
-      const state = await cacheService.getState(request)
-      const newValues = getValidStateFromQueryParameters(
-        prePopFields,
-        query,
-        state
-      )
-
-      await cacheService.mergeState(request, newValues)
-
-      return h.continue
-    }
 
     const loadFormPreHandler = async (
       request: Request<{
@@ -244,9 +214,6 @@ export const plugin = {
       pre: [
         {
           method: loadFormPreHandler
-        },
-        {
-          method: queryParamPreHandler
         }
       ]
     }
@@ -284,9 +251,6 @@ export const plugin = {
       pre: [
         {
           method: loadFormPreHandler
-        },
-        {
-          method: queryParamPreHandler
         }
       ]
     }

--- a/test/cases/server/plugins/engine/helpers.test.ts
+++ b/test/cases/server/plugins/engine/helpers.test.ts
@@ -1,12 +1,10 @@
 import { type ResponseToolkit } from '@hapi/hapi'
-import Joi from 'joi'
 
 import {
   proceed,
   redirectTo,
   redirectUrl,
-  nonRelativeRedirectUrl,
-  getValidStateFromQueryParameters
+  nonRelativeRedirectUrl
 } from '~/src/server/plugins/engine/helpers.js'
 
 describe('Helpers', () => {
@@ -315,67 +313,6 @@ describe('Helpers', () => {
       const nextUrl = 'https://test.com'
       const url = nonRelativeRedirectUrl(request, nextUrl)
       expect(url).toBe('https://test.com/?f_t=true')
-    })
-  })
-
-  describe('getValidStateFromQueryParameters', () => {
-    test('Should return an empty object if none of the query parameters relate to valid fields for pre-population', () => {
-      const query = {
-        aBadQueryParam: 'A value'
-      }
-      const prePopFields = {
-        eggType: Joi.string().required()
-      }
-      expect(
-        Object.keys(getValidStateFromQueryParameters(prePopFields, query))
-      ).toHaveLength(0)
-    })
-
-    test('Should return an empty object when a query parameter is valid, but a value already exists in the form state', () => {
-      const query = {
-        aBadQueryParam: 'A value',
-        eggType: 'Hard boiled'
-      }
-      const prePopFields = {
-        eggType: Joi.string().required()
-      }
-      const state = {
-        eggType: 'Fried'
-      }
-
-      expect(
-        Object.keys(
-          getValidStateFromQueryParameters(prePopFields, query, state)
-        )
-      ).toHaveLength(0)
-    })
-
-    test('Should be able to update nested object values', () => {
-      const query = {
-        'yourEggs.eggType': 'Fried egg'
-      }
-      const prePopFields = {
-        yourEggs: {
-          eggType: Joi.string().required()
-        }
-      }
-      expect(
-        getValidStateFromQueryParameters(prePopFields, query).yourEggs.eggType
-      ).toBe('Fried egg')
-    })
-
-    test('Should reject a value if it fails validation', () => {
-      const query = {
-        'yourEggs.eggType': 'deviled'
-      }
-      const prePopFields = {
-        yourEggs: {
-          eggType: Joi.string().valid('boiled', 'fried', 'poached')
-        }
-      }
-      expect(
-        Object.keys(getValidStateFromQueryParameters(prePopFields, query))
-      ).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
This PR removes the "Allow pre-population" feature from component JSON and query strings

The option was removed from **forms-designer** in https://github.com/DEFRA/forms-designer/pull/320/commits/819a416c8367fe617ec9d0ee18074c8f49c607a5

See [story #411565](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/411565)
