### PR TITLE
Remove unused "Expose to context" feature

### DIFF
--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -10,7 +10,6 @@ import { add } from 'date-fns'
 import { Parser } from 'expr-eval'
 import joi from 'joi'
 
-import { ComponentCollection } from '~/src/server/plugins/engine/components/index.js'
 import { type ExecutableCondition } from '~/src/server/plugins/engine/models/types.js'
 import {
   getPageController,
@@ -54,7 +53,6 @@ export class FormModel {
 
   basePath: string
   conditions: Partial<Record<string, ExecutableCondition>>
-  fieldsForContext: ComponentCollection
   pages: PageControllerClass[]
   startPage?: PageControllerClass
   specialPages?: FormDefinition['specialPages']
@@ -114,13 +112,6 @@ export class FormModel {
       this.conditions[condition.name] = condition
     })
 
-    const exposedComponentDefs = def.pages.flatMap(({ components = [] }) => {
-      return components.filter(({ options }) => {
-        return 'exposeToContext' in options && options.exposeToContext
-      })
-    })
-
-    this.fieldsForContext = new ComponentCollection(exposedComponentDefs, this)
     this.pages = def.pages.map((pageDef) => this.makePage(pageDef))
 
     // All models get an Application Status page
@@ -271,22 +262,5 @@ export class FormModel {
 
   getList(name: string): List | undefined {
     return this.lists.find((list) => list.name === name)
-  }
-
-  getContextState(state: FormSubmissionState) {
-    const contextState = Object.keys(state).reduce((acc, curr) => {
-      if (typeof state[curr] === 'object') {
-        return {
-          ...acc,
-          ...state[curr]
-        }
-      }
-      return {
-        ...acc,
-        [curr]: state[curr]
-      }
-    }, {})
-
-    return this.fieldsForContext.getFormDataFromState(contextState)
   }
 }

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -306,17 +306,11 @@ export class PageControllerBase {
         : {}
 
       return {
-        ...this.components.getFormDataFromState(
-          newState as FormSubmissionState
-        ),
-        ...this.model.fieldsForContext.getFormDataFromState(
-          newState as FormSubmissionState
-        )
+        ...this.components.getFormDataFromState(newState as FormSubmissionState)
       }
     }
     return {
-      ...this.components.getFormDataFromState(pageState || {}),
-      ...this.model.getContextState(state)
+      ...this.components.getFormDataFromState(pageState || {})
     }
   }
 

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -5,7 +5,6 @@ import {
   type RouteOptions
 } from '@hapi/hapi'
 import { format } from 'date-fns'
-import nunjucks from 'nunjucks'
 
 import { config } from '~/src/config/index.js'
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
@@ -244,8 +243,7 @@ async function sendEmail(
 
 function getPersonalisation(
   summaryViewModel: SummaryViewModel,
-  model: FormModel,
-  state: FormSubmissionState
+  model: FormModel
 ) {
   /**
    * @todo Refactor this below but the code to
@@ -256,8 +254,7 @@ function getPersonalisation(
   const formSubmissionData = getFormSubmissionData(
     relevantPages,
     details,
-    model,
-    model.getContextState(state)
+    model
   )
 
   const lines: string[] = []
@@ -284,7 +281,7 @@ function getPersonalisation(
   }
 }
 
-function getFormSubmissionData(relevantPages, details, model, contextState) {
+function getFormSubmissionData(relevantPages, details, model) {
   const questions = relevantPages?.map((page) => {
     const isRepeatable = !!page.repeatField
 
@@ -317,9 +314,7 @@ function getFormSubmissionData(relevantPages, details, model, contextState) {
     let pageTitle = page.title
 
     if (pageTitle) {
-      pageTitle = nunjucks.renderString(page.title.en ?? page.title, {
-        ...contextState
-      })
+      pageTitle = page.title.en ?? page.title
     }
 
     return {


### PR DESCRIPTION
This PR removes the "Expose to context" feature to add field values to Nunjucks context

The option was removed from **forms-designer** in https://github.com/DEFRA/forms-designer/pull/320/commits/dc0ba09e349c571bf3a3230fd584bf9c1e7fc28a

See [story #411565](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/411565)
