### PR TITLE
Add helper `hasComponentField()` to check component types etc

### DIFF
--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -34,7 +34,7 @@ export class ComponentBase {
   /**
    * This is passed onto webhooks, see {@link answerFromDetailItem}
    */
-  dataType?: DataType = 'text'
+  dataType: DataType = 'text'
   model: FormModel
 
   /** joi schemas based on a component defined in the form JSON. This validates a user's answer and is generated from {@link ComponentDef} */

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -2,11 +2,14 @@ import { type ComponentDef } from '@defra/forms-model'
 import joi from 'joi'
 
 import {
-  type ComponentBase,
   type ComponentSchema,
   type ComponentSchemaNested
 } from '~/src/server/plugins/engine/components/ComponentBase.js'
-import { type FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
+import {
+  hasComponentField,
+  type ComponentFieldClass,
+  type FormComponentFieldClass
+} from '~/src/server/plugins/engine/components/helpers.js'
 import * as Components from '~/src/server/plugins/engine/components/index.js'
 import { type ComponentCollectionViewModel } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -18,24 +21,24 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class ComponentCollection {
-  items: (ComponentBase | ComponentCollection | FormComponent)[]
-  formItems: FormComponent /* | ConditionalFormComponent */[]
+  items: ComponentFieldClass[]
+  formItems: FormComponentFieldClass[]
   formSchema: ComponentSchema
   stateSchema: ComponentSchema
 
   constructor(componentDefs: ComponentDef[] = [], model: FormModel) {
     const components = componentDefs.map((def) => {
-      const Comp = Components[def.type]
-
-      if (typeof Comp !== 'function') {
+      if (!hasComponentField(def.type)) {
         throw new Error(`Component type ${def.type} doesn't exist`)
       }
 
+      const Comp = Components[def.type]
       return new Comp(def, model)
     })
 
     const formComponents = components.filter(
-      (component) => 'isFormComponent' in component && component.isFormComponent
+      (component): component is FormComponentFieldClass =>
+        'isFormComponent' in component && component.isFormComponent
     )
 
     this.items = components

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -6,11 +6,10 @@ import {
   type ComponentSchemaNested
 } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import {
-  hasComponentField,
+  getComponentField,
   type ComponentFieldClass,
   type FormComponentFieldClass
 } from '~/src/server/plugins/engine/components/helpers.js'
-import * as Components from '~/src/server/plugins/engine/components/index.js'
 import { type ComponentCollectionViewModel } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
@@ -28,12 +27,13 @@ export class ComponentCollection {
 
   constructor(componentDefs: ComponentDef[] = [], model: FormModel) {
     const components = componentDefs.map((def) => {
-      if (!hasComponentField(def.type)) {
+      const Component = getComponentField(def)
+
+      if (!Component) {
         throw new Error(`Component type ${def.type} doesn't exist`)
       }
 
-      const Comp = Components[def.type]
-      return new Comp(def, model)
+      return new Component(def, model)
     })
 
     const formComponents = components.filter(

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -6,9 +6,9 @@ import {
 } from '@defra/forms-model'
 import joi from 'joi'
 
-import { type FormModel } from '~/src/server/plugins/engine/components/../models/index.js'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type DataType } from '~/src/server/plugins/engine/components/types.js'
+import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
   type FormSubmissionState,

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -9,7 +9,7 @@ import { ComponentCollection } from '~/src/server/plugins/engine/components/Comp
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { buildStateSchema } from '~/src/server/plugins/engine/components/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
-import { type PageControllerBase } from '~/src/server/plugins/engine/pageControllers/index.js'
+import { type PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 import {
   type FormData,
   type FormPayload,

--- a/src/server/plugins/engine/components/helpers.ts
+++ b/src/server/plugins/engine/components/helpers.ts
@@ -1,6 +1,31 @@
 import { add, startOfToday, sub } from 'date-fns'
 import joi from 'joi'
 
+import * as Components from '~/src/server/plugins/engine/components/index.js'
+
+export type ComponentFieldClass = InstanceType<ComponentFieldType>
+export type ComponentFieldType = (typeof Components)[keyof typeof Components]
+
+export type FormComponentFieldClass = InstanceType<FormComponentFieldType>
+export type FormComponentFieldType =
+  | typeof Components.AutocompleteField
+  | typeof Components.CheckboxesField
+  | typeof Components.DatePartsField
+  | typeof Components.EmailAddressField
+  | typeof Components.MonthYearField
+  | typeof Components.MultilineTextField
+  | typeof Components.NumberField
+  | typeof Components.SelectField
+  | typeof Components.TelephoneNumberField
+  | typeof Components.TextField
+  | typeof Components.UkAddressField
+
+export function hasComponentField(
+  componentType: string
+): componentType is keyof typeof Components {
+  return componentType in Components
+}
+
 /**
  * FIXME:- this code is bonkers. buildFormSchema and buildState schema are duplicates.
  * The xxField classes should be responsible for generating their own schemas.

--- a/src/server/plugins/engine/components/helpers.ts
+++ b/src/server/plugins/engine/components/helpers.ts
@@ -1,3 +1,4 @@
+import { type ComponentDef } from '@defra/forms-model'
 import { add, startOfToday, sub } from 'date-fns'
 import joi from 'joi'
 
@@ -24,6 +25,19 @@ export function hasComponentField(
   componentType: string
 ): componentType is keyof typeof Components {
   return componentType in Components
+}
+
+/**
+ * Gets the field class for each {@link ComponentDef} type
+ */
+export function getComponentField(component: ComponentDef) {
+  const { type } = component
+
+  if (!hasComponentField(type)) {
+    return
+  }
+
+  return Components[type]
 }
 
 /**

--- a/src/server/plugins/engine/components/index.ts
+++ b/src/server/plugins/engine/components/index.ts
@@ -6,13 +6,9 @@
 
 export { AutocompleteField } from '~/src/server/plugins/engine/components/AutocompleteField.js'
 export { CheckboxesField } from '~/src/server/plugins/engine/components/CheckboxesField.js'
-export { ComponentBase as Component } from '~/src/server/plugins/engine/components/ComponentBase.js'
-export { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-// export { ConditionalFormComponent } from "./ConditionalFormComponent";
 export { DatePartsField } from '~/src/server/plugins/engine/components/DatePartsField.js'
 export { Details } from '~/src/server/plugins/engine/components/Details.js'
 export { EmailAddressField } from '~/src/server/plugins/engine/components/EmailAddressField.js'
-export { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 export { Html } from '~/src/server/plugins/engine/components/Html.js'
 export { InsetText } from '~/src/server/plugins/engine/components/InsetText.js'
 export { List } from '~/src/server/plugins/engine/components/List.js'

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -11,15 +11,13 @@ import { Parser } from 'expr-eval'
 import joi from 'joi'
 
 import { type ExecutableCondition } from '~/src/server/plugins/engine/models/types.js'
+import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 import {
   getPageController,
   type PageControllerClass,
   type PageControllerType
 } from '~/src/server/plugins/engine/pageControllers/helpers.js'
-import {
-  PageController,
-  PageControllerBase
-} from '~/src/server/plugins/engine/pageControllers/index.js'
+import { PageController } from '~/src/server/plugins/engine/pageControllers/index.js'
 import { type FormSubmissionState } from '~/src/server/plugins/engine/types.js'
 
 class EvaluationContext {
@@ -184,7 +182,7 @@ export class FormModel {
   /**
    * instantiates a Page based on {@link Page}
    */
-  makePage(pageDef: Page) {
+  makePage(pageDef: Page): PageControllerClass {
     if (pageDef.controller) {
       const PageController = getPageController(pageDef.controller)
 

--- a/src/server/plugins/engine/models/types.ts
+++ b/src/server/plugins/engine/models/types.ts
@@ -4,7 +4,7 @@ import {
   type Section
 } from '@defra/forms-model'
 
-import { type Component } from '~/src/server/plugins/engine/models/../components/index.js'
+import { type ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { type FeedbackContextInfo } from '~/src/server/plugins/engine/models/../feedback/index.js'
 
 export type Fields = {
@@ -62,13 +62,13 @@ export interface DetailItem {
   /**
    * Name of the component defined in the JSON {@link FormDefinition}
    */
-  name: Component['name']
+  name: ComponentBase['name']
 
   /**
    * Title of the component defined in the JSON {@link FormDefinition}
-   * Used as a human readable form of {@link Component.#name} and HTML content for HTML Label tag
+   * Used as a human readable form of {@link ComponentBase.name} and HTML content for HTML Label tag
    */
-  label: Component['title']
+  label: ComponentBase['title']
 
   /**
    * Path to redirect the user to if they decide to change this value
@@ -86,10 +86,10 @@ export interface DetailItem {
   rawValue: string | number | object
   url: string
   pageId: string
-  type: Component['type']
-  title: Component['title']
-  dataType?: Component['dataType']
-  items: DetailItem[]
+  type: ComponentBase['type']
+  title: ComponentBase['title']
+  dataType: ComponentBase['dataType']
+  items?: DetailItem[]
 }
 
 /**

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -1,8 +1,4 @@
-import {
-  type Request,
-  type ResponseToolkit,
-  type RouteOptions
-} from '@hapi/hapi'
+import { type RouteOptions } from '@hapi/hapi'
 
 import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 

--- a/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.ts
@@ -24,13 +24,15 @@ export type PageControllerType =
 /**
  * Gets the class for the controller defined in a {@link Page}
  */
-export function getPageController(nameOrPath: string): PageControllerType {
+export function getPageController(
+  nameOrPath: string
+): PageControllerType | undefined {
   const controllerName = path.extname(nameOrPath)
     ? controllerNameFromPath(nameOrPath)
     : nameOrPath
 
   if (!isPageController(controllerName)) {
-    return PageControllers.PageControllerBase
+    return
   }
 
   return PageControllers[controllerName]

--- a/src/server/plugins/engine/pageControllers/index.ts
+++ b/src/server/plugins/engine/pageControllers/index.ts
@@ -1,7 +1,6 @@
 export { DobPageController } from '~/src/server/plugins/engine/pageControllers/DobPageController.js'
 export { HomePageController } from '~/src/server/plugins/engine/pageControllers/HomePageController.js'
 export { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
-export { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 export { RepeatingFieldPageController } from '~/src/server/plugins/engine/pageControllers/RepeatingFieldPageController.js'
 export { RepeatingSummaryPageController } from '~/src/server/plugins/engine/pageControllers/RepeatingSummaryPageController.js'
 export { StartDatePageController } from '~/src/server/plugins/engine/pageControllers/StartDatePageController.js'

--- a/test/cases/server/plugins/engine/pageControllers/PageControllerBase.test.ts
+++ b/test/cases/server/plugins/engine/pageControllers/PageControllerBase.test.ts
@@ -1,7 +1,7 @@
 import { ComponentType, type FormDefinition } from '@defra/forms-model'
 
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
-import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/index.js'
+import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 
 describe('PageControllerBase', () => {
   test('getErrors correctly parses ISO string to readable string', () => {


### PR DESCRIPTION
We currently support "Time" components in **forms-designer** but they don't exist in **forms-runner**

Included in this PR are 2x new helpers to match our page controller approach:

* Helper `hasComponentField()` to check component types
* Helper `getComponentField()` to return field class for component

This is a safeguard for [story #411565](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/411565)