### PR TITLE
Always safely escape hint text

### DIFF
--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -81,7 +81,7 @@ export class FormComponent extends ComponentBase {
 
     if (hint) {
       viewModel.hint = {
-        html: hint
+        text: hint
       }
     }
 

--- a/src/server/plugins/engine/components/List.ts
+++ b/src/server/plugins/engine/components/List.ts
@@ -5,6 +5,7 @@ import {
 } from '@defra/forms-model'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
+import { type ListItem } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
@@ -47,17 +48,14 @@ export class List extends ComponentBase {
       text: this.hint ?? ''
     }
 
-    viewModel.items = items.map((item) => {
-      const contentItem: { text: string; condition?: string } = {
-        text: item.text
-      }
-
-      if (item.condition) {
-        contentItem.condition = item.condition
-      }
-
-      return contentItem
-    })
+    viewModel.items = items.map(
+      ({ text, description = '', condition }) =>
+        ({
+          text,
+          hint: { html: description },
+          condition: condition ?? undefined
+        }) satisfies ListItem
+    )
 
     return viewModel
   }

--- a/src/server/plugins/engine/components/List.ts
+++ b/src/server/plugins/engine/components/List.ts
@@ -52,7 +52,7 @@ export class List extends ComponentBase {
       ({ text, description = '', condition }) =>
         ({
           text,
-          hint: { html: description },
+          hint: { text: description },
           condition: condition ?? undefined
         }) satisfies ListItem
     )

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -13,7 +13,10 @@ import joi, {
 } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
-import { DataType } from '~/src/server/plugins/engine/components/types.js'
+import {
+  DataType,
+  type ListItem
+} from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
@@ -93,13 +96,14 @@ export class ListFormComponent extends FormComponent {
     const { name, items } = this
     const viewModel = super.getViewModel(payload, errors)
     const viewModelItems = items.map(
-      ({ text, value, description = '', condition }) => ({
-        text,
-        value: `${value}`,
-        description,
-        selected: `${value}` === `${payload[name]}`,
-        condition: condition ?? undefined
-      })
+      ({ text, value, description = '', condition }) =>
+        ({
+          text,
+          value: `${value}`,
+          hint: { html: description },
+          selected: `${value}` === `${payload[name]}`,
+          condition: condition ?? undefined
+        }) satisfies ListItem
     )
 
     viewModel.items = viewModelItems

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -100,7 +100,7 @@ export class ListFormComponent extends FormComponent {
         ({
           text,
           value: `${value}`,
-          hint: { html: description },
+          hint: { text: description },
           selected: `${value}` === `${payload[name]}`,
           condition: condition ?? undefined
         }) satisfies ListItem

--- a/src/server/plugins/engine/components/SelectionControlField.ts
+++ b/src/server/plugins/engine/components/SelectionControlField.ts
@@ -10,7 +10,7 @@ import {
  */
 export class SelectionControlField extends ListFormComponent {
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {
-    const { name, options } = this
+    const { options } = this
 
     const viewModel = super.getViewModel(payload, errors)
     let { fieldset, items, label } = viewModel
@@ -22,12 +22,8 @@ export class SelectionControlField extends ListFormComponent {
       }
     }
 
-    items = items?.map((item) => {
-      const itemModel: ListItem = {
-        text: item.text,
-        value: item.value,
-        checked: `${item.value}` === `${payload[name]}`
-      }
+    items = items?.map(({ selected, ...item }) => {
+      const itemModel = { ...item, checked: selected } satisfies ListItem
 
       if ('bold' in options && options.bold) {
         itemModel.label = {
@@ -35,16 +31,7 @@ export class SelectionControlField extends ListFormComponent {
         }
       }
 
-      if (item.description) {
-        itemModel.hint = {
-          html: item.description
-        }
-      }
-
       return itemModel
-
-      // FIXME:- add this back when GDS fix accessibility issues involving conditional reveal fields
-      // return super.addConditionalComponents(item, itemModel, payload, errors);
     })
 
     return {

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -33,8 +33,6 @@ export class YesNoField extends ListFormComponent {
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionErrors) {
-    const { name } = this
-
     const viewModel = super.getViewModel(payload, errors)
     let { fieldset, items, label } = viewModel
 
@@ -45,10 +43,9 @@ export class YesNoField extends ListFormComponent {
       }
     }
 
-    items = items?.map(({ text, value }) => ({
-      text,
-      value,
-      checked: `${value}` === `${payload[name]}`
+    items = items?.map(({ selected, ...item }) => ({
+      ...item,
+      checked: selected
     }))
 
     return {

--- a/src/server/plugins/engine/components/types.ts
+++ b/src/server/plugins/engine/components/types.ts
@@ -19,7 +19,7 @@ export interface ListItem {
   text?: string
   value?: string | boolean | number
   hint?: {
-    html: string
+    text: string
   }
   checked?: boolean
   selected?: boolean
@@ -35,7 +35,7 @@ export interface ViewModel {
   name?: string
   value?: any // TODO
   hint?: {
-    html: string
+    text: string
   }
   classes?: string
   condition?: string


### PR DESCRIPTION
This PR fixes an issue where HTML code in hint text was not escaped by Nunjucks

<img width="543" alt="Unsafe hint text" src="https://github.com/user-attachments/assets/d759acdd-99cf-4bbf-9576-bf736d53f6f3">
