### PR TITLE
Remove schema `.optional()` when value is always submitted

### DIFF
--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -94,9 +94,9 @@ describe.each([
 
         const { formSchema } = componentOptional
 
-        expect(formSchema.describe().flags).toEqual(
+        expect(formSchema.describe()).toEqual(
           expect.objectContaining({
-            presence: 'optional'
+            allow: expect.arrayContaining([''])
           })
         )
 

--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -132,7 +132,7 @@ describe.each([
 
         expect(result.error).toEqual(
           expect.objectContaining({
-            message: expect.stringContaining(`Select ${label}`)
+            message: `Select ${label}`
           })
         )
       })

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -30,7 +30,7 @@ export class DatePartsField extends FormComponent {
     let stateSchema = joi.date().label(title.toLowerCase()).required()
 
     if (options.required === false) {
-      stateSchema = stateSchema.allow('', null).optional()
+      stateSchema = stateSchema.allow(null)
     }
 
     this.children = new ComponentCollection(

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -68,13 +68,13 @@ describe('EmailAddressField', () => {
 
         const { formSchema } = componentOptional
 
-        expect(formSchema.describe().flags).toEqual(
+        expect(formSchema.describe()).toEqual(
           expect.objectContaining({
-            presence: 'optional'
+            allow: ['']
           })
         )
 
-        const result = formSchema.validate(undefined, opts)
+        const result = formSchema.validate('', opts)
         expect(result.error).toBeUndefined()
       })
 

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -24,7 +24,7 @@ export class EmailAddressField extends FormComponent {
       .required()
 
     if (options.required === false) {
-      formSchema = formSchema.allow('').optional()
+      formSchema = formSchema.allow('')
     }
 
     if (options.customValidationMessage) {

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -71,16 +71,12 @@ export class ListFormComponent extends FormComponent {
       this.listType = this.list?.type ?? 'string'
     }
 
-    let formSchema = joi[this.listType]()
+    const formSchema = joi[this.listType]()
       .valid(...this.values)
       .label(title.toLowerCase())
       .required()
 
-    if (options.required === false) {
-      formSchema = formSchema.valid('').optional()
-    }
-
-    this.formSchema = formSchema.default('')
+    this.formSchema = formSchema
     this.stateSchema = formSchema.default(null).allow(null)
     this.options = options
   }

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -33,7 +33,7 @@ export class MultilineTextField extends FormComponent {
     let formSchema = Joi.string().trim().label(title.toLowerCase()).required()
 
     if (options.required === false) {
-      formSchema = formSchema.allow('').optional()
+      formSchema = formSchema.allow('')
     }
 
     if (typeof schema.length !== 'number') {

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -69,13 +69,13 @@ describe('NumberField', () => {
 
         const { formSchema } = componentOptional
 
-        expect(formSchema.describe().flags).toEqual(
+        expect(formSchema.describe()).toEqual(
           expect.objectContaining({
-            presence: 'optional'
+            allow: ['']
           })
         )
 
-        const result = formSchema.validate(undefined, opts)
+        const result = formSchema.validate('', opts)
         expect(result.error).toBeUndefined()
       })
 

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -22,7 +22,7 @@ export class NumberField extends FormComponent {
     let formSchema = joi.number().label(title.toLowerCase()).required()
 
     if (options.required === false) {
-      formSchema = formSchema.allow('').optional()
+      formSchema = formSchema.allow('')
     }
 
     if (typeof schema.min === 'number') {

--- a/src/server/plugins/engine/components/RadiosField.ts
+++ b/src/server/plugins/engine/components/RadiosField.ts
@@ -10,7 +10,13 @@ export class RadiosField extends SelectionControlField {
     super(def, model)
 
     const { options } = def
+    let { formSchema } = this
 
+    if (options.required === false) {
+      formSchema = formSchema.optional()
+    }
+
+    this.formSchema = formSchema
     this.options = options
   }
 }

--- a/src/server/plugins/engine/components/SelectField.test.ts
+++ b/src/server/plugins/engine/components/SelectField.test.ts
@@ -94,9 +94,9 @@ describe.each([
 
         const { formSchema } = componentOptional
 
-        expect(formSchema.describe().flags).toEqual(
+        expect(formSchema.describe()).toEqual(
           expect.objectContaining({
-            presence: 'optional'
+            allow: expect.arrayContaining([''])
           })
         )
 

--- a/src/server/plugins/engine/components/SelectField.test.ts
+++ b/src/server/plugins/engine/components/SelectField.test.ts
@@ -132,7 +132,7 @@ describe.each([
 
         expect(result.error).toEqual(
           expect.objectContaining({
-            message: expect.stringContaining(`Select ${label}`)
+            message: `Select ${label}`
           })
         )
       })

--- a/src/server/plugins/engine/components/SelectField.ts
+++ b/src/server/plugins/engine/components/SelectField.ts
@@ -22,7 +22,15 @@ export class SelectField extends ListFormComponent {
     super(def, model)
 
     const { options } = def
+    let { formSchema } = this
 
+    if (options.required === false) {
+      formSchema = formSchema.allow('')
+    } else {
+      formSchema = formSchema.empty('')
+    }
+
+    this.formSchema = formSchema
     this.options = options
   }
 

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -28,7 +28,7 @@ export class TelephoneNumberField extends FormComponent {
       .required()
 
     if (options.required === false) {
-      formSchema = formSchema.allow('').optional()
+      formSchema = formSchema.allow('')
     }
 
     if (options.customValidationMessage) {

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -69,13 +69,13 @@ describe('TextField', () => {
 
         const { formSchema } = componentOptional
 
-        expect(formSchema.describe().flags).toEqual(
+        expect(formSchema.describe()).toEqual(
           expect.objectContaining({
-            presence: 'optional'
+            allow: ['']
           })
         )
 
-        const result = formSchema.validate(undefined, opts)
+        const result = formSchema.validate('', opts)
         expect(result.error).toBeUndefined()
       })
 

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -32,7 +32,7 @@ export class TextField extends FormComponent {
     let formSchema = joi.string().trim().label(title.toLowerCase()).required()
 
     if (options.required === false) {
-      formSchema = formSchema.allow('').optional()
+      formSchema = formSchema.allow('')
     }
 
     if (typeof schema.length !== 'number') {

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -32,7 +32,7 @@ export class UkAddressField extends FormComponent {
     let stateSchema = joi.object().label(title).required()
 
     if (options.required === false) {
-      stateSchema = stateSchema.allow('', null).optional()
+      stateSchema = stateSchema.allow(null)
     }
 
     const childrenList = [

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -20,9 +20,15 @@ export class YesNoField extends ListFormComponent {
     super({ ...def, list: '__yesNo' }, model)
 
     const { options } = def
+    let { formSchema } = this
 
     addClassOptionIfNone(options, 'govuk-radios--inline')
 
+    if (options.required === false) {
+      formSchema = formSchema.optional()
+    }
+
+    this.formSchema = formSchema
     this.options = options
   }
 

--- a/test/condition/text.test.js
+++ b/test/condition/text.test.js
@@ -45,7 +45,7 @@ describe('TextField based conditions', () => {
     expect($input).not.toHaveValue()
   })
 
-  test('Testing POST /text/first-page with an nothing string redirects correctly', async () => {
+  test('Testing POST /text/first-page without values does not redirect', async () => {
     const form = {}
 
     const res = await server.inject({
@@ -54,8 +54,7 @@ describe('TextField based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(302)
-    expect(res.headers.location).toBe('/text/second-page')
+    expect(res.statusCode).toEqual(200)
   })
 
   test('Testing POST /text/first-page with an empty string redirects correctly', async () => {


### PR DESCRIPTION
This PR is a supporting change for [bug #428455](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/428455) to prevent double error messages

Only yes/no, radios and checkboxes are now `.optional()` since their values are not always POST'd

Other fields now default to empty strings `''` where appropriate