### PR TITLE
Remove build schema helpers

### DIFF
--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -9,6 +9,7 @@ import joi, {
   type AlternativesSchema,
   type ArraySchema,
   type BooleanSchema,
+  type DateSchema,
   type NumberSchema,
   type ObjectSchema,
   type StringSchema
@@ -83,6 +84,7 @@ export type ComponentSchema =
   | ArraySchema<number>
   | ArraySchema<boolean>
   | BooleanSchema<string>
+  | DateSchema
   | NumberSchema<string>
   | NumberSchema
   | ObjectSchema

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -3,14 +3,12 @@ import {
   type DatePartsFieldFieldComponent
 } from '@defra/forms-model'
 import { parseISO, format } from 'date-fns'
+import joi from 'joi'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
-import {
-  buildStateSchema,
-  getCustomDateValidator
-} from '~/src/server/plugins/engine/components/helpers.js'
+import { getCustomDateValidator } from '~/src/server/plugins/engine/components/helpers.js'
 import { type DataType } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
@@ -28,10 +26,16 @@ export class DatePartsField extends FormComponent {
   constructor(def: DatePartsFieldFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { name, options, schema } = def
+    const { name, options, schema, title } = def
 
     const isRequired = options.required !== false
     const hideOptional = options.optionalText
+
+    let stateSchema = joi.date().required().label(title)
+
+    if (options.required === false) {
+      stateSchema = stateSchema.allow('').allow(null)
+    }
 
     this.children = new ComponentCollection(
       [
@@ -77,7 +81,7 @@ export class DatePartsField extends FormComponent {
 
     this.options = options
     this.schema = schema
-    this.stateSchema = buildStateSchema('date', this)
+    this.stateSchema = stateSchema
   }
 
   getFormSchemaKeys() {

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -31,7 +31,12 @@ export class ListFormComponent extends FormComponent {
     return this.items.map((item) => item.value)
   }
 
-  constructor(def: ListComponentsDef | YesNoFieldComponent, model: FormModel) {
+  constructor(
+    def:
+      | ListComponentsDef // Allow for Yes/No field custom list
+      | (YesNoFieldComponent & Pick<ListComponentsDef, 'list'>),
+    model: FormModel
+  ) {
     super(def, model)
 
     const { schema, options, title } = def

--- a/src/server/plugins/engine/components/SelectField.ts
+++ b/src/server/plugins/engine/components/SelectField.ts
@@ -4,7 +4,6 @@ import {
 } from '@defra/forms-model'
 
 import { ListFormComponent } from '~/src/server/plugins/engine/components/ListFormComponent.js'
-import { type DataType } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type FormPayload,
@@ -17,7 +16,6 @@ export class SelectField extends ListFormComponent {
     | AutocompleteFieldComponent['options']
 
   schema: SelectFieldComponent['schema']
-  dataType: DataType = 'list'
 
   constructor(
     def: SelectFieldComponent | AutocompleteFieldComponent,

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -20,7 +20,7 @@ import {
 export class UkAddressField extends FormComponent {
   options: UkAddressFieldComponent['options']
   schema: UkAddressFieldComponent['schema']
-  formChildren: ComponentCollection
+  children: ComponentCollection
   stateChildren: ComponentCollection
 
   constructor(def: UkAddressFieldComponent, model: FormModel) {
@@ -92,13 +92,13 @@ export class UkAddressField extends FormComponent {
 
     this.options = options
     this.schema = schema
-    this.formChildren = formChildren
+    this.children = formChildren
     this.stateChildren = stateChildren
     this.stateSchema = buildStateSchema('date', this)
   }
 
   getFormSchemaKeys() {
-    return this.formChildren.getFormSchemaKeys()
+    return this.children.getFormSchemaKeys()
   }
 
   getStateSchemaKeys() {
@@ -157,7 +157,7 @@ export class UkAddressField extends FormComponent {
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {
-    const { formChildren, options } = this
+    const { children: formChildren, options } = this
 
     const viewModel = super.getViewModel(payload, errors)
     let { children, fieldset, label } = viewModel

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -7,7 +7,6 @@ import joi from 'joi'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
-import { buildStateSchema } from '~/src/server/plugins/engine/components/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { type PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 import {
@@ -26,10 +25,16 @@ export class UkAddressField extends FormComponent {
   constructor(def: UkAddressFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { name, options, schema } = def
+    const { name, options, schema, title } = def
 
     const isRequired = options.required !== false
     const hideOptional = options.optionalText
+
+    let stateSchema = joi.object().required().label(title)
+
+    if (options.required === false) {
+      stateSchema = stateSchema.allow('').allow(null)
+    }
 
     const childrenList = [
       {
@@ -94,7 +99,7 @@ export class UkAddressField extends FormComponent {
     this.schema = schema
     this.children = formChildren
     this.stateChildren = stateChildren
-    this.stateSchema = buildStateSchema('date', this)
+    this.stateSchema = stateSchema
   }
 
   getFormSchemaKeys() {

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -1,11 +1,7 @@
-import { type List, type YesNoFieldComponent } from '@defra/forms-model'
+import { type YesNoFieldComponent } from '@defra/forms-model'
 
 import { ListFormComponent } from '~/src/server/plugins/engine/components/ListFormComponent.js'
-import {
-  addClassOptionIfNone,
-  buildFormSchema,
-  buildStateSchema
-} from '~/src/server/plugins/engine/components/helpers.js'
+import { addClassOptionIfNone } from '~/src/server/plugins/engine/components/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
@@ -21,50 +17,15 @@ export class YesNoField extends ListFormComponent {
   options: YesNoFieldComponent['options']
   schema: YesNoFieldComponent['schema']
 
-  list?: List = {
-    name: '__yesNo',
-    title: 'Yes/No',
-    type: 'boolean',
-    items: [
-      {
-        text: 'Yes',
-        value: true
-      },
-      {
-        text: 'No',
-        value: false
-      }
-    ]
-  }
-
-  get items() {
-    return this.list?.items ?? []
-  }
-
-  get values() {
-    return [true, false]
-  }
-
   constructor(def: YesNoFieldComponent, model: FormModel) {
-    super(def, model)
+    super({ ...def, list: '__yesNo' }, model)
 
     const { options, schema } = def
 
+    addClassOptionIfNone(options, 'govuk-radios--inline')
+
     this.options = options
     this.schema = schema
-
-    this.formSchema = buildFormSchema(
-      'boolean',
-      this,
-      options.required !== false
-    ).valid(true, false)
-
-    this.stateSchema = buildStateSchema(this.list?.type, this).valid(
-      true,
-      false
-    )
-
-    addClassOptionIfNone(options, 'govuk-radios--inline')
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/helpers.ts
+++ b/src/server/plugins/engine/components/helpers.ts
@@ -1,6 +1,6 @@
 import { type ComponentDef } from '@defra/forms-model'
 import { add, startOfToday, sub } from 'date-fns'
-import joi from 'joi'
+import { type CustomHelpers } from 'joi'
 
 import * as Components from '~/src/server/plugins/engine/components/index.js'
 
@@ -40,82 +40,8 @@ export function getComponentField(component: ComponentDef) {
   return Components[type]
 }
 
-/**
- * FIXME:- this code is bonkers. buildFormSchema and buildState schema are duplicates.
- * The xxField classes should be responsible for generating their own schemas.
- */
-export function buildSchema(type, keys) {
-  const schema = type?.isJoi ? type : joi[type?.type ?? type]()
-
-  Object.keys(keys).forEach((key) => {
-    let val = keys[key]
-    if (key === 'regex') {
-      val = new RegExp(val)
-    }
-    schema[key](typeof val === 'boolean' ? undefined : val)
-  })
-
-  return schema
-}
-
-export function buildFormSchema(schemaType, component, isRequired = true) {
-  let schema = buildSchema(schemaType, component.schema)
-
-  if (isRequired) {
-    schema = schema.required()
-  }
-
-  if (component.title) {
-    schema = schema.label(component.title.toLowerCase())
-  }
-
-  if (component.options.required === false) {
-    schema = schema.allow(null, '').optional()
-  }
-
-  if (schema.trim && component.schema.trim !== false) {
-    schema = schema.trim()
-  }
-
-  return schema
-}
-
-export function buildStateSchema(schemaType, component) {
-  let schema = buildSchema(schemaType, component.schema)
-
-  if (component.title) {
-    schema = schema.label(component.title.toLowerCase())
-  }
-
-  if (component.options.required !== false) {
-    schema = schema.required()
-  }
-
-  if (component.options.required === false) {
-    schema = schema.allow(null, '').optional()
-  }
-
-  if (schema.trim && component.schema.trim !== false) {
-    schema = schema.trim()
-  }
-
-  return schema
-}
-
-export function getFormSchemaKeys(_name, schemaType, component) {
-  const schema = buildFormSchema(schemaType, component)
-
-  return { [component.name]: schema }
-}
-
-export function getStateSchemaKeys(name, schemaType, component) {
-  const schema = buildStateSchema(schemaType, component)
-
-  return { [name]: schema }
-}
-
 export const addClassOptionIfNone = (
-  options: { classes?: string; [prop: string]: any },
+  options: Extract<ComponentDef['options'], { classes?: string }>,
   className: string
 ) => {
   if (!options.classes) {
@@ -126,7 +52,7 @@ export function getCustomDateValidator(
   maxDaysInPast?: number,
   maxDaysInFuture?: number
 ) {
-  return (value: Date, helpers: joi.CustomHelpers) => {
+  return (value: Date, helpers: CustomHelpers) => {
     if (maxDaysInPast) {
       const minDate = sub(startOfToday(), { days: maxDaysInPast })
       if (value < minDate) {


### PR DESCRIPTION
This PR removes the helpers `buildSchema()`, `buildStateSchema()` etc

These changes address the comment:

https://github.com/DEFRA/forms-runner/blob/79dfe9d92f57c4282ceecb5b8149fcd7a05547f8/src/server/plugins/engine/components/helpers.ts#L4-L8