### PR TITLE
Avoid legacy controller paths in form JSON

### DIFF
--- a/src/server/forms/cph-demo.json
+++ b/src/server/forms/cph-demo.json
@@ -521,7 +521,7 @@
       "title": "Check your answers before submitting your form",
       "components": [],
       "next": [],
-      "controller": "./pages/summary.js"
+      "controller": "SummaryPageController"
     },
     {
       "path": "/whats-your-business-address",

--- a/src/server/forms/get-condition-evaluation-context.json
+++ b/src/server/forms/get-condition-evaluation-context.json
@@ -370,7 +370,7 @@
     },
     {
       "path": "/summary",
-      "controller": "./pages/summary.js",
+      "controller": "SummaryPageController",
       "title": "Summary",
       "components": [],
       "next": []

--- a/src/server/forms/report-a-terrorist.json
+++ b/src/server/forms/report-a-terrorist.json
@@ -82,7 +82,7 @@
     {
       "title": "summary",
       "path": "/summary",
-      "controller": "./pages/summary.js",
+      "controller": "SummaryPageController",
       "components": []
     },
     {

--- a/src/server/forms/runner-components-test.json
+++ b/src/server/forms/runner-components-test.json
@@ -77,7 +77,7 @@
           "path": "/do-you-own-a-vehicle"
         }
       ],
-      "controller": "./pages/start.js"
+      "controller": "StartPageController"
     },
     {
       "path": "/details-about-your-vehicle",
@@ -196,7 +196,7 @@
       "title": "Summary",
       "components": [],
       "next": [],
-      "controller": "./pages/summary.js"
+      "controller": "SummaryPageController"
     }
   ],
   "lists": [

--- a/src/server/forms/test.json
+++ b/src/server/forms/test.json
@@ -10,7 +10,7 @@
           "path": "/uk-passport"
         }
       ],
-      "controller": "./pages/start.js"
+      "controller": "StartPageController"
     },
     {
       "path": "/uk-passport",
@@ -389,7 +389,7 @@
     },
     {
       "path": "/summary",
-      "controller": "./pages/summary.js",
+      "controller": "SummaryPageController",
       "title": "Summary",
       "components": [],
       "next": []

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -75,7 +75,7 @@ const stubFormDefinition: FormDefinition = {
     {
       title: 'Summary',
       path: '/summary',
-      controller: './pages/summary.js',
+      controller: 'SummaryPageController',
       components: []
     }
   ],

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -117,7 +117,7 @@ export class FormModel {
         title: 'Application complete',
         components: [],
         next: [],
-        controller: './pages/status.js'
+        controller: 'StatusPageController'
       })
     )
 

--- a/src/server/plugins/engine/pageControllers/helpers.test.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.test.ts
@@ -1,6 +1,7 @@
 import {
   controllerNameFromPath,
-  getPageController
+  getPageController,
+  isPageController
 } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import {
   HomePageController,
@@ -58,5 +59,23 @@ describe('Page controller helpers', () => {
         expect(getPageController(path)).toEqual(controller)
       }
     )
+  })
+
+  describe('Helper: isPageController', () => {
+    it.each([...controllers])(
+      "allows valid page controller '$name'",
+      ({ name }) => {
+        expect(isPageController(name)).toBe(true)
+      }
+    )
+
+    it.each([
+      { name: './pages/unknown.js' },
+      { name: 'UnknownPageController' },
+      { name: undefined },
+      { name: '' }
+    ])("rejects invalid page controller '$name'", ({ name }) => {
+      expect(isPageController(name)).toBe(false)
+    })
   })
 })

--- a/src/server/plugins/engine/pageControllers/helpers.test.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.test.ts
@@ -2,46 +2,61 @@ import {
   controllerNameFromPath,
   getPageController
 } from '~/src/server/plugins/engine/pageControllers/helpers.js'
-import * as PageControllers from '~/src/server/plugins/engine/pageControllers/index.js'
+import {
+  HomePageController,
+  PageController,
+  StartPageController,
+  SummaryPageController,
+  StatusPageController
+} from '~/src/server/plugins/engine/pageControllers/index.js'
 
-describe('Engine Page Controllers getPageController', () => {
-  describe('controllerNameFromPath', () => {
-    test('controller name is extracted correctly', () => {
-      const filePath = './pages/summary.js'
-      const controllerName = controllerNameFromPath(filePath)
-      expect(controllerName).toBe('SummaryPageController')
-    })
+describe('Page controller helpers', () => {
+  const controllers = [
+    {
+      name: 'HomePageController',
+      path: './pages/home.js',
+      controller: HomePageController
+    },
+    {
+      name: 'PageController',
+      path: './pages/page.js',
+      controller: PageController
+    },
+    {
+      name: 'StartPageController',
+      path: './pages/start.js',
+      controller: StartPageController
+    },
+    {
+      name: 'SummaryPageController',
+      path: './pages/summary.js',
+      controller: SummaryPageController
+    },
+    {
+      name: 'StatusPageController',
+      path: './pages/status.js',
+      controller: StatusPageController
+    }
+  ]
 
-    test('kebab-case is pascal-case', () => {
-      const filePath = './pages/home.js'
-      const controllerName = controllerNameFromPath(filePath)
-      expect(controllerName).toBe('HomePageController')
-    })
+  describe('Helper: controllerNameFromPath', () => {
+    it.each([...controllers])(
+      "returns controller name for '$path' legacy path",
+      ({ name, path }) => {
+        expect(controllerNameFromPath(path)).toEqual(name)
+      }
+    )
   })
 
-  describe('getPageController', () => {
-    test('it returns HomePageController when a legacy path is passed', () => {
-      const controllerFromPath = getPageController('./pages/home.js')
-      expect(controllerFromPath).toEqual(PageControllers.HomePageController)
+  describe('Helper: getPageController', () => {
+    it.each([...controllers])(
+      "returns page controller '$name'",
+      ({ controller, name, path }) => {
+        expect(getPageController(name)).toEqual(controller)
 
-      const controllerFromName = getPageController('HomePageController')
-      expect(controllerFromName).toEqual(PageControllers.HomePageController)
-    })
-
-    test('it returns StartPageController when a legacy path is passed', () => {
-      const controllerFromPath = getPageController('./pages/start.js')
-      expect(controllerFromPath).toEqual(PageControllers.StartPageController)
-
-      const controllerFromName = getPageController('StartPageController')
-      expect(controllerFromName).toEqual(PageControllers.StartPageController)
-    })
-
-    test('it returns SummaryPageController when a legacy path is passed', () => {
-      const controllerFromPath = getPageController('./pages/summary.js')
-      expect(controllerFromPath).toEqual(PageControllers.SummaryPageController)
-
-      const controllerFromName = getPageController('SummaryPageController')
-      expect(controllerFromName).toEqual(PageControllers.SummaryPageController)
-    })
+        // Check for legacy path support
+        expect(getPageController(path)).toEqual(controller)
+      }
+    )
   })
 })

--- a/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.ts
@@ -6,15 +6,21 @@ import upperFirst from 'lodash/upperFirst.js'
 
 import * as PageControllers from '~/src/server/plugins/engine/pageControllers/index.js'
 
-export function controllerNameFromPath(filePath: string) {
-  const fileName = path.basename(filePath).split('.')[0]
-  return `${upperFirst(camelCase(fileName))}PageController`
+export function controllerNameFromPath(nameOrPath?: string) {
+  if (!nameOrPath || !path.extname(nameOrPath)) {
+    return nameOrPath
+  }
+
+  const fileName = camelCase(path.basename(nameOrPath).split('.')[0])
+  const prefix = fileName !== 'page' ? upperFirst(fileName) : ''
+
+  return `${prefix}PageController`
 }
 
 export function isPageController(
-  controllerName: string
+  controllerName?: string
 ): controllerName is keyof typeof PageControllers {
-  return controllerName in PageControllers
+  return !!controllerName && controllerName in PageControllers
 }
 
 export type PageControllerClass = InstanceType<PageControllerType>
@@ -27,9 +33,7 @@ export type PageControllerType =
 export function getPageController(
   nameOrPath: string
 ): PageControllerType | undefined {
-  const controllerName = path.extname(nameOrPath)
-    ? controllerNameFromPath(nameOrPath)
-    : nameOrPath
+  const controllerName = controllerNameFromPath(nameOrPath)
 
   if (!isPageController(controllerName)) {
     return

--- a/test/form/definitions/basic-v0.json
+++ b/test/form/definitions/basic-v0.json
@@ -44,7 +44,7 @@
     },
     {
       "path": "/summary",
-      "controller": "./pages/summary.ts",
+      "controller": "SummaryPageController",
       "components": [],
       "title": "Summary"
     }

--- a/test/form/definitions/basic-v1.json
+++ b/test/form/definitions/basic-v1.json
@@ -44,7 +44,7 @@
     },
     {
       "path": "/summary",
-      "controller": "./pages/summary.ts",
+      "controller": "SummaryPageController",
       "components": [],
       "title": "Summary"
     }

--- a/test/form/definitions/components.json
+++ b/test/form/definitions/components.json
@@ -132,7 +132,7 @@
       "title": "Summary",
       "components": [],
       "next": [],
-      "controller": "./pages/summary.js"
+      "controller": "SummaryPageController"
     }
   ],
   "sections": [

--- a/test/form/definitions/feedback.json
+++ b/test/form/definitions/feedback.json
@@ -24,7 +24,7 @@
     },
     {
       "path": "/summary",
-      "controller": "./pages/summary.js",
+      "controller": "SummaryPageController",
       "title": "Summary",
       "components": [],
       "next": []

--- a/test/form/definitions/phase-alpha.json
+++ b/test/form/definitions/phase-alpha.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "/summary",
-      "controller": "./pages/summary.js",
+      "controller": "SummaryPageController",
       "title": "Summary",
       "components": [],
       "next": []

--- a/test/form/definitions/phase-default.json
+++ b/test/form/definitions/phase-default.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "/summary",
-      "controller": "./pages/summary.js",
+      "controller": "SummaryPageController",
       "title": "Summary",
       "components": [],
       "next": []

--- a/test/form/definitions/phase-none.json
+++ b/test/form/definitions/phase-none.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "/summary",
-      "controller": "./pages/summary.js",
+      "controller": "SummaryPageController",
       "title": "Summary",
       "components": [],
       "next": []

--- a/test/form/definitions/status.json
+++ b/test/form/definitions/status.json
@@ -53,7 +53,7 @@
     {
       "title": "Summary",
       "path": "/summary",
-      "controller": "./pages/summary.js",
+      "controller": "SummaryPageController",
       "components": []
     }
   ],

--- a/test/form/definitions/test.json
+++ b/test/form/definitions/test.json
@@ -10,7 +10,7 @@
           "path": "/uk-passport"
         }
       ],
-      "controller": "./pages/start.js"
+      "controller": "StartPageController"
     },
     {
       "path": "/uk-passport",
@@ -389,7 +389,7 @@
     },
     {
       "path": "/summary",
-      "controller": "./pages/summary.js",
+      "controller": "SummaryPageController",
       "title": "Summary",
       "components": [],
       "next": []

--- a/test/form/definitions/titles.json
+++ b/test/form/definitions/titles.json
@@ -149,7 +149,7 @@
     },
     {
       "path": "/summary",
-      "controller": "./pages/summary.js",
+      "controller": "SummaryPageController",
       "title": "Summary",
       "components": [],
       "next": []


### PR DESCRIPTION
This PR updates all form JSON and test fixtures to avoid legacy controller file paths

For example `./pages/summary.js` → `SummaryPageController`

