### PR TITLE
Update field classes with optional schema/options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.275",
+        "@defra/forms-model": "^3.0.302",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/boom": "^10.0.1",
         "@hapi/catbox": "^12.1.1",
@@ -2038,9 +2038,9 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.275",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.275.tgz",
-      "integrity": "sha512-4bFNwv6lCCaTLFJ6YGpR+0jdbGEC5dv4rXlDcZumUSE2YX5cpaj+6kd8sEeCHpGnD7nEacA2GUHhpJ0E5Gqbgw==",
+      "version": "3.0.302",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.302.tgz",
+      "integrity": "sha512-BIqc51hQyLp8LNOaldih5XTlrDu/GrryIGzIj0++wwRULd0MrL0spik1iDZISmMFPHpQ313566qCfyjiKx8ZUA==",
       "dependencies": {
         "slug": "^9.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@defra/forms-model": "^3.0.275",
+    "@defra/forms-model": "^3.0.302",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/boom": "^10.0.1",
     "@hapi/catbox": "^12.1.1",

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -72,7 +72,7 @@ const stubFormDefinition: FormDefinition = {
           schema: {}
         }
       ],
-      next: [{ path: '/summary' }]
+      next: [{ path: ControllerPath.Summary }]
     },
     {
       title: 'Summary',

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,5 +1,7 @@
 import {
   ComponentType,
+  ControllerPath,
+  ControllerType,
   type FormDefinition,
   type FormMetadata,
   type FormMetadataAuthor,
@@ -74,9 +76,8 @@ const stubFormDefinition: FormDefinition = {
     },
     {
       title: 'Summary',
-      path: '/summary',
-      controller: 'SummaryPageController',
-      components: []
+      path: ControllerPath.Summary,
+      controller: ControllerType.Summary
     }
   ],
   conditions: [],

--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -53,8 +53,7 @@ describe('AutocompleteField', () => {
       name: 'MyAutocomplete',
       type: ComponentType.AutocompleteField,
       options: {},
-      list: 'Countries',
-      schema: {}
+      list: 'Countries'
     }
 
     const formModel = {

--- a/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.ts
@@ -10,15 +10,13 @@ import {
 
 export class AutocompleteField extends SelectField {
   declare options: AutocompleteFieldComponent['options']
-  declare schema: AutocompleteFieldComponent['schema']
 
   constructor(def: AutocompleteFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { schema, options } = def
+    const { options } = def
 
     this.options = options
-    this.schema = schema
   }
 
   getDisplayStringFromState(state: FormSubmissionState): string {

--- a/src/server/plugins/engine/components/CheckboxesField.test.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.test.ts
@@ -62,8 +62,7 @@ describe('CheckboxesField', () => {
       name: 'myComponent',
       type: ComponentType.CheckboxesField,
       list: 'listNumber',
-      options: {},
-      schema: {}
+      options: {}
     } satisfies CheckboxesFieldComponent
 
     formModel = new FormModel(definition, {

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -11,7 +11,6 @@ import {
 
 export class CheckboxesField extends SelectionControlField {
   declare options: CheckboxesFieldComponent['options']
-  declare schema: CheckboxesFieldComponent['schema']
   declare formSchema: ArraySchema<string> | ArraySchema<number>
   declare stateSchema: ArraySchema<string> | ArraySchema<number>
 
@@ -19,7 +18,7 @@ export class CheckboxesField extends SelectionControlField {
     super(def, model)
 
     const { listType: type } = this
-    const { options, schema, title } = def
+    const { options, title } = def
 
     let formSchema =
       type === 'string' ? joi.array<string>() : joi.array<number>()
@@ -41,7 +40,6 @@ export class CheckboxesField extends SelectionControlField {
     this.formSchema = formSchema.default([])
     this.stateSchema = formSchema.default(null).allow(null)
     this.options = options
-    this.schema = schema
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -23,8 +23,8 @@ export class ComponentBase {
   type: ComponentDef['type']
   name: ComponentDef['name']
   title: ComponentDef['title']
-  schema: ComponentDef['schema']
-  options: ComponentDef['options']
+  schema?: Extract<ComponentDef, { schema: object }>['schema']
+  options?: Extract<ComponentDef, { options: object }>['options']
 
   isFormComponent = false
 
@@ -42,8 +42,14 @@ export class ComponentBase {
     this.type = def.type
     this.name = def.name
     this.title = def.title
-    this.schema = def.schema
-    this.options = def.options
+
+    if ('schema' in def) {
+      this.schema = def.schema
+    }
+
+    if ('options' in def) {
+      this.options = def.options
+    }
 
     this.model = model
   }

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -1,8 +1,11 @@
-import { ComponentType, type ComponentDef } from '@defra/forms-model'
+import {
+  ComponentType,
+  type ComponentDef,
+  type FormDefinition
+} from '@defra/forms-model'
 
 import { DatePartsField } from '~/src/server/plugins/engine/components/DatePartsField.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
-import { type FormDefinition } from '~/src/server/plugins/engine/services/formsService.js'
 
 describe('Date parts field', () => {
   let formModel: FormModel
@@ -25,8 +28,7 @@ describe('Date parts field', () => {
       name: 'myComponent',
       title: 'My component',
       type: ComponentType.DatePartsField,
-      options: {},
-      schema: {}
+      options: {}
     }
 
     const underTest = new DatePartsField(def, formModel)
@@ -50,8 +52,7 @@ describe('Date parts field', () => {
       name: 'myComponent',
       title: 'My component',
       type: ComponentType.DatePartsField,
-      options: { required: false },
-      schema: {}
+      options: { required: false }
     }
 
     const underTest = new DatePartsField(def, formModel)
@@ -75,8 +76,7 @@ describe('Date parts field', () => {
       title: 'My component',
       hint: 'a hint',
       type: ComponentType.DatePartsField,
-      options: { required: false },
-      schema: {}
+      options: { required: false }
     }
 
     const errors = {
@@ -101,8 +101,7 @@ describe('Date parts field', () => {
       title: 'Example checkboxes',
       name: 'myComponent',
       type: ComponentType.DatePartsField,
-      options: {},
-      schema: {}
+      options: {}
     }
 
     const underTest = new DatePartsField(datePartsFieldComponent, formModel)

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -19,14 +19,13 @@ import {
 
 export class DatePartsField extends FormComponent {
   declare options: DatePartsFieldFieldComponent['options']
-  declare schema: DatePartsFieldFieldComponent['schema']
   children: ComponentCollection
   dataType: DataType = 'date'
 
   constructor(def: DatePartsFieldFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { name, options, schema, title } = def
+    const { name, options, title } = def
 
     const isRequired = options.required !== false
     const hideOptional = options.optionalText
@@ -80,7 +79,6 @@ export class DatePartsField extends FormComponent {
     )
 
     this.options = options
-    this.schema = schema
     this.stateSchema = stateSchema
   }
 

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -1,7 +1,4 @@
-import {
-  ComponentType,
-  type DatePartsFieldFieldComponent
-} from '@defra/forms-model'
+import { ComponentType, type DatePartsFieldComponent } from '@defra/forms-model'
 import { parseISO, format } from 'date-fns'
 import joi from 'joi'
 
@@ -18,11 +15,11 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class DatePartsField extends FormComponent {
-  declare options: DatePartsFieldFieldComponent['options']
+  declare options: DatePartsFieldComponent['options']
   children: ComponentCollection
   dataType: DataType = 'date'
 
-  constructor(def: DatePartsFieldFieldComponent, model: FormModel) {
+  constructor(def: DatePartsFieldComponent, model: FormModel) {
     super(def, model)
 
     const { name, options, title } = def

--- a/src/server/plugins/engine/components/Details.ts
+++ b/src/server/plugins/engine/components/Details.ts
@@ -9,17 +9,15 @@ import {
 
 export class Details extends ComponentBase {
   declare options: DetailsComponent['options']
-  declare schema: DetailsComponent['schema']
   content: DetailsComponent['content']
 
   constructor(def: DetailsComponent, model: FormModel) {
     super(def, model)
 
-    const { content, schema, options } = def
+    const { content, options } = def
 
     this.content = content
     this.options = options
-    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -34,8 +34,7 @@ describe('EmailAddressFieldComponent', () => {
         title: 'Example email address field',
         name: 'myComponent',
         type: ComponentType.EmailAddressField,
-        options: {},
-        schema: {}
+        options: {}
       } satisfies EmailAddressFieldComponent
 
       component = new EmailAddressField(def, formModel)
@@ -150,8 +149,7 @@ describe('EmailAddressFieldComponent', () => {
           title: 'Example email address field',
           name: 'myComponent',
           type: ComponentType.EmailAddressField,
-          options: {},
-          schema: {}
+          options: {}
         } satisfies EmailAddressFieldComponent,
         assertions: [
           {
@@ -174,8 +172,7 @@ describe('EmailAddressFieldComponent', () => {
           title: 'Example email address field',
           name: 'myComponent',
           type: ComponentType.EmailAddressField,
-          options: {},
-          schema: {}
+          options: {}
         } satisfies EmailAddressFieldComponent,
         assertions: [
           {

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -10,12 +10,11 @@ import {
 
 export class EmailAddressField extends FormComponent {
   declare options: EmailAddressFieldComponent['options']
-  declare schema: EmailAddressFieldComponent['schema']
 
   constructor(def: EmailAddressFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { schema, options, title } = def
+    const { options, title } = def
 
     let formSchema = joi
       .string()
@@ -41,7 +40,6 @@ export class EmailAddressField extends FormComponent {
     this.formSchema = formSchema.default('')
     this.stateSchema = formSchema.default(null).allow(null)
     this.options = options
-    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -71,7 +71,7 @@ export class FormComponent extends ComponentBase {
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {
-    const { hint, name, options, title } = this
+    const { hint, name, options = {}, title } = this
 
     const viewModel = super.getViewModel(payload, errors)
 

--- a/src/server/plugins/engine/components/Html.ts
+++ b/src/server/plugins/engine/components/Html.ts
@@ -9,17 +9,15 @@ import {
 
 export class Html extends ComponentBase {
   declare options: HtmlComponent['options']
-  declare schema: HtmlComponent['schema']
   content: HtmlComponent['content']
 
   constructor(def: HtmlComponent, model: FormModel) {
     super(def, model)
 
-    const { content, schema, options } = def
+    const { content, options } = def
 
     this.content = content
     this.options = options
-    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/InsetText.ts
+++ b/src/server/plugins/engine/components/InsetText.ts
@@ -9,18 +9,14 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class InsetText extends ComponentBase {
-  declare options: InsetTextComponent['options']
-  declare schema: InsetTextComponent['schema']
   content: InsetTextComponent['content']
 
   constructor(def: InsetTextComponent, model: FormModel) {
     super(def, model)
 
-    const { content, schema, options } = def
+    const { content } = def
 
     this.content = content
-    this.options = options
-    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors): ViewModel {

--- a/src/server/plugins/engine/components/List.ts
+++ b/src/server/plugins/engine/components/List.ts
@@ -12,7 +12,6 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class List extends ComponentBase {
-  declare schema: ListComponent['schema']
   declare options: ListComponent['options']
   hint: ListComponent['hint']
   list?: ListType
@@ -24,12 +23,11 @@ export class List extends ComponentBase {
   constructor(def: ListComponent, model: FormModel) {
     super(def, model)
 
-    const { hint, list, options, schema } = def
+    const { hint, list, options } = def
 
     this.hint = hint
     this.list = model.getList(list)
     this.options = options
-    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/ListFormComponent.test.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.test.ts
@@ -48,8 +48,7 @@ describe('ListFormComponent', () => {
         name: 'myCheckboxes',
         type: ComponentType.CheckboxesField,
         list: 'listNumber',
-        options: {},
-        schema: {}
+        options: {}
       } satisfies ListComponentsDef,
 
       options: {
@@ -71,8 +70,7 @@ describe('ListFormComponent', () => {
         name: 'myRadios',
         type: ComponentType.RadiosField,
         list: 'listString',
-        options: {},
-        schema: {}
+        options: {}
       } satisfies ListComponentsDef,
 
       options: {
@@ -94,8 +92,7 @@ describe('ListFormComponent', () => {
         name: 'mySelect',
         type: ComponentType.SelectField,
         list: 'listString',
-        options: {},
-        schema: {}
+        options: {}
       } satisfies ListComponentsDef,
 
       options: {
@@ -117,8 +114,7 @@ describe('ListFormComponent', () => {
         name: 'myAutocomplete',
         type: ComponentType.AutocompleteField,
         list: 'listString',
-        options: {},
-        schema: {}
+        options: {}
       } satisfies ListComponentsDef,
 
       options: {

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -2,6 +2,7 @@ import {
   type Item,
   type List,
   type ListComponentsDef,
+  type SelectionComponentsDef,
   type YesNoFieldComponent
 } from '@defra/forms-model'
 import joi, {
@@ -21,8 +22,11 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class ListFormComponent extends FormComponent {
-  declare options: ListComponentsDef['options'] | YesNoFieldComponent['options']
-  declare schema: ListComponentsDef['schema'] | YesNoFieldComponent['options']
+  declare options: Extract<
+    SelectionComponentsDef,
+    { options: object }
+  >['options']
+
   declare formSchema:
     | ArraySchema<string>
     | ArraySchema<number>
@@ -51,13 +55,13 @@ export class ListFormComponent extends FormComponent {
 
   constructor(
     def:
-      | ListComponentsDef // Allow for Yes/No field custom list
+      | SelectionComponentsDef // Allow for Yes/No field custom list
       | (YesNoFieldComponent & Pick<ListComponentsDef, 'list'>),
     model: FormModel
   ) {
     super(def, model)
 
-    const { schema, options, title } = def
+    const { options, title } = def
 
     if ('list' in def) {
       this.list = model.getList(def.list)
@@ -76,7 +80,6 @@ export class ListFormComponent extends FormComponent {
     this.formSchema = formSchema.default('')
     this.stateSchema = formSchema.default(null).allow(null)
     this.options = options
-    this.schema = schema
   }
 
   getDisplayStringFromState(state: FormSubmissionState): string | string[] {

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -20,8 +20,7 @@ describe('Month Year Field', () => {
       title: 'My component',
       hint: 'a hint',
       type: ComponentType.MonthYearField,
-      options: {},
-      schema: {}
+      options: {}
     }
 
     const monthYearField = new MonthYearField(def)

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -13,14 +13,13 @@ import {
 
 export class MonthYearField extends FormComponent {
   declare options: MonthYearFieldComponent['options']
-  declare schema: MonthYearFieldComponent['schema']
   children: ComponentCollection
   dataType: DataType = 'monthYear'
 
   constructor(def: MonthYearFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { name, options, schema } = def
+    const { name, options } = def
     const isRequired = options.required !== false
 
     this.children = new ComponentCollection(
@@ -51,7 +50,6 @@ export class MonthYearField extends FormComponent {
     )
 
     this.options = options
-    this.schema = schema
   }
 
   getFormSchemaKeys() {

--- a/src/server/plugins/engine/components/RadiosField.ts
+++ b/src/server/plugins/engine/components/RadiosField.ts
@@ -5,14 +5,12 @@ import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 
 export class RadiosField extends SelectionControlField {
   declare options: RadiosFieldComponent['options']
-  declare schema: RadiosFieldComponent['schema']
 
   constructor(def: RadiosFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { schema, options } = def
+    const { options } = def
 
     this.options = options
-    this.schema = schema
   }
 }

--- a/src/server/plugins/engine/components/SelectField.test.ts
+++ b/src/server/plugins/engine/components/SelectField.test.ts
@@ -54,8 +54,7 @@ describe('SelectField', () => {
       name: 'countryOfBirth',
       type: ComponentType.SelectField,
       options: {},
-      list: 'Countries',
-      schema: {}
+      list: 'Countries'
     }
 
     const formModel: FormModel = {

--- a/src/server/plugins/engine/components/SelectField.ts
+++ b/src/server/plugins/engine/components/SelectField.ts
@@ -15,18 +15,15 @@ export class SelectField extends ListFormComponent {
     | SelectFieldComponent['options']
     | AutocompleteFieldComponent['options']
 
-  declare schema: SelectFieldComponent['schema']
-
   constructor(
     def: SelectFieldComponent | AutocompleteFieldComponent,
     model: FormModel
   ) {
     super(def, model)
 
-    const { schema, options } = def
+    const { options } = def
 
     this.options = options
-    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/SelectionControlField.ts
+++ b/src/server/plugins/engine/components/SelectionControlField.ts
@@ -29,7 +29,7 @@ export class SelectionControlField extends ListFormComponent {
         checked: `${item.value}` === `${payload[name]}`
       }
 
-      if (options.bold) {
+      if ('bold' in options && options.bold) {
         itemModel.label = {
           classes: 'govuk-label--s'
         }

--- a/src/server/plugins/engine/components/TelephoneNumberField.test.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.test.ts
@@ -13,8 +13,7 @@ describe('Telephone number field', () => {
       options: {
         customValidationMessage: 'This is a custom error',
         required: false
-      },
-      schema: {}
+      }
     }
     const telephoneNumberField = new TelephoneNumberField(def, {})
     const { formSchema: schema } = telephoneNumberField
@@ -46,8 +45,7 @@ describe('Telephone number field', () => {
       title: 'Telephone number',
       hint: 'a hint',
       type: ComponentType.TelephoneNumberField,
-      options: {},
-      schema: {}
+      options: {}
     }
     const telephoneNumberField = new TelephoneNumberField(def, {})
     const { formSchema: schema } = telephoneNumberField
@@ -65,8 +63,7 @@ describe('Telephone number field', () => {
       title: 'Telephone number',
       hint: 'a hint',
       type: ComponentType.TelephoneNumberField,
-      options: {},
-      schema: {}
+      options: {}
     }
     const telephoneNumberField = new TelephoneNumberField(def, {})
     const { formSchema: schema } = telephoneNumberField
@@ -81,8 +78,7 @@ describe('Telephone number field', () => {
       title: 'My component',
       hint: 'a hint',
       type: ComponentType.TelephoneNumberField,
-      options: {},
-      schema: {}
+      options: {}
     }
     const telephoneNumberField = new TelephoneNumberField(def, {})
     expect(telephoneNumberField.getViewModel({})).toEqual(

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -13,13 +13,12 @@ const PATTERN = /^[0-9\\\s+()-]*$/
 
 export class TelephoneNumberField extends FormComponent {
   declare options: TelephoneNumberFieldComponent['options']
-  declare schema: TelephoneNumberFieldComponent['schema']
   declare formSchema: StringSchema
 
   constructor(def: TelephoneNumberFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { schema, options, title } = def
+    const { options, title } = def
 
     let formSchema = joi
       .string()
@@ -47,7 +46,6 @@ export class TelephoneNumberField extends FormComponent {
     this.formSchema = formSchema.default('')
     this.stateSchema = formSchema.default(null).allow(null)
     this.options = options
-    this.schema = schema
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -16,9 +16,7 @@ export class TextField extends FormComponent {
     | TextFieldComponent['options']
     | EmailAddressFieldComponent['options']
 
-  declare schema:
-    | TextFieldComponent['schema']
-    | EmailAddressFieldComponent['options']
+  declare schema: TextFieldComponent['schema']
 
   declare formSchema: StringSchema
 
@@ -28,7 +26,8 @@ export class TextField extends FormComponent {
   ) {
     super(def, model)
 
-    const { options, schema, title } = def
+    const { options, title } = def
+    const schema = 'schema' in def ? def.schema : {}
 
     let formSchema = joi.string().trim().label(title.toLowerCase()).required()
 
@@ -76,7 +75,7 @@ export class TextField extends FormComponent {
     const options = this.options
     const viewModel = super.getViewModel(payload, errors)
 
-    if (options.autocomplete) {
+    if ('autocomplete' in options) {
       viewModel.autocomplete = options.autocomplete
     }
 

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -18,14 +18,13 @@ import {
 
 export class UkAddressField extends FormComponent {
   declare options: UkAddressFieldComponent['options']
-  declare schema: UkAddressFieldComponent['schema']
   children: ComponentCollection
   stateChildren: ComponentCollection
 
   constructor(def: UkAddressFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { name, options, schema, title } = def
+    const { name, options, title } = def
 
     const isRequired = options.required !== false
     const hideOptional = options.optionalText
@@ -52,7 +51,7 @@ export class UkAddressField extends FormComponent {
         type: ComponentType.TextField,
         name: 'addressLine2',
         title: 'Address line 2',
-        schema: { max: 100, allow: '' },
+        schema: { max: 100 },
         options: {
           autocomplete: 'address-line2',
           required: false,
@@ -96,7 +95,6 @@ export class UkAddressField extends FormComponent {
     const formChildren = new ComponentCollection(childrenList, model)
 
     this.options = options
-    this.schema = schema
     this.children = formChildren
     this.stateChildren = stateChildren
     this.stateSchema = stateSchema

--- a/src/server/plugins/engine/components/YesNoField.test.ts
+++ b/src/server/plugins/engine/components/YesNoField.test.ts
@@ -27,8 +27,7 @@ describe('YesNoField', () => {
       title: 'Example yes/no',
       name: 'myComponent',
       type: ComponentType.YesNoField,
-      options: {},
-      schema: {}
+      options: {}
     } satisfies YesNoFieldComponent
 
     formModel = new FormModel(definition, {

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -15,17 +15,15 @@ import {
  */
 export class YesNoField extends ListFormComponent {
   declare options: YesNoFieldComponent['options']
-  declare schema: YesNoFieldComponent['schema']
 
   constructor(def: YesNoFieldComponent, model: FormModel) {
     super({ ...def, list: '__yesNo' }, model)
 
-    const { options, schema } = def
+    const { options } = def
 
     addClassOptionIfNone(options, 'govuk-radios--inline')
 
     this.options = options
-    this.schema = schema
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -1,5 +1,7 @@
 import {
   ConditionsModel,
+  ControllerPath,
+  ControllerType,
   formDefinitionSchema,
   type ConditionWrapper,
   type ConditionsModelData,
@@ -110,14 +112,21 @@ export class FormModel {
 
     this.pages = def.pages.map((pageDef) => this.makePage(pageDef))
 
-    // All models get an Application Status page
-    this.pages.push(
-      this.makePage({
-        title: 'Form submitted',
-        path: ControllerPath.Status,
-        controller: ControllerType.Status
-      })
-    )
+    if (
+      !def.pages.some(
+        ({ controller }) =>
+          // Check for user-provided status page (optional)
+          controller === ControllerType.Status
+      )
+    ) {
+      this.pages.push(
+        this.makePage({
+          title: 'Form submitted',
+          path: ControllerPath.Status,
+          controller: ControllerType.Status
+        })
+      )
+    }
 
     this.startPage = this.pages.find((page) => page.path === def.startPage)
   }

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -113,11 +113,9 @@ export class FormModel {
     // All models get an Application Status page
     this.pages.push(
       this.makePage({
-        path: '/status',
         title: 'Form submitted',
-        components: [],
-        next: [],
-        controller: 'StatusPageController'
+        path: ControllerPath.Status,
+        controller: ControllerType.Status
       })
     )
 

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -10,7 +10,6 @@ import {
   type DetailItem
 } from '~/src/server/plugins/engine/models/types.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
-import { SummaryPageController } from '~/src/server/plugins/engine/pageControllers/index.js'
 import { type FormSubmissionState } from '~/src/server/plugins/engine/types.js'
 
 export class SummaryViewModel {
@@ -158,10 +157,7 @@ export class SummaryViewModel {
     while (nextPage != null) {
       if (nextPage.hasFormComponents) {
         relevantPages.push(nextPage)
-      } else if (
-        !nextPage.hasNext &&
-        !(nextPage instanceof SummaryPageController)
-      ) {
+      } else if (nextPage.next.length) {
         endPage = nextPage
       }
       nextPage = nextPage.getNextPage(state)

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
@@ -37,7 +37,8 @@ describe('FileUploadPageController', () => {
     page = {
       path: '/first-page',
       title: 'Upload files',
-      components: [component1, component2]
+      components: [component1, component2],
+      next: []
     }
 
     definition = {
@@ -60,7 +61,8 @@ describe('FileUploadPageController', () => {
         const fileUploadController = new FileUploadPageController(formModel, {
           path: '/first-page',
           title: 'Upload files',
-          components: [component1]
+          components: [component1],
+          next: []
         })
 
         return fileUploadController
@@ -82,7 +84,8 @@ describe('FileUploadPageController', () => {
         const fileUploadController = new FileUploadPageController(formModel, {
           path: '/first-page',
           title: 'Upload files',
-          components: [textComponent, component2]
+          components: [textComponent, component2],
+          next: []
         })
 
         return fileUploadController

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
@@ -14,8 +14,7 @@ describe('FileUploadPageController', () => {
     content: '<b>Guidance<b>',
     title: 'Guidance',
     type: ComponentType.Html,
-    options: {},
-    schema: {}
+    options: {}
   }
 
   const component2: ComponentDef = {

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -1,5 +1,6 @@
 import {
   ComponentType,
+  hasComponents,
   type FileUploadFieldComponent,
   type Page
 } from '@defra/forms-model'
@@ -57,12 +58,14 @@ export class FileUploadPageController extends PageController {
 
   constructor(model: FormModel, pageDef: Page) {
     // Get the file upload components from the list of components
-    const fileUploadComponents = pageDef.components?.filter(
-      (c) => c.type === ComponentType.FileUploadField
-    )
+    const fileUploadComponents = hasComponents(pageDef)
+      ? pageDef.components.filter(
+          (c) => c.type === ComponentType.FileUploadField
+        )
+      : []
 
     // Assert we have exactly 1 file upload component
-    if (!fileUploadComponents || fileUploadComponents.length !== 1) {
+    if (fileUploadComponents.length !== 1) {
       throw Boom.badImplementation(
         `Expected 1 FileUploadFieldComponent in FileUploadPageController '${pageDef.path}'`
       )

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
@@ -14,16 +14,14 @@ describe('PageControllerBase', () => {
     name: 'dateField',
     title: 'Date of marriage',
     type: ComponentType.DatePartsField,
-    options: {},
-    schema: {}
+    options: {}
   }
 
   const component2: ComponentDef = {
     name: 'yesNoField',
     title: 'Have you previously been married?',
     type: ComponentType.YesNoField,
-    options: {},
-    schema: {}
+    options: {}
   }
 
   let page: Page

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
@@ -33,7 +33,8 @@ describe('PageControllerBase', () => {
     page = {
       path: '/first-page',
       title: 'When will you get married?',
-      components: [component1, component2]
+      components: [component1, component2],
+      next: []
     }
 
     definition = {

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -3,7 +3,9 @@ import {
   type Link,
   type FormDefinition,
   type Page,
-  type Section
+  type Section,
+  hasNext,
+  hasComponents
 } from '@defra/forms-model'
 import { type Boom } from '@hapi/boom'
 import {
@@ -88,10 +90,10 @@ export class PageControllerBase {
     )
 
     // Components collection
-    const components = new ComponentCollection(pageDef.components, model)
+    const components = hasComponents(pageDef) ? pageDef.components : []
 
-    this.components = components
-    this.hasFormComponents = !!components.formItems.length
+    this.components = new ComponentCollection(components, model)
+    this.hasFormComponents = !!this.components.formItems.length
 
     this[FORM_SCHEMA] = this.components.formSchema
     this[STATE_SCHEMA] = this.components.stateSchema
@@ -165,15 +167,12 @@ export class PageControllerBase {
     }
   }
 
-  /**
-   * utility function that checks if this page has any items in the {@link Page.next} object.
-   */
-  get hasNext() {
-    return Array.isArray(this.pageDef.next) && this.pageDef.next.length > 0
-  }
-
   get next(): PageLink[] {
-    return (this.pageDef.next ?? [])
+    if (!hasNext(this.pageDef)) {
+      return []
+    }
+
+    return this.pageDef.next
       .map((next) => {
         const { path } = next
 

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -101,7 +101,9 @@ export class PageControllerBase {
 
   /**
    * Used for mapping form payloads and errors to govuk-frontend's template api, so a page can be rendered
-   * @param payload - contains a user's form payload, and any validation errors that may have occurred
+   * @param request - the hapi request
+   * @param payload - contains a user's form payload
+   * @param [errors] - validation errors that may have occurred
    */
   getViewModel(
     request: Request,

--- a/src/server/plugins/engine/pageControllers/helpers.test.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.test.ts
@@ -1,52 +1,53 @@
+import { ControllerType, ControllerTypes } from '@defra/forms-model'
+
 import {
-  controllerNameFromPath,
   getPageController,
-  isPageController
+  isPageController,
+  type PageControllerType
 } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import {
+  FileUploadPageController,
   HomePageController,
   PageController,
   StartPageController,
-  SummaryPageController,
-  StatusPageController
+  StatusPageController,
+  SummaryPageController
 } from '~/src/server/plugins/engine/pageControllers/index.js'
 
 describe('Page controller helpers', () => {
-  const controllers = [
-    {
-      name: 'HomePageController',
-      path: './pages/home.js',
-      controller: HomePageController
-    },
-    {
-      name: 'PageController',
-      path: './pages/page.js',
-      controller: PageController
-    },
-    {
-      name: 'StartPageController',
-      path: './pages/start.js',
-      controller: StartPageController
-    },
-    {
-      name: 'SummaryPageController',
-      path: './pages/summary.js',
-      controller: SummaryPageController
-    },
-    {
-      name: 'StatusPageController',
-      path: './pages/status.js',
-      controller: StatusPageController
-    }
-  ]
+  const controllers = ControllerTypes.map((defaults) => {
+    let controller: PageControllerType | undefined
 
-  describe('Helper: controllerNameFromPath', () => {
-    it.each([...controllers])(
-      "returns controller name for '$path' legacy path",
-      ({ name, path }) => {
-        expect(controllerNameFromPath(path)).toEqual(name)
-      }
-    )
+    switch (defaults.name) {
+      case ControllerType.Start:
+        controller = StartPageController
+        break
+
+      case ControllerType.Home:
+        controller = HomePageController
+        break
+
+      case ControllerType.Page:
+        controller = PageController
+        break
+
+      case ControllerType.FileUpload:
+        controller = FileUploadPageController
+        break
+
+      case ControllerType.Summary:
+        controller = SummaryPageController
+        break
+
+      case ControllerType.Status:
+        controller = StatusPageController
+        break
+    }
+
+    return {
+      ...defaults,
+      controller
+    }
   })
 
   describe('Helper: getPageController', () => {

--- a/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.ts
@@ -1,26 +1,16 @@
-import path from 'node:path'
-
-import { type Page } from '@defra/forms-model'
-import camelCase from 'lodash/camelCase.js'
-import upperFirst from 'lodash/upperFirst.js'
+import {
+  controllerNameFromPath,
+  isControllerName,
+  type ControllerType,
+  type Page
+} from '@defra/forms-model'
 
 import * as PageControllers from '~/src/server/plugins/engine/pageControllers/index.js'
 
-export function controllerNameFromPath(nameOrPath?: string) {
-  if (!nameOrPath || !path.extname(nameOrPath)) {
-    return nameOrPath
-  }
-
-  const fileName = camelCase(path.basename(nameOrPath).split('.')[0])
-  const prefix = fileName !== 'page' ? upperFirst(fileName) : ''
-
-  return `${prefix}PageController`
-}
-
 export function isPageController(
-  controllerName?: string
+  controllerName?: string | ControllerType
 ): controllerName is keyof typeof PageControllers {
-  return !!controllerName && controllerName in PageControllers
+  return isControllerName(controllerName) && controllerName in PageControllers
 }
 
 export type PageControllerClass = InstanceType<PageControllerType>

--- a/src/server/plugins/engine/views/index.html
+++ b/src/server/plugins/engine/views/index.html
@@ -17,7 +17,7 @@
       {% include "partials/heading.html" %}
 
       {% block form %}
-        {% if page.hasNext %}
+        {% if page.next | length %}
           {% include "partials/form.html" %}
         {% else %}
           {{ componentList(components) }}

--- a/test/form/rate-limit.test.js
+++ b/test/form/rate-limit.test.js
@@ -1,6 +1,8 @@
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { ControllerPath } from '@defra/forms-model'
+
 import { createServer } from '~/src/server/index.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
@@ -25,7 +27,7 @@ describe('Rate limit', () => {
     })
     server.route({
       method: 'GET',
-      path: '/start',
+      path: ControllerPath.Start,
       handler: () => {
         return {}
       },


### PR DESCRIPTION
This PR removes schema options where no longer used since https://github.com/DEFRA/forms-designer/commit/c079b204da0731cc6befec10bf29c0172ed64a98

## Type narrowing
I'll follow up with another PR to demonstrate how we can narrow types

```ts
// All form components with schema options
Extract<InputFieldsComponentsDef, { schema: object }>

// Selection form components with schema options
Extract<SelectionComponentsDef, { options: object }>
```

You'll see this happen automatically in switch statements, letting the compiler narrow value types etc:

```ts
switch (item.dataType) {
  case DataType.List:
    value = item.rawValue
    break

  case DataType.File:
    value = item.rawValue
    break

  case DataType.Date:
    value = format(new Date(item.rawValue), 'yyyy-MM-dd')
    break

  case DataType.MonthYear: {
    const [month, year] = Object.values(item.rawValue)
    value = format(new Date(`${year}-${month}-1`), 'yyyy-MM')
    break
  }

  default:
    value = item.value
}
```