### PR TITLE
Fix checkboxes field allowing unknown values, missing label

### DIFF
--- a/src/server/plugins/engine/components/CheckboxesField.test.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.test.ts
@@ -1,101 +1,248 @@
 import {
   ComponentType,
-  type ComponentDef,
-  type FormDefinition
+  type FormDefinition,
+  type List,
+  type CheckboxesFieldComponent
 } from '@defra/forms-model'
 
 import { CheckboxesField } from '~/src/server/plugins/engine/components/CheckboxesField.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import { validationOptions as opts } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 
 describe('CheckboxesField', () => {
-  const lists: FormDefinition['lists'] = [
-    {
-      name: 'numberOfApplicants',
-      title: 'Number of people',
-      type: 'number',
-      items: [
-        {
-          text: '1',
-          value: 1,
-          description: '',
-          condition: ''
-        },
-        {
-          text: '2',
-          value: 2,
-          description: '',
-          condition: ''
-        },
-        {
-          text: '3',
-          value: 3,
-          description: '',
-          condition: ''
-        },
-        {
-          text: '4',
-          value: 4,
-          description: '',
-          condition: ''
-        }
-      ]
-    }
-  ]
+  const list = {
+    title: 'Example number list',
+    name: 'listNumber',
+    type: 'number',
+    items: [
+      { text: '1 point', value: 1 },
+      { text: '2 points', value: 2 },
+      { text: '3 points', value: 3 },
+      { text: '4 points', value: 4 }
+    ]
+  } satisfies List
 
-  describe('Generated schema', () => {
-    const componentDefinition: ComponentDef = {
+  const definition = {
+    pages: [],
+    lists: [list],
+    sections: [],
+    conditions: []
+  } satisfies FormDefinition
+
+  let def: CheckboxesFieldComponent
+  let formModel: FormModel
+  let component: CheckboxesField
+  let label: string
+  let allow: number[]
+
+  beforeEach(() => {
+    def = {
+      title: 'Example checkboxes',
+      name: 'myComponent',
       type: ComponentType.CheckboxesField,
-      name: 'myCheckbox',
-      title: 'Tada',
+      list: 'listNumber',
       options: {},
-      list: 'numberOfApplicants',
       schema: {}
-    }
-    const formModel = {
-      getList: () => lists[0],
-      makePage: () => jest.fn()
-    }
-    const component = new CheckboxesField(componentDefinition, formModel)
+    } satisfies CheckboxesFieldComponent
+
+    formModel = new FormModel(definition, {
+      basePath: 'test'
+    })
+
+    component = new CheckboxesField(def, formModel)
+    label = def.title.toLowerCase()
+    allow = [1, 2, 3, 4]
+  })
+
+  describe('Schema', () => {
+    it('uses component title as label', () => {
+      const { formSchema } = component
+
+      expect(formSchema.describe().flags).toEqual(
+        expect.objectContaining({ label })
+      )
+    })
 
     it('is required by default', () => {
-      expect(component.formSchema.describe().flags).toEqual(
+      const { formSchema } = component
+
+      expect(formSchema.describe().flags).toEqual(
         expect.objectContaining({
           presence: 'required'
         })
       )
     })
-    it('allows the items defined in the List object with the correct type', () => {
-      expect(component.formSchema.describe().items).toEqual(
-        expect.arrayContaining([
-          {
-            type: 'number',
-            allow: [1, 2, 3, 4]
-          }
-        ])
+
+    it('is optional when configured', () => {
+      const componentOptional = new CheckboxesField(
+        { ...def, options: { required: false } },
+        formModel
       )
+
+      const { formSchema } = componentOptional
+
+      expect(formSchema.describe().flags).not.toEqual(
+        expect.objectContaining({
+          presence: 'required'
+        })
+      )
+
+      const result = formSchema.validate(undefined, opts)
+      expect(result.error).toBeUndefined()
     })
-    it('allows single answers', () => {
-      expect(component.formSchema.describe().flags).toEqual(
+
+    it('is configured for single values', () => {
+      const { formSchema } = component
+
+      expect(formSchema.describe().flags).toEqual(
         expect.objectContaining({
           single: true
         })
       )
     })
-    it('is not required when explicitly configured', () => {
-      const component = new CheckboxesField(
-        {
-          ...componentDefinition,
-          options: { required: false }
-        },
-        formModel
-      )
-      expect(component.formSchema.describe().flags).not.toEqual(
+
+    it('is configured with checkbox items', () => {
+      const { formSchema } = component
+
+      expect(formSchema.describe()).toEqual(
         expect.objectContaining({
-          presence: 'required'
+          items: [
+            {
+              allow,
+              flags: {
+                label,
+                only: true
+              },
+              type: 'number'
+            }
+          ]
         })
       )
     })
-    it('validates correctly', () => {
-      expect(component.formSchema.validate({}).error).toBeTruthy()
+
+    it('accepts valid checkbox single value', () => {
+      const { formSchema } = component
+
+      const result = formSchema.validate(1, opts)
+      expect(result.error).toBeUndefined()
+    })
+
+    it('accepts valid checkbox multiple values', () => {
+      const { formSchema } = component
+
+      const result = formSchema.validate([1, 3], opts)
+      expect(result.error).toBeUndefined()
+    })
+
+    it('adds errors for empty value', () => {
+      const { formSchema } = component
+
+      const result = formSchema.validate(undefined, opts)
+
+      expect(result.error).toEqual(
+        expect.objectContaining({
+          message: `Select ${label}`
+        })
+      )
+    })
+
+    it('adds errors for single unknown value', () => {
+      const { formSchema } = component
+
+      const result = formSchema.validate(8, opts)
+
+      expect(result.error).toEqual(
+        expect.objectContaining({
+          message: `Select ${label}`
+        })
+      )
+    })
+
+    it('adds errors for multiple unknown values', () => {
+      const { formSchema } = component
+
+      const result = formSchema.validate([8, 9], opts)
+
+      expect(result.error).toEqual(
+        expect.objectContaining({
+          message: `Select ${label}`
+        })
+      )
+    })
+
+    it('adds errors for invalid values', () => {
+      const { formSchema } = component
+
+      const result1 = formSchema.validate('invalid', opts)
+      const result2 = formSchema.validate(['invalid1', 'invalid2'], opts)
+      const result3 = formSchema.validate({ unknown: 'invalid' }, opts)
+
+      const message = expect.stringMatching(`^Select ${label}`)
+
+      expect(result1.error).toEqual(expect.objectContaining({ message }))
+      expect(result2.error).toEqual(expect.objectContaining({ message }))
+      expect(result3.error).toEqual(expect.objectContaining({ message }))
+    })
+  })
+
+  describe('State', () => {
+    it('Returns text from single state value', () => {
+      const text = component.getDisplayStringFromState({
+        [def.name]: [1]
+      })
+
+      expect(text).toBe('1 point')
+    })
+
+    it('Returns text from multiple state values', () => {
+      const text = component.getDisplayStringFromState({
+        [def.name]: [1, 3]
+      })
+
+      expect(text).toBe('1 point, 3 points')
+    })
+  })
+
+  describe('View model', () => {
+    const items = [
+      {
+        text: '1 point',
+        value: '1',
+        state: 1
+      }
+    ]
+
+    it('sets Nunjucks component defaults', () => {
+      const item = items[0]
+
+      const viewModel = component.getViewModel({
+        [def.name]: item.value
+      })
+
+      expect(viewModel).toEqual(
+        expect.objectContaining({
+          label: { text: def.title },
+          name: 'myComponent',
+          id: 'myComponent',
+          value: item.value
+        })
+      )
+    })
+
+    it.each([...items])('sets Nunjucks component checkbox items', (item) => {
+      const viewModel = component.getViewModel({
+        [def.name]: item.value
+      })
+
+      expect(viewModel.items).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            text: item.text,
+            value: item.value,
+            checked: true
+          })
+        ])
+      )
     })
   })
 })

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -26,10 +26,10 @@ export class CheckboxesField extends SelectionControlField {
       // null or empty string is valid for optional fields
       formSchema = formSchema
         .empty(null)
-        .items(joi[this.listType]().allow(...this.values, ''))
+        .items(joi[this.listType]().valid(...this.values, ''))
     } else {
       formSchema = formSchema
-        .items(joi[this.listType]().allow(...this.values))
+        .items(joi[this.listType]().valid(...this.values))
         .required()
     }
 

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -21,16 +21,15 @@ export class CheckboxesField extends SelectionControlField {
     const { options, schema, title } = def
 
     let formSchema = joi.array<string>().single().label(title.toLowerCase())
+    const listSchema = joi[this.listType]().label(title.toLowerCase())
 
     if (options.required === false) {
       // null or empty string is valid for optional fields
       formSchema = formSchema
         .empty(null)
-        .items(joi[this.listType]().valid(...this.values, ''))
+        .items(listSchema.valid(...this.values, ''))
     } else {
-      formSchema = formSchema
-        .items(joi[this.listType]().valid(...this.values))
-        .required()
+      formSchema = formSchema.items(listSchema.valid(...this.values)).required()
     }
 
     this.formSchema = formSchema


### PR DESCRIPTION
This PR expands all the tests for `CheckboxesField` and fixes two new bugs:

1. Prevent unknown list values using `.valid()` versus `allow()`
2. Add missing label to checkboxes list schema used by `.items()`