### PR TITLE
Ensure request logger only logs errors in development

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -159,7 +159,7 @@ export const config = convict({
   logLevel: {
     doc: 'Logging level',
     format: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
-    default: 'info',
+    default: process.env.NODE_ENV === 'development' ? 'error' : 'info',
     env: 'LOG_LEVEL'
   },
 


### PR DESCRIPTION
This PR applies change already made in **forms-designer** via https://github.com/DEFRA/forms-designer/commit/c2ba33671e2bce7951e9929744ff99a028346cc8

To reduce noise, only errors will be logged via `npm run dev`

But when necessary `LOG_LEVEL` can be set using:

```console
LOG_LEVEL=info npm run dev
```