### PR TITLE
Add expanded tests for `TextField`

### DIFF
--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -1,106 +1,284 @@
-import { ComponentType, type ComponentDef } from '@defra/forms-model'
+import {
+  ComponentType,
+  type FormDefinition,
+  type TextFieldComponent
+} from '@defra/forms-model'
 
 import { TextField } from '~/src/server/plugins/engine/components/TextField.js'
-import { messages } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import { validationOptions as opts } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 
-describe('TextField', () => {
-  describe('Generated schema', () => {
-    const componentDefinition: ComponentDef = {
-      title: "What's your first name?",
-      name: 'firstName',
-      type: ComponentType.TextField,
-      options: {
-        autocomplete: 'given-name'
+describe('TextFieldComponent', () => {
+  const definition = {
+    pages: [],
+    lists: [],
+    sections: [],
+    conditions: []
+  } satisfies FormDefinition
+
+  let formModel: FormModel
+
+  beforeEach(() => {
+    formModel = new FormModel(definition, {
+      basePath: 'test'
+    })
+  })
+
+  describe('Defaults', () => {
+    let def: TextFieldComponent
+    let component: TextField
+    let label: string
+
+    beforeEach(() => {
+      def = {
+        title: 'Example text field',
+        name: 'myComponent',
+        type: ComponentType.TextField,
+        options: {},
+        schema: {}
+      } satisfies TextFieldComponent
+
+      component = new TextField(def, formModel)
+      label = def.title.toLowerCase()
+    })
+
+    describe('Schema', () => {
+      it('uses component title as label', () => {
+        const { formSchema } = component
+
+        expect(formSchema.describe().flags).toEqual(
+          expect.objectContaining({ label })
+        )
+      })
+
+      it('is required by default', () => {
+        const { formSchema } = component
+
+        expect(formSchema.describe().flags).toEqual(
+          expect.objectContaining({
+            presence: 'required'
+          })
+        )
+      })
+
+      it('is optional when configured', () => {
+        const componentOptional = new TextField(
+          { ...def, options: { required: false } },
+          formModel
+        )
+
+        const { formSchema } = componentOptional
+
+        expect(formSchema.describe().flags).toEqual(
+          expect.objectContaining({
+            presence: 'optional'
+          })
+        )
+
+        const result = formSchema.validate(undefined, opts)
+        expect(result.error).toBeUndefined()
+      })
+
+      it('accepts valid values', () => {
+        const { formSchema } = component
+
+        const result1 = formSchema.validate('Text', opts)
+        const result2 = formSchema.validate('Text field', opts)
+
+        expect(result1.error).toBeUndefined()
+        expect(result2.error).toBeUndefined()
+      })
+
+      it('adds errors for empty value', () => {
+        const { formSchema } = component
+
+        const result = formSchema.validate('', opts)
+
+        expect(result.error).toEqual(
+          expect.objectContaining({
+            message: `Enter ${label}`
+          })
+        )
+      })
+
+      it('adds errors for invalid values', () => {
+        const { formSchema } = component
+
+        const result1 = formSchema.validate(['invalid'], opts)
+        const result2 = formSchema.validate({ unknown: 'invalid' }, opts)
+
+        expect(result1.error).toBeTruthy()
+        expect(result2.error).toBeTruthy()
+      })
+    })
+
+    describe('State', () => {
+      it('Returns text from state value', () => {
+        const text = component.getDisplayStringFromState({
+          [def.name]: 'Text field'
+        })
+
+        expect(text).toBe('Text field')
+      })
+    })
+
+    describe('View model', () => {
+      it('sets Nunjucks component defaults', () => {
+        const viewModel = component.getViewModel({
+          [def.name]: 'Text field'
+        })
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            label: { text: def.title },
+            name: 'myComponent',
+            id: 'myComponent',
+            value: 'Text field'
+          })
+        )
+      })
+    })
+  })
+
+  describe('Validation', () => {
+    describe.each([
+      {
+        description: 'Trim empty spaces',
+        component: {
+          title: 'Example text field',
+          name: 'myComponent',
+          type: ComponentType.TextField,
+          options: {},
+          schema: {}
+        } satisfies TextFieldComponent,
+        assertions: [
+          {
+            input: '  Leading spaces',
+            output: { value: 'Leading spaces' }
+          },
+          {
+            input: 'Trailing spaces  ',
+            output: { value: 'Trailing spaces' }
+          },
+          {
+            input: '  Mixed spaces and new lines \n\n',
+            output: { value: 'Mixed spaces and new lines' }
+          }
+        ]
       },
-      schema: {}
-    }
+      {
+        description: 'Schema min and max',
+        component: {
+          title: 'Example text field',
+          name: 'myComponent',
+          type: ComponentType.TextField,
+          options: {},
+          schema: {
+            min: 5,
+            max: 8
+          }
+        } satisfies TextFieldComponent,
+        assertions: [
+          {
+            input: 'Text',
+            output: {
+              value: 'Text',
+              error: new Error(
+                'example text field must be 5 characters or more'
+              )
+            }
+          },
+          {
+            input: 'Text field',
+            output: {
+              value: 'Text field',
+              error: new Error(
+                'example text field must be 8 characters or less'
+              )
+            }
+          }
+        ]
+      },
+      {
+        description: 'Schema length',
+        component: {
+          title: 'Example text field',
+          name: 'myComponent',
+          type: ComponentType.TextField,
+          options: {},
+          schema: {
+            length: 4
+          }
+        } satisfies TextFieldComponent,
+        assertions: [
+          {
+            input: 'Text',
+            output: { value: 'Text' }
+          },
+          {
+            input: 'Text field',
+            output: {
+              value: 'Text field',
+              error: new Error(
+                'example text field length must be 4 characters long'
+              )
+            }
+          }
+        ]
+      },
+      {
+        description: 'Schema regex',
+        component: {
+          title: 'Example text field',
+          name: 'myComponent',
+          type: ComponentType.TextField,
+          options: {},
+          schema: {
+            regex: '^[a-zA-Z]{1,2}\\d[a-zA-Z\\d]?\\s?\\d[a-zA-Z]{2}$'
+          }
+        } satisfies TextFieldComponent,
+        assertions: [
+          {
+            input: 'SW1P',
+            output: {
+              value: 'SW1P',
+              error: new Error('Enter a valid example text field')
+            }
+          },
+          {
+            input: 'SW1P 4DF',
+            output: { value: 'SW1P 4DF' }
+          }
+        ]
+      }
+    ])('$description', ({ component: def, assertions }) => {
+      let component: TextField
+      let label: string
 
-    const formModel = {
-      makePage: () => jest.fn()
-    }
-
-    const component = new TextField(componentDefinition, formModel)
-
-    it('is required by default', () => {
-      expect(component.formSchema.describe().flags).toEqual(
-        expect.objectContaining({
-          presence: 'required'
-        })
-      )
-    })
-
-    it('is not required when explicitly configured', () => {
-      const component = TextComponent({ options: { required: false } })
-
-      expect(component.formSchema.describe().flags).toEqual(
-        expect.objectContaining({
-          presence: 'optional'
-        })
-      )
-    })
-
-    it('validates correctly', () => {
-      expect(component.formSchema.validate({}).error).toBeTruthy()
-    })
-
-    it('should match pattern for regex', () => {
-      let component = TextComponent({ schema: { regex: '[abc]*' } })
-
-      expect(component.formSchema.validate('ab', { messages })).toEqual({
-        value: 'ab'
+      beforeEach(() => {
+        component = new TextField(def, formModel)
+        label = def.title.toLowerCase()
       })
 
-      component = TextComponent({ schema: { regex: null } })
+      it('validates empty value', () => {
+        const { formSchema } = component
 
-      expect(component.formSchema.validate('*', { messages })).toEqual({
-        value: '*'
-      })
-
-      component = TextComponent({ schema: { regex: undefined } })
-
-      expect(component.formSchema.validate('/', { messages })).toEqual({
-        value: '/'
-      })
-
-      component = TextComponent({ schema: { regex: '' } })
-
-      expect(component.formSchema.validate('', { messages })).not.toEqual({
-        value: ''
-      })
-
-      component = TextComponent({
-        schema: {
-          regex: '[A-Z]{1,2}[0-9]{1,2} ?[0-9][A-Z]{2}',
-          min: 5,
-          max: 10
+        const input = ''
+        const output = {
+          value: '',
+          error: new Error(`Enter ${label}`)
         }
+
+        const result = formSchema.validate(input, opts)
+        expect(result).toEqual(output)
       })
 
-      expect(component.formSchema.validate('AJ98 7AX', { messages })).toEqual({
-        value: 'AJ98 7AX'
+      it.each(assertions)('validates custom example', ({ input, output }) => {
+        const { formSchema } = component
+
+        const result = formSchema.validate(input, opts)
+        expect(result).toEqual(output)
       })
-
-      const invalidRegexResult = component.formSchema.validate('###six')
-      expect(invalidRegexResult.error.details[0].type).toBe(
-        'string.pattern.base'
-      )
-
-      const tooFewCharsResult = component.formSchema.validate('AJ98')
-      expect(tooFewCharsResult.error.details[0].type).toBe('string.min')
-
-      const tooManyCharsResult =
-        component.formSchema.validate('AJ98 7AXAJ98 7AX')
-      expect(tooManyCharsResult.error.details[0].type).toBe('string.max')
     })
-
-    function TextComponent(properties) {
-      return new TextField(
-        {
-          ...componentDefinition,
-          ...properties
-        },
-        formModel
-      )
-    }
   })
 })


### PR DESCRIPTION
Increases test coverage for the text input field, with examples:

* Trim empty spaces
* Schema min and max
* Schema length

Where the previous tests only included optional/required + regex checks