### PR TITLE
#454587 Remove bypass of the summary page

### DIFF
--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -21,7 +21,6 @@ export class SummaryViewModel {
   pageTitle: string
   declaration?: string
   skipSummary?: boolean
-  endPage?: PageControllerClass
   result: any
   details: Detail[]
   relevantPages: PageControllerClass[]
@@ -51,15 +50,11 @@ export class SummaryViewModel {
     this.pageTitle = pageTitle
     this.serviceUrl = `/${model.basePath}`
     this.name = model.def.name
-    const { relevantPages, endPage } = this.getRelevantPages(
-      model,
-      relevantState
-    )
+    const relevantPages = this.getRelevantPages(model, relevantState)
     const details = this.summaryDetails(request, model, state, relevantPages)
     const { def } = model
     this.declaration = def.declaration
     this.skipSummary = def.skipSummary
-    this.endPage = endPage
     this.feedbackLink =
       def.feedback?.url ??
       ((!!def.feedback?.emailAddress &&
@@ -180,20 +175,18 @@ export class SummaryViewModel {
 
   private getRelevantPages(model: FormModel, state: FormSubmissionState) {
     let nextPage = model.startPage
-    let endPage
 
     const relevantPages: PageControllerClass[] = []
 
     while (nextPage != null) {
       if (nextPage.hasFormComponents) {
         relevantPages.push(nextPage)
-      } else if (nextPage.next.length) {
-        endPage = nextPage
       }
+
       nextPage = nextPage.getNextPage(state)
     }
 
-    return { relevantPages, endPage }
+    return relevantPages
   }
 }
 

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -73,14 +73,6 @@ export class SummaryPageController extends PageController {
         request
       )
 
-      if (viewModel.endPage) {
-        return redirectTo(
-          request,
-          h,
-          `/${model.basePath}${viewModel.endPage.path}`
-        )
-      }
-
       /**
        * iterates through the errors. If there are errors, a user will be redirected to the page
        * with the error with returnUrl=`/${model.basePath}/summary` in the URL query parameter.


### PR DESCRIPTION
Removing this as it's causing a problem on a form Bethan's working on (redirecting rather than taking the user to the summary page as intended).

I can't see a reason this needs to exist, given that all forms have a summary page built into the form definition.