### PR TITLE
Add custom error message

### DIFF
--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -1,4 +1,5 @@
 import { type EmailAddressFieldComponent } from '@defra/forms-model'
+import joi from 'joi'
 
 import { TextField } from '~/src/server/plugins/engine/components/TextField.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -14,9 +15,25 @@ export class EmailAddressField extends TextField {
   constructor(def: EmailAddressFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { schema, options } = def
+    const { schema, options, title } = def
 
-    this.formSchema = this.formSchema.email()
+    let formSchema = joi.string().label(title.toLowerCase()).email()
+
+    if (options.required === false) {
+      formSchema = formSchema.allow('').allow(null)
+    }
+
+    if (options.customValidationMessage) {
+      const message = options.customValidationMessage
+
+      formSchema = formSchema.messages({
+        'any.required': message,
+        'string.empty': message,
+        'string.email': message
+      })
+    }
+
+    this.formSchema = formSchema
     this.options = options
     this.schema = schema
   }

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -17,7 +17,7 @@ export class EmailAddressField extends FormComponent {
 
     const { schema, options, title } = def
 
-    let formSchema = joi.string().label(title.toLowerCase()).email()
+    let formSchema = joi.string().trim().label(title.toLowerCase()).email()
 
     if (options.required === false) {
       formSchema = formSchema.allow('').allow(null)

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -1,14 +1,14 @@
 import { type EmailAddressFieldComponent } from '@defra/forms-model'
 import joi from 'joi'
 
-import { TextField } from '~/src/server/plugins/engine/components/TextField.js'
+import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
   type FormSubmissionErrors
 } from '~/src/server/plugins/engine/types.js'
 
-export class EmailAddressField extends TextField {
+export class EmailAddressField extends FormComponent {
   declare options: EmailAddressFieldComponent['options']
   declare schema: EmailAddressFieldComponent['schema']
 

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -33,7 +33,7 @@ export class MonthYearField extends FormComponent {
           options: {
             required: isRequired,
             classes: 'govuk-input--width-2',
-            customValidationMessage: '{{label}} must be between 1 and 12'
+            customValidationMessage: '{{#label}} must be between 1 and 12'
           }
         },
         {

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -21,10 +21,6 @@ export class NumberField extends FormComponent {
 
     let formSchema = joi.number().label(title.toLowerCase())
 
-    if (typeof schema.min === 'number' && typeof schema.max === 'number') {
-      formSchema = formSchema.$
-    }
-
     if (typeof schema.min === 'number') {
       formSchema = formSchema.min(schema.min)
     }
@@ -34,8 +30,13 @@ export class NumberField extends FormComponent {
     }
 
     if (options.customValidationMessage) {
-      formSchema = formSchema.rule({
-        message: options.customValidationMessage
+      const message = options.customValidationMessage
+
+      formSchema = formSchema.messages({
+        'any.required': message,
+        'number.base': message,
+        'number.min': message,
+        'number.max': message
       })
     }
 

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -44,7 +44,7 @@ export class NumberField extends FormComponent {
       const optionalSchema = joi
         .alternatives<string | number>()
         .try(
-          joi.string().allow(null).allow('').default('').optional(),
+          joi.string().trim().allow(null).allow('').default('').optional(),
           formSchema
         )
 

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -9,7 +9,8 @@ import {
   type FormSubmissionErrors
 } from '~/src/server/plugins/engine/types.js'
 
-const PATTERN = /^[0-9\\\s+()-]*$/
+const PATTERN =
+  /\s*(([+](\s?\d)([-\s]?\d)|0)?(\s?\d)([-\s]?\d){9}|[(](\s?\d)([-\s]?\d)+\s*[)]([-\s]?\d)+)\s*/
 
 export class TelephoneNumberField extends FormComponent {
   declare options: TelephoneNumberFieldComponent['options']

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -22,7 +22,11 @@ export class TelephoneNumberField extends FormComponent {
 
     const { schema, options, title } = def
 
-    let formSchema = joi.string().label(title.toLowerCase()).pattern(PATTERN)
+    let formSchema = joi
+      .string()
+      .trim()
+      .label(title.toLowerCase())
+      .pattern(PATTERN)
 
     if (options.required === false) {
       formSchema = formSchema.allow('').allow(null)

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -10,7 +10,6 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 const PATTERN = /^[0-9\\\s+()-]*$/
-const DEFAULT_MESSAGE = 'Enter a telephone number in the correct format'
 
 export class TelephoneNumberField extends FormComponent {
   declare options: TelephoneNumberFieldComponent['options']
@@ -22,24 +21,20 @@ export class TelephoneNumberField extends FormComponent {
 
     const { schema, options, title } = def
 
-    const pattern = schema.regex ? new RegExp(schema.regex) : PATTERN
-    let formSchema = joi.string()
+    let formSchema = joi.string().label(title.toLowerCase()).pattern(PATTERN)
 
     if (options.required === false) {
       formSchema = formSchema.allow('').allow(null)
     }
 
-    formSchema = formSchema
-      .pattern(pattern)
-      .message(options.customValidationMessage ?? DEFAULT_MESSAGE)
-      .label(title.toLowerCase())
+    if (options.customValidationMessage) {
+      const message = options.customValidationMessage
 
-    if (typeof schema.max === 'number') {
-      formSchema = formSchema.max(schema.max)
-    }
-
-    if (typeof schema.min === 'number') {
-      formSchema = formSchema.min(schema.min)
+      formSchema = formSchema.messages({
+        'any.required': message,
+        'string.empty': message,
+        'string.pattern.base': message
+      })
     }
 
     addClassOptionIfNone(options, 'govuk-input--width-20')

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -9,8 +9,7 @@ import {
   type FormSubmissionErrors
 } from '~/src/server/plugins/engine/types.js'
 
-const PATTERN =
-  /\s*(([+](\s?\d)([-\s]?\d)|0)?(\s?\d)([-\s]?\d){9}|[(](\s?\d)([-\s]?\d)+\s*[)]([-\s]?\d)+)\s*/
+const PATTERN = /^[0-9\\\s+()-]*$/
 
 export class TelephoneNumberField extends FormComponent {
   declare options: TelephoneNumberFieldComponent['options']

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -30,19 +30,22 @@ export class TextField extends FormComponent {
 
     const { options, schema, title } = def
 
-    let formSchema = joi.string().trim().required()
+    let formSchema = joi.string().trim().label(title.toLowerCase()).required()
+
     if (options.required === false) {
       formSchema = formSchema.optional().allow('').allow(null)
     }
 
-    formSchema = formSchema.label(title.toLowerCase())
+    if (typeof schema.length !== 'number') {
+      if (typeof schema.max === 'number') {
+        formSchema = formSchema.max(schema.max)
+      }
 
-    if (typeof schema.max === 'number') {
-      formSchema = formSchema.max(schema.max)
-    }
-
-    if (typeof schema.min === 'number') {
-      formSchema = formSchema.min(schema.min)
+      if (typeof schema.min === 'number') {
+        formSchema = formSchema.min(schema.min)
+      }
+    } else {
+      formSchema = formSchema.length(schema.length)
     }
 
     if (schema.regex) {
@@ -51,8 +54,15 @@ export class TextField extends FormComponent {
     }
 
     if (options.customValidationMessage) {
+      const message = options.customValidationMessage
+
       formSchema = formSchema.messages({
-        any: options.customValidationMessage
+        'any.required': message,
+        'string.empty': message,
+        'string.max': message,
+        'string.min': message,
+        'string.length': message,
+        'string.pattern.base': message
       })
     }
 

--- a/test/cases/server/plugins/engine/TelephoneNumberField.test.ts
+++ b/test/cases/server/plugins/engine/TelephoneNumberField.test.ts
@@ -1,12 +1,13 @@
 import { ComponentType, type ComponentDef } from '@defra/forms-model'
 
 import { TelephoneNumberField } from '~/src/server/plugins/engine/components/index.js'
+import { validationOptions as opts } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 
 describe('Telephone number field', () => {
   test('Should supply custom validation message if defined', () => {
     const def: ComponentDef = {
       name: 'myComponent',
-      title: 'My component',
+      title: 'Telephone number',
       hint: 'a hint',
       type: ComponentType.TelephoneNumberField,
       options: {
@@ -18,48 +19,31 @@ describe('Telephone number field', () => {
     const telephoneNumberField = new TelephoneNumberField(def, {})
     const { formSchema: schema } = telephoneNumberField
 
-    expect(schema.validate('not a phone').error?.message).toBe(
+    expect(schema.validate('not a phone', opts).error?.message).toBe(
       'This is a custom error'
     )
-    expect(schema.validate('').error).toBeUndefined()
-    expect(schema.validate('+111-111-11').error).toBeUndefined()
-    expect(schema.validate('+111 111 11').error).toBeUndefined()
-    expect(schema.validate('+11111111').error).toBeUndefined()
+    expect(schema.validate('', opts).error).toBeUndefined()
+    expect(schema.validate('+111-111-11', opts).error?.message).toBe(
+      'This is a custom error'
+    )
+    expect(schema.validate('+111 111 11', opts).error?.message).toBe(
+      'This is a custom error'
+    )
+    expect(schema.validate('+11111111', opts).error?.message).toBe(
+      'This is a custom error'
+    )
+    expect(schema.validate('+44 7930 111 222', opts).error).toBeUndefined()
+    expect(schema.validate('07930 111 222', opts).error).toBeUndefined()
+    expect(schema.validate('01606 76543', opts).error).toBeUndefined()
+    expect(schema.validate('01606 765432', opts).error).toBeUndefined()
+    expect(schema.validate('0203 765 443', opts).error).toBeUndefined()
+    expect(schema.validate('0800 123 321', opts).error).toBeUndefined()
   })
 
   test('Should validate when schema options are supplied', () => {
     const def: ComponentDef = {
       name: 'myComponent',
-      title: 'My component',
-      hint: 'a hint',
-      type: ComponentType.TelephoneNumberField,
-      options: {},
-      schema: {
-        min: 3,
-        max: 5,
-        regex: '^[0-9+()]*$'
-      }
-    }
-    const telephoneNumberField = new TelephoneNumberField(def, {})
-    const { formSchema: schema } = telephoneNumberField
-
-    expect(schema.validate('1234').error).toBeUndefined()
-    expect(schema.validate('12345').error).toBeUndefined()
-    expect(schema.validate('1').error?.message).toContain(
-      'must be at least 3 characters long'
-    )
-    expect(schema.validate('12-3').error?.message).toContain(
-      'Enter a telephone number in the correct format'
-    )
-    expect(schema.validate('1  1').error?.message).toContain(
-      'Enter a telephone number in the correct format'
-    )
-  })
-
-  test('Should apply default schema if no options are passed', () => {
-    const def: ComponentDef = {
-      name: 'myComponent',
-      title: 'My component',
+      title: 'Telephone number',
       hint: 'a hint',
       type: ComponentType.TelephoneNumberField,
       options: {},
@@ -68,8 +52,37 @@ describe('Telephone number field', () => {
     const telephoneNumberField = new TelephoneNumberField(def, {})
     const { formSchema: schema } = telephoneNumberField
 
-    expect(schema.validate('not a phone').error?.message).toBe(
-      'Enter a telephone number in the correct format'
+    expect(schema.validate('1234', opts).error?.message).toBe(
+      'Enter a valid telephone number'
+    )
+    expect(schema.validate('12345', opts).error?.message).toBe(
+      'Enter a valid telephone number'
+    )
+    expect(schema.validate('1', opts).error?.message).toBe(
+      'Enter a valid telephone number'
+    )
+    expect(schema.validate('12-3', opts).error?.message).toBe(
+      'Enter a valid telephone number'
+    )
+    expect(schema.validate('1  1', opts).error?.message).toBe(
+      'Enter a valid telephone number'
+    )
+  })
+
+  test('Should apply default schema if no options are passed', () => {
+    const def: ComponentDef = {
+      name: 'myComponent',
+      title: 'Telephone number',
+      hint: 'a hint',
+      type: ComponentType.TelephoneNumberField,
+      options: {},
+      schema: {}
+    }
+    const telephoneNumberField = new TelephoneNumberField(def, {})
+    const { formSchema: schema } = telephoneNumberField
+
+    expect(schema.validate('not a phone', opts).error?.message).toBe(
+      'Enter a valid telephone number'
     )
   })
   test("Should add 'tel' to the autocomplete attribute", () => {

--- a/test/cases/server/plugins/engine/TelephoneNumberField.test.ts
+++ b/test/cases/server/plugins/engine/TelephoneNumberField.test.ts
@@ -38,6 +38,12 @@ describe('Telephone number field', () => {
     expect(schema.validate('01606 765432', opts).error).toBeUndefined()
     expect(schema.validate('0203 765 443', opts).error).toBeUndefined()
     expect(schema.validate('0800 123 321', opts).error).toBeUndefined()
+    expect(schema.validate('(01606) 765432', opts).error).toBeUndefined()
+    expect(schema.validate('(01606) 765-432', opts).error).toBeUndefined()
+    expect(schema.validate('01606 765-432', opts).error).toBeUndefined()
+    expect(schema.validate('+44203-765-443', opts).error).toBeUndefined()
+    expect(schema.validate('0800123-321', opts).error).toBeUndefined()
+    expect(schema.validate('0800-123-321', opts).error).toBeUndefined()
   })
 
   test('Should validate when schema options are supplied', () => {

--- a/test/cases/server/plugins/engine/TelephoneNumberField.test.ts
+++ b/test/cases/server/plugins/engine/TelephoneNumberField.test.ts
@@ -23,15 +23,9 @@ describe('Telephone number field', () => {
       'This is a custom error'
     )
     expect(schema.validate('', opts).error).toBeUndefined()
-    expect(schema.validate('+111-111-11', opts).error?.message).toBe(
-      'This is a custom error'
-    )
-    expect(schema.validate('+111 111 11', opts).error?.message).toBe(
-      'This is a custom error'
-    )
-    expect(schema.validate('+11111111', opts).error?.message).toBe(
-      'This is a custom error'
-    )
+    expect(schema.validate('+111-111-11', opts).error?.message).toBeUndefined()
+    expect(schema.validate('+111 111 11', opts).error?.message).toBeUndefined()
+    expect(schema.validate('+11111111', opts).error?.message).toBeUndefined()
     expect(schema.validate('+44 7930 111 222', opts).error).toBeUndefined()
     expect(schema.validate('07930 111 222', opts).error).toBeUndefined()
     expect(schema.validate('01606 76543', opts).error).toBeUndefined()
@@ -58,21 +52,11 @@ describe('Telephone number field', () => {
     const telephoneNumberField = new TelephoneNumberField(def, {})
     const { formSchema: schema } = telephoneNumberField
 
-    expect(schema.validate('1234', opts).error?.message).toBe(
-      'Enter a valid telephone number'
-    )
-    expect(schema.validate('12345', opts).error?.message).toBe(
-      'Enter a valid telephone number'
-    )
-    expect(schema.validate('1', opts).error?.message).toBe(
-      'Enter a valid telephone number'
-    )
-    expect(schema.validate('12-3', opts).error?.message).toBe(
-      'Enter a valid telephone number'
-    )
-    expect(schema.validate('1  1', opts).error?.message).toBe(
-      'Enter a valid telephone number'
-    )
+    expect(schema.validate('1234', opts).error?.message).toBeUndefined()
+    expect(schema.validate('12345', opts).error?.message).toBeUndefined()
+    expect(schema.validate('1', opts).error?.message).toBeUndefined()
+    expect(schema.validate('12-3', opts).error?.message).toBeUndefined()
+    expect(schema.validate('1  1', opts).error?.message).toBeUndefined()
   })
 
   test('Should apply default schema if no options are passed', () => {


### PR DESCRIPTION
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/398579#18941354

- When a `customValidationMessage` is set for Email, Text, TextArea, Number and Telephone components, the message should be used for any errors for the component
