### PR TITLE
Fix empty autocomplete validation (when cleared)

### DIFF
--- a/src/client/javascripts/application.js
+++ b/src/client/javascripts/application.js
@@ -44,7 +44,7 @@ function initAutocomplete($select, init) {
 
   // Reset select when input value is not allowed
   $input?.addEventListener('blur', () => {
-    if (!inputValues.includes($input.value)) {
+    if (!$input.value || !inputValues.includes($input.value)) {
       $select.value = ''
     }
   })


### PR DESCRIPTION
This PR fixes [bug #428456](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/428456)

After clearing an **Autocomplete** `<input>` its `<select>` is now reset to the default `''` value

Previously the old `<select>` value remained selected