### PR TITLE
Transform dates to yyyy-MM-dd before evaluating conditions

### DIFF
--- a/src/server/forms/date-branching.json
+++ b/src/server/forms/date-branching.json
@@ -1,0 +1,85 @@
+{
+  "name": "Date condition test",
+  "startPage": "/page-one",
+  "pages": [
+    {
+      "path": "/page-one",
+      "title": "Page one",
+      "components": [
+        {
+          "name": "BWvMaM",
+          "title": "Date field",
+          "type": "DatePartsField",
+          "hint": "",
+          "options": {},
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/is-not-2024-08-01"
+        },
+        {
+          "path": "/is-2024-08-01",
+          "condition": "RVtgRf"
+        }
+      ]
+    },
+    {
+      "title": "Is not 2024-08-01",
+      "path": "/is-not-2024-08-01",
+      "controller": "SummaryPageController",
+      "components": [],
+      "next": []
+    },
+    {
+      "path": "/is-2024-08-01",
+      "title": "Is 2024-08-01",
+      "components": [],
+      "next": []
+    }
+  ],
+  "conditions": [
+    {
+      "name": "RVtgRf",
+      "displayName": "Is 2024-08-01",
+      "value": {
+        "name": "Is 2024-08-01",
+        "conditions": [
+          {
+            "field": {
+              "name": "BWvMaM",
+              "type": "DatePartsField",
+              "display": "Date field"
+            },
+            "operator": "is",
+            "value": {
+              "type": "Value",
+              "value": "2024-08-01",
+              "display": "2024-08-01"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "sections": [],
+  "lists": [
+    {
+      "title": "test",
+      "name": "iwXEkZ",
+      "type": "string",
+      "items": [
+        {
+          "text": "foo",
+          "value": "foo"
+        },
+        {
+          "text": "bar",
+          "value": "bar"
+        }
+      ]
+    }
+  ],
+  "skipSummary": false
+}

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -1,9 +1,25 @@
 import { ComponentType, type ComponentDef } from '@defra/forms-model'
 
 import { DatePartsField } from '~/src/server/plugins/engine/components/DatePartsField.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import { type FormDefinition } from '~/src/server/plugins/engine/services/formsService.js'
+
+
 
 describe('Date parts field', () => {
+  let formModel: FormModel
+
+  beforeEach(() => {
+    const definition: FormDefinition = {
+      pages: [],
+      lists: [],
+      sections: [],
+      conditions: []
+    }
+
+    formModel = new FormModel(definition, { basePath: '' })
+  })
+
   test('Should construct appropriate children when required', () => {
     const def: ComponentDef = {
       name: 'myComponent',
@@ -13,7 +29,7 @@ describe('Date parts field', () => {
       schema: {}
     }
 
-    const underTest = new DatePartsField(def, {} as FormModel) // FormModel param not required for testing
+    const underTest = new DatePartsField(def, formModel)
     const returned = underTest.getViewModel({})
 
     expect(returned.fieldset).toEqual({
@@ -38,7 +54,7 @@ describe('Date parts field', () => {
       schema: {}
     }
 
-    const underTest = new DatePartsField(def, {} as FormModel) // FormModel param not required for testing
+    const underTest = new DatePartsField(def, formModel)
     const returned = underTest.getViewModel({})
 
     expect(returned.fieldset).toEqual({
@@ -75,7 +91,7 @@ describe('Date parts field', () => {
       ]
     }
 
-    const underTest = new DatePartsField(def, {} as FormModel)
+    const underTest = new DatePartsField(def, formModel)
     const returned = underTest.getViewModel({}, errors)
     expect(returned.errorMessage?.text).toBe('Day must be a number')
     expect(underTest.getViewModel({}).errorMessage).toBeUndefined()
@@ -89,10 +105,7 @@ describe('Date parts field', () => {
       schema: {}
     }
 
-    const underTest = new DatePartsField(
-      datePartsFieldComponent,
-      {} as FormModel // FormModel param not required for testing
-    )
+    const underTest = new DatePartsField(datePartsFieldComponent, formModel)
 
     const conditonEvaluationStateValue =
       underTest.getConditionEvaluationStateValue({

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -1,4 +1,10 @@
-import { ComponentType, type ComponentDef } from '@defra/forms-model'
+import {
+  ComponentType,
+  type DatePartsFieldFieldComponent,
+  type ComponentDef
+} from '@defra/forms-model'
+
+import { type FormModel } from '../models/FormModel.js'
 
 import { DatePartsField } from '~/src/server/plugins/engine/components/DatePartsField.js'
 
@@ -12,7 +18,7 @@ describe('Date parts field', () => {
       schema: {}
     }
 
-    const underTest = new DatePartsField(def, {})
+    const underTest = new DatePartsField(def, {} as FormModel) // FormModel param not required for testing
     const returned = underTest.getViewModel({})
 
     expect(returned.fieldset).toEqual({
@@ -37,7 +43,7 @@ describe('Date parts field', () => {
       schema: {}
     }
 
-    const underTest = new DatePartsField(def, {})
+    const underTest = new DatePartsField(def, {} as FormModel) // FormModel param not required for testing
     const returned = underTest.getViewModel({})
 
     expect(returned.fieldset).toEqual({
@@ -73,10 +79,32 @@ describe('Date parts field', () => {
         }
       ]
     }
-    const underTest = new DatePartsField(def)
+
+    const underTest = new DatePartsField(def, {} as FormModel)
     const returned = underTest.getViewModel({}, errors)
     expect(returned.errorMessage?.text).toBe('Day must be a number')
     expect(underTest.getViewModel({}).errorMessage).toBeUndefined()
+  })
+  test('Condition evaluation used yyyy-MM-dd format', () => {
+    const datePartsFieldComponent = {
+      title: 'Example checkboxes',
+      name: 'myComponent',
+      type: ComponentType.DatePartsField,
+      options: {},
+      schema: {}
+    } satisfies DatePartsFieldFieldComponent
+
+    const underTest = new DatePartsField(
+      datePartsFieldComponent,
+      {} as FormModel // FormModel param not required for testing
+    )
+
+    const conditonEvaluationStateValue =
+      underTest.getConditionEvaluationStateValue({
+        myComponent: '2024-12-31T01:02:03.004Z'
+      })
+
+    expect(conditonEvaluationStateValue).toBe('2024-12-31')
   })
 })
 

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -4,8 +4,6 @@ import { DatePartsField } from '~/src/server/plugins/engine/components/DateParts
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { type FormDefinition } from '~/src/server/plugins/engine/services/formsService.js'
 
-
-
 describe('Date parts field', () => {
   let formModel: FormModel
 

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -4,9 +4,9 @@ import {
   type ComponentDef
 } from '@defra/forms-model'
 
-import { type FormModel } from '../models/FormModel.js'
-
 import { DatePartsField } from '~/src/server/plugins/engine/components/DatePartsField.js'
+import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+
 
 describe('Date parts field', () => {
   test('Should construct appropriate children when required', () => {

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -1,12 +1,7 @@
-import {
-  ComponentType,
-  type DatePartsFieldFieldComponent,
-  type ComponentDef
-} from '@defra/forms-model'
+import { ComponentType, type ComponentDef } from '@defra/forms-model'
 
 import { DatePartsField } from '~/src/server/plugins/engine/components/DatePartsField.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
-
 
 describe('Date parts field', () => {
   test('Should construct appropriate children when required', () => {
@@ -86,13 +81,13 @@ describe('Date parts field', () => {
     expect(underTest.getViewModel({}).errorMessage).toBeUndefined()
   })
   test('Condition evaluation used yyyy-MM-dd format', () => {
-    const datePartsFieldComponent = {
+    const datePartsFieldComponent: ComponentDef = {
       title: 'Example checkboxes',
       name: 'myComponent',
       type: ComponentType.DatePartsField,
       options: {},
       schema: {}
-    } satisfies DatePartsFieldFieldComponent
+    }
 
     const underTest = new DatePartsField(
       datePartsFieldComponent,

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -15,7 +15,9 @@ describe('Date parts field', () => {
       conditions: []
     }
 
-    formModel = new FormModel(definition, { basePath: '' })
+    formModel = new FormModel(definition, {
+      basePath: 'test'
+    })
   })
 
   test('Should construct appropriate children when required', () => {

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -125,9 +125,13 @@ export class DatePartsField extends FormComponent {
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {
-    const name = this.name
-    const value = state[name]
+    const value = state[this.name]
     return value ? format(parseISO(value), 'd MMMM yyyy') : ''
+  }
+
+  getConditionEvaluationStateValue(state: FormSubmissionState): string {
+    const value = state[this.name]
+    return value ? format(parseISO(value), 'yyyy-MM-dd') : '' // strip the time as it interferes with equals/not equals
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/pageControllers/PageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.test.ts
@@ -1,5 +1,6 @@
 import { type FormDefinition } from '@defra/forms-model'
 
+import dateFormConditionJson from '~/src/server/forms/date-branching.json' with { type: 'json' }
 import formJson from '~/src/server/forms/get-condition-evaluation-context.json' with { type: 'json' }
 import { FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { PageController } from '~/src/server/plugins/engine/pageControllers/index.js'
@@ -78,5 +79,41 @@ describe('Condition Evaluation Context', () => {
         ukPassport: false
       })
     )
+  })
+
+  describe('DatePartsField', () => {
+    it('correctly transforms DateTimeParts components', () => {
+      const formModel = new FormModel(dateFormConditionJson as FormDefinition, {
+        basePath: 'test'
+      })
+
+      const testConditionsPage = formModel.pages.find(
+        (page) => page.path === '/page-one'
+      )
+
+      if (!testConditionsPage) {
+        throw new Error('Test conditions page not found')
+      }
+
+      const page = new PageController(formModel, testConditionsPage.pageDef)
+
+      const completeState = {
+        progress: [],
+        BWvMaM: '2024-01-05T01:02:03.004Z'
+      }
+
+      // get the state including our DatePartsField
+      const relevantState = page.getConditionEvaluationContext(
+        formModel,
+        completeState
+      )
+
+      // Ensure dates are transformed to yyyy-MM-dd format
+      expect(relevantState).toEqual(
+        expect.objectContaining({
+          BWvMaM: '2024-01-05'
+        })
+      )
+    })
   })
 })

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -17,12 +17,12 @@ import { format, parseISO } from 'date-fns'
 import joi from 'joi'
 import { type ValidationResult, type ObjectSchema } from 'joi'
 
-import { DatePartsField } from '../components/DatePartsField.js'
 
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { CheckboxesField } from '~/src/server/plugins/engine/components/CheckboxesField.js'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
+import { DatePartsField } from '~/src/server/plugins/engine/components/DatePartsField.js'
 import { RadiosField } from '~/src/server/plugins/engine/components/RadiosField.js'
 import { type ComponentCollectionViewModel } from '~/src/server/plugins/engine/components/types.js'
 import {

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -17,6 +17,8 @@ import { format, parseISO } from 'date-fns'
 import joi from 'joi'
 import { type ValidationResult, type ObjectSchema } from 'joi'
 
+import { DatePartsField } from '../components/DatePartsField.js'
+
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { CheckboxesField } from '~/src/server/plugins/engine/components/CheckboxesField.js'
@@ -361,6 +363,9 @@ export class PageControllerBase {
           !component.options.required
         ) {
           componentState = null
+        } else if (component instanceof DatePartsField) {
+          componentState =
+            component.getConditionEvaluationStateValue(currentState)
         }
 
         newValue[component.name] = componentState

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -17,7 +17,6 @@ import { format, parseISO } from 'date-fns'
 import joi from 'joi'
 import { type ValidationResult, type ObjectSchema } from 'joi'
 
-
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { CheckboxesField } from '~/src/server/plugins/engine/components/CheckboxesField.js'

--- a/src/server/services/cacheService.ts
+++ b/src/server/services/cacheService.ts
@@ -1,10 +1,10 @@
 import { type Request, type Server } from '@hapi/hapi'
 import { merge } from '@hapi/hoek'
 
-import { type ViewModel } from '../plugins/engine/components/types.js'
 
 import { config } from '~/src/config/index.js'
 import { type createServer } from '~/src/server/index.js'
+import { type ViewModel } from '~/src/server/plugins/engine/components/types.js'
 import { type FormSubmissionState } from '~/src/server/plugins/engine/types.js'
 
 const partition = 'cache'

--- a/src/server/services/cacheService.ts
+++ b/src/server/services/cacheService.ts
@@ -1,7 +1,6 @@
 import { type Request, type Server } from '@hapi/hapi'
 import { merge } from '@hapi/hoek'
 
-
 import { config } from '~/src/config/index.js'
 import { type createServer } from '~/src/server/index.js'
 import { type ViewModel } from '~/src/server/plugins/engine/components/types.js'


### PR DESCRIPTION
Date conditions were previously evaluated as datetime strings (ISO 8601 format). This worked for greater/less than conditions, but failed for quality conditions as `2024-08-01` would never equal `2024-08-01T00:00:00.000Z`. This code transforms the value to the expected format prior to condition evaluation.

@davidjamesstone FYI, implemented as discussed on Friday.