### PR TITLE
Prevent date field showing error messages from other fields

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -7,7 +7,7 @@ describe('Date parts field', () => {
     const def: ComponentDef = {
       name: 'myComponent',
       title: 'My component',
-      type: ComponentType.TextField,
+      type: ComponentType.DatePartsField,
       options: {},
       schema: {}
     }
@@ -32,7 +32,7 @@ describe('Date parts field', () => {
     const def: ComponentDef = {
       name: 'myComponent',
       title: 'My component',
-      type: ComponentType.TextField,
+      type: ComponentType.DatePartsField,
       options: { required: false },
       schema: {}
     }
@@ -66,16 +66,16 @@ describe('Date parts field', () => {
       titleText: 'There is a problem',
       errorList: [
         {
-          path: 'approximate__day',
-          href: '#approximate__day',
-          name: 'approximate__day',
-          text: '"Day" must be a number'
+          path: 'myComponent__day',
+          href: '#myComponent__day',
+          name: 'myComponent__day',
+          text: 'Day must be a number'
         }
       ]
     }
     const underTest = new DatePartsField(def)
     const returned = underTest.getViewModel({}, errors)
-    expect(returned.errorMessage.text).toBe('"Day" must be a number')
+    expect(returned.errorMessage?.text).toBe('Day must be a number')
     expect(underTest.getViewModel({}).errorMessage).toBeUndefined()
   })
 })

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -131,10 +131,12 @@ export class DatePartsField extends FormComponent {
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {
+    const { children, name } = this
+
     const viewModel = super.getViewModel(payload, errors)
 
     // Use the component collection to generate the subitems
-    const componentViewModels = this.children
+    const componentViewModels = children
       .getViewModel(payload, errors)
       .map((vm) => vm.model)
 
@@ -151,8 +153,14 @@ export class DatePartsField extends FormComponent {
       }
     })
 
-    const firstError = errors?.errorList[0]
-    const errorMessage = firstError && { text: firstError.text }
+    // Filter errors for this component only
+    const componentErrors = errors?.errorList.filter(
+      (error) => error.name.startsWith(`${name}__`) // E.g. `${name}__year`
+    )
+
+    const errorMessage = componentErrors?.[0] && {
+      text: componentErrors[0].text
+    }
 
     let { fieldset, label } = viewModel
 

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -88,7 +88,7 @@ export class MonthYearField extends FormComponent {
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {
-    const { children } = this
+    const { children, name } = this
 
     const viewModel = super.getViewModel(payload, errors)
 
@@ -110,6 +110,15 @@ export class MonthYearField extends FormComponent {
       }
     })
 
+    // Filter errors for this component only
+    const componentErrors = errors?.errorList.filter(
+      (error) => error.name.startsWith(`${name}__`) // E.g. `${name}__year`
+    )
+
+    const errorMessage = componentErrors?.[0] && {
+      text: componentErrors[0].text
+    }
+
     let { fieldset, label } = viewModel
 
     fieldset ??= {
@@ -121,6 +130,7 @@ export class MonthYearField extends FormComponent {
 
     return {
       ...viewModel,
+      errorMessage,
       fieldset,
       items: componentViewModels
     }


### PR DESCRIPTION
This PR fixes [bug #415548](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/415548)

Two parts are resolved in the same related bug:

1. Date fields (incorrectly) show the first field's error message
2. Month & year fields (incorrectly) omit the error message and red border

# Part 1: Date fields
Only shows the first field's error message

<img width="695" alt="Incorrect error message" src="https://github.com/user-attachments/assets/b8bb10b2-637e-4ce3-a872-a63f03ce31db">

# Part 1: Month & year fields
No error message or red left border is displayed

## Before

<img width="232" alt="Before" src="https://github.com/user-attachments/assets/d533f3c3-08e7-4a8c-8663-d31de23bfa8b">

## After

<img width="354" alt="After" src="https://github.com/user-attachments/assets/f59aed7d-f26e-463b-80c8-6870806adf2f">
