### PR TITLE
Remove support for legacy controller paths

### DIFF
--- a/src/server/plugins/engine/pageControllers/README.md
+++ b/src/server/plugins/engine/pageControllers/README.md
@@ -2,27 +2,16 @@
 
 Form pages could have specific controllers and this is specified inside the Form JSON, please see below a sample where the page summary is specifying it's controller via `controller` property.
 
-```javascript
+```json
 {
-    "pages": [
-        {
-            "path": "/summary",
-            "controller": "./pages/summary.js", // legacy controller path
-            "title": "Summary",
-            "components": [],
-            "next": []
-        },
-        {
-            "path": "/summary",
-            "controller": "SummaryPageController", // we now use the controller class name
-            "title": "Summary",
-            "components": [],
-            "next": []
-        }
-    ]
+  "pages": [
+    {
+      "path": "/summary",
+      "controller": "SummaryPageController",
+      "title": "Summary",
+      "components": [],
+      "next": []
+    }
+  ]
 }
 ```
-
-Previously controllers were dynamically loaded from the file system, this is why you see a path such as `./pages/summary.js`. This feature has never been used since the application was forked and so it has been deprecated.
-
-To keep backward compatibility with legacy forms JSON we have the `getPageController` helper dealing with the possibility of a controller value being a file path or a class name (see `helpers.ts`)

--- a/src/server/plugins/engine/pageControllers/StartPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StartPageController.ts
@@ -7,7 +7,6 @@ import { type FormRequest } from '~/src/server/routes/types.js'
 
 export class StartPageController extends QuestionPageController {
   /**
-   * The controller which is used when Page["controller"] is defined as "./pages/start.js"
    * This page should not be used in production. This page is helpful for prototyping start pages within the app,
    * but start pages should really live on gov.uk (whitehall publisher) so a user can be properly signposted.
    */

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -52,10 +52,6 @@ const templateId = config.get('notifyTemplateId')
 export class SummaryPageController extends QuestionPageController {
   declare pageDef: PageSummary
 
-  /**
-   * The controller which is used when Page["controller"] is defined as "./pages/summary.js"
-   */
-
   constructor(model: FormModel, pageDef: PageSummary) {
     super(model, pageDef)
     this.viewName = 'summary'

--- a/src/server/plugins/engine/pageControllers/helpers.test.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.test.ts
@@ -1,7 +1,6 @@
 import {
   ComponentType,
   ControllerType,
-  ControllerTypes,
   PageTypes,
   type Page
 } from '@defra/forms-model'
@@ -80,19 +79,7 @@ describe('Page controller helpers', () => {
       "creates page for controller '$pageDef.controller'",
       ({ controller, pageDef }) => {
         const pageDef1 = structuredClone(pageDef)
-        const pageDef2 = structuredClone(pageDef)
-
         expect(createPage(model, pageDef1)).toBeInstanceOf(controller)
-
-        const controllerType = ControllerTypes.find(
-          ({ name }) => name === pageDef1.controller
-        )
-
-        // @ts-expect-error - Allow invalid property for test
-        pageDef2.controller = controllerType?.path
-
-        // Check for legacy path support
-        expect(createPage(model, pageDef2)).toBeInstanceOf(controller)
       }
     )
 
@@ -117,6 +104,17 @@ describe('Page controller helpers', () => {
         expect(isPageController(pageDef.controller)).toBe(true)
       }
     )
+
+    it.each([
+      { name: './pages/start.js' },
+      { name: './pages/page.js' },
+      { name: './pages/repeat.js' },
+      { name: './pages/file-upload.js' },
+      { name: './pages/summary.js' },
+      { name: './pages/status.js' }
+    ])("rejects legacy page controller '$name'", ({ name }) => {
+      expect(isPageController(name)).toBe(false)
+    })
 
     it.each([
       { name: './pages/unknown.js' },

--- a/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.ts
@@ -1,9 +1,4 @@
-import {
-  ControllerType,
-  controllerNameFromPath,
-  isControllerName,
-  type Page
-} from '@defra/forms-model'
+import { ControllerType, isControllerName, type Page } from '@defra/forms-model'
 
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import * as PageControllers from '~/src/server/plugins/engine/pageControllers/index.js'
@@ -22,15 +17,8 @@ export type PageControllerType =
  * Creates page instance for each {@link Page} type
  */
 export function createPage(model: FormModel, pageDef: Page) {
-  const controllerName = controllerNameFromPath(pageDef.controller)
-
   if (!pageDef.controller) {
     return new PageControllers.QuestionPageController(model, pageDef)
-  }
-
-  // Patch legacy controllers
-  if (controllerName && pageDef.controller !== controllerName) {
-    pageDef.controller = controllerName
   }
 
   let controller: PageControllerClass | undefined


### PR DESCRIPTION
This PR removes support for legacy controller paths or "Page type" in the editor

Their usage has been removed from **forms-runner** and **forms-designer** in:

* https://github.com/DEFRA/forms-runner/pull/332
* https://github.com/DEFRA/forms-designer/pull/399

We now only support controllers available in **forms-designer**

## Deprecation

Custom controller paths were deprecated back in 2020:

https://github.com/DEFRA/forms-runner/blob/4bcde59a0f8aa614595b6fa3a746ae76c385d821/src/server/plugins/engine/pageControllers/README.md?plain=1#L26-L28

## Migration

Before we merge, all page controllers in form definition JSON must use the new controller class names by:

1. Editing and re-saving every non-question page
2. Using a schema change to automatically migrate values