### PR TITLE
Allow type narrowing for `DetailItem` variations etc

### DIFF
--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -9,7 +9,7 @@ import joi, {
 } from 'joi'
 
 import {
-  type DataType,
+  DataType,
   type ViewModel
 } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -31,7 +31,7 @@ export class ComponentBase {
   /**
    * This is passed onto webhooks, see {@link answerFromDetailItem}
    */
-  dataType: DataType = 'text'
+  dataType: DataType = DataType.Text
   model: FormModel
 
   /** joi schemas based on a component defined in the form JSON. This validates a user's answer and is generated from {@link ComponentDef} */

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -6,7 +6,7 @@ import { ComponentCollection } from '~/src/server/plugins/engine/components/Comp
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
 import { getCustomDateValidator } from '~/src/server/plugins/engine/components/helpers.js'
-import { type DataType } from '~/src/server/plugins/engine/components/types.js'
+import { DataType } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
@@ -17,7 +17,7 @@ import {
 export class DatePartsField extends FormComponent {
   declare options: DatePartsFieldComponent['options']
   children: ComponentCollection
-  dataType: DataType = 'date'
+  dataType: DataType = DataType.Date
 
   constructor(def: DatePartsFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -3,7 +3,7 @@ import joi, { type ArraySchema } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import {
-  type DataType,
+  DataType,
   type FileUploadFieldViewModel
 } from '~/src/server/plugins/engine/components/types.js'
 import { filesize } from '~/src/server/plugins/engine/helpers.js'
@@ -79,7 +79,7 @@ export const formItemSchema = itemSchema.append({
 export class FileUploadField extends FormComponent {
   declare options: FileUploadFieldComponent['options']
   declare schema: FileUploadFieldComponent['schema']
-  dataType: DataType = 'file'
+  dataType: DataType = DataType.File
 
   declare formSchema: ArraySchema<object>
   declare stateSchema: ArraySchema<object>

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -13,7 +13,7 @@ import joi, {
 } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
-import { type DataType } from '~/src/server/plugins/engine/components/types.js'
+import { DataType } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
@@ -43,7 +43,7 @@ export class ListFormComponent extends FormComponent {
 
   list?: List
   listType: List['type'] = 'string'
-  dataType: DataType = 'list'
+  dataType: DataType = DataType.List
 
   get items(): Item[] {
     return this.list?.items ?? []

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -3,7 +3,7 @@ import { ComponentType, type MonthYearFieldComponent } from '@defra/forms-model'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
-import { type DataType } from '~/src/server/plugins/engine/components/types.js'
+import { DataType } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
@@ -14,7 +14,7 @@ import {
 export class MonthYearField extends FormComponent {
   declare options: MonthYearFieldComponent['options']
   children: ComponentCollection
-  dataType: DataType = 'monthYear'
+  dataType: DataType = DataType.MonthYear
 
   constructor(def: MonthYearFieldComponent, model: FormModel) {
     super(def, model)

--- a/src/server/plugins/engine/components/types.ts
+++ b/src/server/plugins/engine/components/types.ts
@@ -105,10 +105,11 @@ export type ComponentCollectionViewModel = (
   | ContentComponentViewModel
 )[]
 
-export type DataType =
-  | 'list'
-  | 'text'
-  | 'date'
-  | 'monthYear'
-  | 'number'
-  | 'file'
+export enum DataType {
+  List = 'list',
+  Text = 'text',
+  Date = 'date',
+  MonthYear = 'monthYear',
+  Number = 'number',
+  File = 'file'
+}

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -28,7 +28,7 @@ export class SummaryViewModel {
   value: any
   name: string | undefined
   backLink?: string
-  feedbackLink: string
+  feedbackLink?: string
   phaseTag?: string
   errors:
     | {

--- a/src/server/plugins/engine/models/types.ts
+++ b/src/server/plugins/engine/models/types.ts
@@ -1,11 +1,18 @@
 import {
   type ConditionWrapper,
+  type DatePartsFieldComponent,
+  type FileUploadFieldComponent,
   type FormDefinition,
+  type InputFieldsComponentsDef,
+  type ListComponentsDef,
+  type MonthYearFieldComponent,
+  type NumberFieldComponent,
   type Section
 } from '@defra/forms-model'
 import { type Expression } from 'expr-eval'
 
 import { type ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
+import { type DataType } from '~/src/server/plugins/engine/components/types.js'
 import { type FeedbackContextInfo } from '~/src/server/plugins/engine/feedback/index.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import {
@@ -60,8 +67,7 @@ export type ExecutableCondition = ConditionWrapper & {
 /**
  * Used to render a row on a Summary List (check your answers)
  */
-
-export interface DetailItem {
+export interface DetailItemBase {
   /**
    * Name of the component defined in the JSON {@link FormDefinition}
    */
@@ -74,9 +80,14 @@ export interface DetailItem {
   label: ComponentBase['title']
 
   /**
-   * Path to redirect the user to if they decide to change this value
+   * Path to page excluding base path
    */
   path: PageControllerClass['path']
+
+  /**
+   * Path to page including base path
+   */
+  pageId: string
 
   /**
    * String and/or display value of a field. For example, a Date will be displayed as 25 December 2022
@@ -84,17 +95,68 @@ export interface DetailItem {
   value: string
 
   /**
+   * Flag to indicate if field is in error and should be changed
+   */
+  inError?: boolean
+
+  /**
    * Raw value of a field. For example, a Date will be displayed as 2022-12-25
    */
   rawValue: string | number | boolean | FileState[] | null
+
   url: string
-  pageId: string
   type: ComponentBase['type']
   title: ComponentBase['title']
   dataType: ComponentBase['dataType']
-  items?: DetailItem[]
-  inError?: boolean
 }
+
+export interface DetailItemDate extends DetailItemBase {
+  type: DatePartsFieldComponent['type']
+  dataType: DataType.Date
+  rawValue: string | null
+}
+
+export interface DetailItemMonthYear extends DetailItemBase {
+  type: MonthYearFieldComponent['type']
+  dataType: DataType.MonthYear
+  rawValue: string | null
+}
+
+export interface DetailItemList extends DetailItemBase {
+  type: ListComponentsDef['type']
+  dataType: DataType.List
+  items: DetailItem[]
+  rawValue: string | number | boolean | null
+}
+
+export interface DetailItemNumber extends DetailItemBase {
+  type: NumberFieldComponent['type']
+  dataType: DataType.Number
+  rawValue: number | null
+}
+
+export interface DetailItemText extends DetailItemBase {
+  type: Exclude<
+    InputFieldsComponentsDef,
+    NumberFieldComponent | FileUploadFieldComponent
+  >['type']
+  dataType: DataType.Text
+  rawValue: FileState[] | null
+}
+
+export interface DetailItemFileUpload extends DetailItemBase {
+  type: FileUploadFieldComponent['type']
+  dataType: DataType.File
+  rawValue: FileState[] | null
+}
+
+export type DetailItem =
+  | DetailItemDate
+  | DetailItemMonthYear
+  | DetailItemList
+  | DetailItemNumber
+  | DetailItemText
+  | DetailItemFileUpload
 
 /**
  * Used to render a row on a Summary List (check your answers)

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -12,6 +12,7 @@ import { config } from '~/src/config/index.js'
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
 import { DataType } from '~/src/server/plugins/engine/components/types.js'
 import {
+  decodeFeedbackContextInfo,
   FeedbackContextInfo,
   RelativeUrl
 } from '~/src/server/plugins/engine/feedback/index.js'


### PR DESCRIPTION
This PR adds types for the different `DetailItem` flavours to fix errors such as:

```console
  Overload 1 of 5, '(value: string | number | Date): Date', gave the following error.
    Argument of type 'string | number | boolean | FileState[] | null' is not assignable to parameter of type 'string | number | Date'.
      Type 'null' is not assignable to type 'string | number | Date'.
  Overload 2 of 5, '(vd: VarDate): Date', gave the following error.
    Argument of type 'string | number | boolean | FileState[] | null' is not assignable to parameter of type 'VarDate'.
      Type 'null' is not assignable to type 'VarDate'.
  Overload 3 of 5, '(value: string | number): Date', gave the following error.
    Argument of type 'string | number | boolean | FileState[] | null' is not assignable to parameter of type 'string | number'.
      Type 'null' is not assignable to type 'string | number'.

416       return format(new Date(item.rawValue), 'yyyy-MM-dd')
```