### PR TITLE
Use “Enter…” not “Select…” error messages for Autocomplete

### DIFF
--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -132,7 +132,7 @@ describe.each([
 
         expect(result.error).toEqual(
           expect.objectContaining({
-            message: `Select ${label}`
+            message: `Enter ${label}`
           })
         )
       })

--- a/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.ts
@@ -2,6 +2,7 @@ import { type AutocompleteFieldComponent } from '@defra/forms-model'
 
 import { SelectField } from '~/src/server/plugins/engine/components/SelectField.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 import {
   type FormData,
   type FormSubmissionErrors,
@@ -15,8 +16,17 @@ export class AutocompleteField extends SelectField {
     super(def, model)
 
     const { options } = def
+    let { formSchema } = this
+
+    if (options.required !== false) {
+      formSchema = formSchema.messages({
+        'any.only': messageTemplate.required,
+        'any.required': messageTemplate.required
+      })
+    }
 
     this.options = options
+    this.formSchema = formSchema
   }
 
   getDisplayStringFromState(state: FormSubmissionState): string {

--- a/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -1,8 +1,8 @@
-import { type ValidationOptions } from 'joi'
+import { type LanguageMessages, type ValidationOptions } from 'joi'
 /**
  * see @link https://joi.dev/api/?v=17.4.2#template-syntax for template syntax
  */
-const messageTemplate = {
+export const messageTemplate = {
   required: 'Enter {{#label}}',
   selectRequired: 'Select {{#label}}',
   max: '{{#label}} must be {{#limit}} characters or less',
@@ -19,7 +19,7 @@ const messageTemplate = {
   dateMax: '{{#label}} must be the same as or before {{#limit}}'
 }
 
-export const messages: ValidationOptions['messages'] = {
+export const messages: LanguageMessages = {
   'string.base': messageTemplate.required,
   'string.min': messageTemplate.min,
   'string.empty': messageTemplate.required,


### PR DESCRIPTION
This PR fixes [bug #428455](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/428455) to use the correct  “Enter…” not “Select…” error message for Autocomplete fields

See PR https://github.com/DEFRA/forms-runner/pull/444 (stacked) where double errors messages affected other fields

<img width="709" alt="Enter versus Select" src="https://github.com/user-attachments/assets/b12b9b30-44e1-4d97-a2d2-5a52e26a77d1">