### PR TITLE
Add form validation to email address field

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -19,7 +19,6 @@ module.exports = {
     '@babel/plugin-syntax-import-attributes'
   ],
   presets: [
-    '@babel/preset-typescript',
     [
       '@babel/preset-env',
       {
@@ -29,6 +28,12 @@ module.exports = {
         // Apply ES module transforms for Jest
         // https://jestjs.io/docs/ecmascript-modules
         modules: NODE_ENV === 'test' ? 'auto' : false
+      }
+    ],
+    [
+      '@babel/preset-typescript',
+      {
+        allowDeclareFields: true
       }
     ]
   ],

--- a/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.ts
@@ -9,8 +9,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class AutocompleteField extends SelectField {
-  options: AutocompleteFieldComponent['options']
-  schema: AutocompleteFieldComponent['schema']
+  declare options: AutocompleteFieldComponent['options']
+  declare schema: AutocompleteFieldComponent['schema']
 
   constructor(def: AutocompleteFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -1,5 +1,5 @@
 import { type CheckboxesFieldComponent } from '@defra/forms-model'
-import joi from 'joi'
+import joi, { type ArraySchema } from 'joi'
 
 import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -12,6 +12,8 @@ import {
 export class CheckboxesField extends SelectionControlField {
   declare options: CheckboxesFieldComponent['options']
   declare schema: CheckboxesFieldComponent['schema']
+  declare formSchema: ArraySchema<string>
+  declare stateSchema: ArraySchema<string>
 
   constructor(def: CheckboxesFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -10,8 +10,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class CheckboxesField extends SelectionControlField {
-  options: CheckboxesFieldComponent['options']
-  schema: CheckboxesFieldComponent['schema']
+  declare options: CheckboxesFieldComponent['options']
+  declare schema: CheckboxesFieldComponent['schema']
 
   constructor(def: CheckboxesFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -18,8 +18,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class DatePartsField extends FormComponent {
-  options: DatePartsFieldFieldComponent['options']
-  schema: DatePartsFieldFieldComponent['schema']
+  declare options: DatePartsFieldFieldComponent['options']
+  declare schema: DatePartsFieldFieldComponent['schema']
   children: ComponentCollection
   dataType: DataType = 'date'
 

--- a/src/server/plugins/engine/components/Details.ts
+++ b/src/server/plugins/engine/components/Details.ts
@@ -8,8 +8,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class Details extends ComponentBase {
-  options: DetailsComponent['options']
-  schema: DetailsComponent['schema']
+  declare options: DetailsComponent['options']
+  declare schema: DetailsComponent['schema']
 
   constructor(def: DetailsComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -1,23 +1,22 @@
 import { type EmailAddressFieldComponent } from '@defra/forms-model'
-import { type StringSchema } from 'joi'
 
-import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
+import { TextField } from '~/src/server/plugins/engine/components/TextField.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
   type FormSubmissionErrors
 } from '~/src/server/plugins/engine/types.js'
 
-export class EmailAddressField extends FormComponent {
+export class EmailAddressField extends TextField {
   declare options: EmailAddressFieldComponent['options']
   declare schema: EmailAddressFieldComponent['schema']
-  declare formSchema: StringSchema
 
   constructor(def: EmailAddressFieldComponent, model: FormModel) {
     super(def, model)
 
     const { schema, options } = def
 
+    this.formSchema = this.formSchema.email()
     this.options = options
     this.schema = schema
   }

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -1,4 +1,5 @@
 import { type EmailAddressFieldComponent } from '@defra/forms-model'
+import { type StringSchema } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -10,6 +11,7 @@ import {
 export class EmailAddressField extends FormComponent {
   declare options: EmailAddressFieldComponent['options']
   declare schema: EmailAddressFieldComponent['schema']
+  declare formSchema: StringSchema
 
   constructor(def: EmailAddressFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -8,8 +8,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class EmailAddressField extends FormComponent {
-  options: EmailAddressFieldComponent['options']
-  schema: EmailAddressFieldComponent['schema']
+  declare options: EmailAddressFieldComponent['options']
+  declare schema: EmailAddressFieldComponent['schema']
 
   constructor(def: EmailAddressFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -1,3 +1,5 @@
+import capitalize from 'lodash/capitalize.js'
+
 import {
   ComponentBase,
   type ComponentSchemaKeys
@@ -71,8 +73,10 @@ export class FormComponent extends ComponentBase {
 
     errors?.errorList.forEach((err) => {
       if (err.name === name) {
+        err.text = capitalize(err.text)
+
         viewModel.errorMessage = {
-          text: err.text
+          text: capitalize(err.text)
         }
       }
     })

--- a/src/server/plugins/engine/components/Html.ts
+++ b/src/server/plugins/engine/components/Html.ts
@@ -8,8 +8,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class Html extends ComponentBase {
-  options: HtmlComponent['options']
-  schema: HtmlComponent['schema']
+  declare options: HtmlComponent['options']
+  declare schema: HtmlComponent['schema']
 
   constructor(def: HtmlComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/InsetText.ts
+++ b/src/server/plugins/engine/components/InsetText.ts
@@ -9,8 +9,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class InsetText extends ComponentBase {
-  options: InsetTextComponent['options']
-  schema: InsetTextComponent['schema']
+  declare options: InsetTextComponent['options']
+  declare schema: InsetTextComponent['schema']
 
   constructor(def: InsetTextComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/List.ts
+++ b/src/server/plugins/engine/components/List.ts
@@ -12,8 +12,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class List extends ComponentBase {
-  schema: ListComponent['schema']
-  options: ListComponent['options']
+  declare schema: ListComponent['schema']
+  declare options: ListComponent['options']
   list?: ListType
 
   get items(): Item[] {

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -4,7 +4,12 @@ import {
   type ListComponentsDef,
   type YesNoFieldComponent
 } from '@defra/forms-model'
-import joi from 'joi'
+import joi, {
+  type ArraySchema,
+  type BooleanSchema,
+  type NumberSchema,
+  type StringSchema
+} from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type DataType } from '~/src/server/plugins/engine/components/types.js'
@@ -18,6 +23,17 @@ import {
 export class ListFormComponent extends FormComponent {
   declare options: ListComponentsDef['options'] | YesNoFieldComponent['options']
   declare schema: ListComponentsDef['schema'] | YesNoFieldComponent['options']
+  declare formSchema:
+    | ArraySchema<string>
+    | BooleanSchema<string>
+    | NumberSchema<string>
+    | StringSchema
+
+  declare stateSchema:
+    | ArraySchema<string>
+    | BooleanSchema<string>
+    | NumberSchema<string>
+    | StringSchema
 
   list?: List
   listType: List['type'] = 'string'

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -16,8 +16,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class ListFormComponent extends FormComponent {
-  options: ListComponentsDef['options'] | YesNoFieldComponent['options']
-  schema: ListComponentsDef['schema'] | YesNoFieldComponent['options']
+  declare options: ListComponentsDef['options'] | YesNoFieldComponent['options']
+  declare schema: ListComponentsDef['schema'] | YesNoFieldComponent['options']
 
   list?: List
   listType: List['type'] = 'string'

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -12,8 +12,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class MonthYearField extends FormComponent {
-  options: MonthYearFieldComponent['options']
-  schema: MonthYearFieldComponent['schema']
+  declare options: MonthYearFieldComponent['options']
+  declare schema: MonthYearFieldComponent['schema']
   children: ComponentCollection
   dataType: DataType = 'monthYear'
 

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -1,5 +1,5 @@
 import { type MultilineTextFieldComponent } from '@defra/forms-model'
-import Joi from 'joi'
+import Joi, { type StringSchema } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type MultilineTextFieldViewModel } from '~/src/server/plugins/engine/components/types.js'
@@ -21,6 +21,8 @@ function inputIsOverWordCount(input: string, maxWords: number) {
 export class MultilineTextField extends FormComponent {
   declare options: MultilineTextFieldComponent['options']
   declare schema: MultilineTextFieldComponent['schema']
+  declare formSchema: StringSchema
+
   customValidationMessage?: string
   isCharacterOrWordCount = false
 

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -19,8 +19,8 @@ function inputIsOverWordCount(input: string, maxWords: number) {
 }
 
 export class MultilineTextField extends FormComponent {
-  options: MultilineTextFieldComponent['options']
-  schema: MultilineTextFieldComponent['schema']
+  declare options: MultilineTextFieldComponent['options']
+  declare schema: MultilineTextFieldComponent['schema']
   customValidationMessage?: string
   isCharacterOrWordCount = false
 

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -1,5 +1,5 @@
 import { type NumberFieldComponent } from '@defra/forms-model'
-import joi from 'joi'
+import joi, { type AlternativesSchema, type NumberSchema } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -12,6 +12,7 @@ import {
 export class NumberField extends FormComponent {
   declare options: NumberFieldComponent['options']
   declare schema: NumberFieldComponent['schema']
+  declare formSchema: AlternativesSchema<string | number> | NumberSchema
 
   constructor(def: NumberFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -10,8 +10,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class NumberField extends FormComponent {
-  options: NumberFieldComponent['options']
-  schema: NumberFieldComponent['schema']
+  declare options: NumberFieldComponent['options']
+  declare schema: NumberFieldComponent['schema']
 
   constructor(def: NumberFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/RadiosField.ts
+++ b/src/server/plugins/engine/components/RadiosField.ts
@@ -4,8 +4,8 @@ import { SelectionControlField } from '~/src/server/plugins/engine/components/Se
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 
 export class RadiosField extends SelectionControlField {
-  options: RadiosFieldComponent['options']
-  schema: RadiosFieldComponent['schema']
+  declare options: RadiosFieldComponent['options']
+  declare schema: RadiosFieldComponent['schema']
 
   constructor(def: RadiosFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/SelectField.ts
+++ b/src/server/plugins/engine/components/SelectField.ts
@@ -11,11 +11,11 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class SelectField extends ListFormComponent {
-  options:
+  declare options:
     | SelectFieldComponent['options']
     | AutocompleteFieldComponent['options']
 
-  schema: SelectFieldComponent['schema']
+  declare schema: SelectFieldComponent['schema']
 
   constructor(
     def: SelectFieldComponent | AutocompleteFieldComponent,

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -13,8 +13,8 @@ const PATTERN = /^[0-9\\\s+()-]*$/
 const DEFAULT_MESSAGE = 'Enter a telephone number in the correct format'
 
 export class TelephoneNumberField extends FormComponent {
-  options: TelephoneNumberFieldComponent['options']
-  schema: TelephoneNumberFieldComponent['schema']
+  declare options: TelephoneNumberFieldComponent['options']
+  declare schema: TelephoneNumberFieldComponent['schema']
 
   constructor(def: TelephoneNumberFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -1,5 +1,5 @@
 import { type TelephoneNumberFieldComponent } from '@defra/forms-model'
-import joi from 'joi'
+import joi, { type StringSchema } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { addClassOptionIfNone } from '~/src/server/plugins/engine/components/helpers.js'
@@ -15,6 +15,7 @@ const DEFAULT_MESSAGE = 'Enter a telephone number in the correct format'
 export class TelephoneNumberField extends FormComponent {
   declare options: TelephoneNumberFieldComponent['options']
   declare schema: TelephoneNumberFieldComponent['schema']
+  declare formSchema: StringSchema
 
   constructor(def: TelephoneNumberFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -9,8 +9,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class TextField extends FormComponent {
-  options: TextFieldComponent['options']
-  schema: TextFieldComponent['schema']
+  declare options: TextFieldComponent['options']
+  declare schema: TextFieldComponent['schema']
 
   constructor(def: TextFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -1,5 +1,5 @@
 import { type TextFieldComponent } from '@defra/forms-model'
-import joi from 'joi'
+import joi, { type StringSchema } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -11,6 +11,7 @@ import {
 export class TextField extends FormComponent {
   declare options: TextFieldComponent['options']
   declare schema: TextFieldComponent['schema']
+  declare formSchema: StringSchema
 
   constructor(def: TextFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -1,4 +1,7 @@
-import { type TextFieldComponent } from '@defra/forms-model'
+import {
+  type EmailAddressFieldComponent,
+  type TextFieldComponent
+} from '@defra/forms-model'
 import joi, { type StringSchema } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
@@ -9,11 +12,20 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class TextField extends FormComponent {
-  declare options: TextFieldComponent['options']
-  declare schema: TextFieldComponent['schema']
+  declare options:
+    | TextFieldComponent['options']
+    | EmailAddressFieldComponent['options']
+
+  declare schema:
+    | TextFieldComponent['schema']
+    | EmailAddressFieldComponent['options']
+
   declare formSchema: StringSchema
 
-  constructor(def: TextFieldComponent, model: FormModel) {
+  constructor(
+    def: TextFieldComponent | EmailAddressFieldComponent,
+    model: FormModel
+  ) {
     super(def, model)
 
     const { options, schema, title } = def

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -17,8 +17,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class UkAddressField extends FormComponent {
-  options: UkAddressFieldComponent['options']
-  schema: UkAddressFieldComponent['schema']
+  declare options: UkAddressFieldComponent['options']
+  declare schema: UkAddressFieldComponent['schema']
   children: ComponentCollection
   stateChildren: ComponentCollection
 

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -14,8 +14,8 @@ import {
  * YesNoField is a radiosField with predefined values.
  */
 export class YesNoField extends ListFormComponent {
-  options: YesNoFieldComponent['options']
-  schema: YesNoFieldComponent['schema']
+  declare options: YesNoFieldComponent['options']
+  declare schema: YesNoFieldComponent['schema']
 
   constructor(def: YesNoFieldComponent, model: FormModel) {
     super({ ...def, list: '__yesNo' }, model)

--- a/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -8,7 +8,7 @@ const messageTemplate = {
   max: '{{#label}} must be {{#limit}} characters or less',
   min: '{{#label}} must be {{#limit}} characters or more',
   pattern: 'Enter a valid {{#label}}',
-  email: '{{#label}} must be a valid email address',
+  email: 'Enter {{#label}} in the correct format',
   number: '{{#label}} must be a number',
   numberMin: '{{#label}} must be {{#limit}} or higher',
   numberMax: '{{#label}} must be {{#limit}} or lower',


### PR DESCRIPTION
This PR completes work on stories [#366938](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/366938) and [#366937](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/366937)

There's one change to the acceptance criteria but I've added:

1. Email address extends all text input features
2. All error messages now start with a capital letter

### Expected
We should add the "a" or "an" article before the label

```
'Enter an {{#label}} in the correct format'
```

### Actual
We need to wait for [#382043](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/382043) so I've dropped "a" or "an" for now

```
'Enter {{#label}} in the correct format'
```

**Note:** See [npm package `indefinite`](https://www.npmjs.com/package/indefinite) for automatic "a" or "an" handling in future?