### PR TITLE
Fix Hapi request types causing ESLint warnings etc

### DIFF
--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -27,7 +27,6 @@ export const configureEnginePlugin = (
     const id = idFromFilename(formFileName)
 
     model = new FormModel(definition, {
-      formId: id,
       basePath: id
     })
   }

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -6,12 +6,12 @@ import {
   encodeUrl,
   proceed,
   redirectTo,
-  redirectUrl,
-  type RequestWithQuery
+  redirectUrl
 } from '~/src/server/plugins/engine/helpers.js'
+import { type FormRequest } from '~/src/server/routes/types.js'
 
 describe('Helpers', () => {
-  let request: Pick<RequestWithQuery, 'query'>
+  let request: Pick<FormRequest, 'query'>
   let h: Pick<ResponseToolkit, 'redirect'>
 
   beforeEach(() => {

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -58,7 +58,7 @@ describe('Helpers', () => {
   describe('redirectTo', () => {
     it('should redirect to next url when no query params in the request', () => {
       const nextUrl = 'badgers/monkeys'
-      redirectTo(request, h, nextUrl)
+      redirectTo(h, nextUrl)
 
       expect(h.redirect).toHaveBeenCalledTimes(1)
       expect(h.redirect).toHaveBeenCalledWith(nextUrl)
@@ -69,7 +69,7 @@ describe('Helpers', () => {
       request.query.myParam2 = 'myValue2'
 
       const nextUrl = 'badgers/monkeys'
-      redirectTo(request, h, nextUrl)
+      redirectTo(h, nextUrl)
 
       expect(h.redirect).toHaveBeenCalledTimes(1)
       expect(h.redirect).toHaveBeenCalledWith(nextUrl)
@@ -104,7 +104,7 @@ describe('Helpers', () => {
   describe('redirectUrl', () => {
     it('should return target url when no query params in the request', () => {
       const nextUrl = 'badgers/monkeys'
-      const returned = redirectUrl(request, nextUrl)
+      const returned = redirectUrl(nextUrl)
 
       expect(returned).toEqual(nextUrl)
     })
@@ -114,7 +114,7 @@ describe('Helpers', () => {
       request.query.myParam2 = 'myValue2'
 
       const nextUrl = 'badgers/monkeys'
-      const returned = redirectUrl(request, nextUrl)
+      const returned = redirectUrl(nextUrl)
 
       expect(returned).toEqual(nextUrl)
     })
@@ -122,7 +122,7 @@ describe('Helpers', () => {
     it('should set params from params object', () => {
       const nextUrl = 'badgers/monkeys'
 
-      const returned = redirectUrl(request, nextUrl, {
+      const returned = redirectUrl(nextUrl, {
         returnUrl: '/myreturnurl',
         badger: 'monkeys'
       })

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -1,4 +1,4 @@
-import { type Request, type ResponseToolkit } from '@hapi/hapi'
+import { type ResponseToolkit } from '@hapi/hapi'
 
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
@@ -7,6 +7,11 @@ import {
   FormState,
   type FormStatus
 } from '~/src/server/plugins/engine/models/types.js'
+import {
+  type FormQuery,
+  type FormRequest,
+  type FormRequestPayload
+} from '~/src/server/routes/types.js'
 
 const logger = createLogger()
 
@@ -14,7 +19,7 @@ export const ADD_ANOTHER = 'add-another'
 export const CONTINUE = 'continue'
 
 export function proceed(
-  request: Pick<RequestWithQuery, 'query'>,
+  request: Pick<FormRequest | FormRequestPayload, 'query'>,
   h: Pick<ResponseToolkit, 'redirect'>,
   nextUrl: string
 ) {
@@ -41,7 +46,7 @@ export function encodeUrl(link?: string) {
   }
 }
 
-export function redirectUrl(targetUrl: string, params?: Params) {
+export function redirectUrl(targetUrl: string, params?: FormQuery) {
   const relativeUrl = new RelativeUrl(targetUrl)
 
   Object.entries(params ?? {}).forEach(([name, value]) => {
@@ -54,7 +59,7 @@ export function redirectUrl(targetUrl: string, params?: Params) {
 export function redirectTo(
   h: Pick<ResponseToolkit, 'redirect'>,
   targetUrl: string,
-  params?: Params
+  params?: FormQuery
 ) {
   if (targetUrl.startsWith('http')) {
     return h.redirect(targetUrl)
@@ -101,11 +106,3 @@ export function checkFormStatus(path: string): FormStatus {
     state
   }
 }
-
-export interface Params extends Partial<Record<string, string>> {
-  returnUrl?: string
-}
-
-export type RequestWithQuery = Request<{
-  Query: Params
-}>

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -23,7 +23,7 @@ export function proceed(
   if (returnUrl?.startsWith('/')) {
     return h.redirect(returnUrl)
   } else {
-    return redirectTo(request, h, nextUrl)
+    return redirectTo(h, nextUrl)
   }
 }
 
@@ -41,12 +41,9 @@ export function encodeUrl(link?: string) {
   }
 }
 
-export function redirectUrl(
-  request: Pick<RequestWithQuery, 'query'>,
-  targetUrl: string,
-  params?: Params
-) {
+export function redirectUrl(targetUrl: string, params?: Params) {
   const relativeUrl = new RelativeUrl(targetUrl)
+
   Object.entries(params ?? {}).forEach(([name, value]) => {
     relativeUrl.setParam(name, `${value}`)
   })
@@ -55,7 +52,6 @@ export function redirectUrl(
 }
 
 export function redirectTo(
-  request: Pick<RequestWithQuery, 'query'>,
   h: Pick<ResponseToolkit, 'redirect'>,
   targetUrl: string,
   params?: Params
@@ -64,7 +60,7 @@ export function redirectTo(
     return h.redirect(targetUrl)
   }
 
-  const url = redirectUrl(request, targetUrl, params)
+  const url = redirectUrl(targetUrl, params)
   return h.redirect(url)
 }
 

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -134,21 +134,18 @@ export class FormModel {
   /**
    * build the entire model schema from individual pages/sections
    */
-  makeSchema(state: FormSubmissionState) {
-    return this.makeFilteredSchema(state, this.pages)
+  makeSchema() {
+    return this.makeFilteredSchema(this.pages)
   }
 
   /**
    * build the entire model schema from individual pages/sections and filter out answers
    * for pages which are no longer accessible due to an answer that has been changed
    */
-  makeFilteredSchema(
-    _state: FormSubmissionState,
-    relevantPages: PageControllerClass[]
-  ) {
+  makeFilteredSchema(relevantPages: PageControllerClass[]) {
     // Build the entire model schema
     // from the individual pages/sections
-    let schema = joi.object().required()
+    let schema = joi.object<FormSubmissionState>().required()
 
     relevantPages.forEach((page) => {
       schema = schema.concat(page.stateSchema)

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -15,13 +15,10 @@ import { Parser } from 'expr-eval'
 import joi from 'joi'
 
 import { type ExecutableCondition } from '~/src/server/plugins/engine/models/types.js'
-import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 import {
   getPageController,
-  type PageControllerClass,
-  type PageControllerType
+  type PageControllerClass
 } from '~/src/server/plugins/engine/pageControllers/helpers.js'
-import { PageController } from '~/src/server/plugins/engine/pageControllers/index.js'
 import { type FormSubmissionState } from '~/src/server/plugins/engine/types.js'
 
 class EvaluationContext {
@@ -51,11 +48,9 @@ export class FormModel {
 
   lists: FormDefinition['lists']
   sections: FormDefinition['sections'] = []
-  options: { basePath: string; defaultPageController?: string }
+  options: { basePath: string }
   name: string
   values: FormDefinition
-  DefaultPageController: PageControllerType | undefined = PageController
-
   basePath: string
   conditions: Partial<Record<string, ExecutableCondition>>
   pages: PageControllerClass[]
@@ -95,16 +90,9 @@ export class FormModel {
     this.options = options
     this.name = def.name ?? ''
     this.values = result.value
-
-    if (options.defaultPageController) {
-      this.DefaultPageController = getPageController(
-        options.defaultPageController
-      )
-    }
-
     this.basePath = options.basePath
-
     this.conditions = {}
+
     def.conditions.forEach((conditionDef) => {
       const condition = this.makeCondition(conditionDef)
       this.conditions[condition.name] = condition
@@ -158,22 +146,8 @@ export class FormModel {
    * instantiates a Page based on {@link Page}
    */
   makePage(pageDef: Page): PageControllerClass {
-    if (pageDef.controller) {
-      const PageController = getPageController(pageDef.controller)
-
-      if (!PageController) {
-        throw new Error(`PageController for ${pageDef.controller} not found`)
-      }
-
-      return new PageController(this, pageDef)
-    }
-
-    if (this.DefaultPageController) {
-      const DefaultPageController = this.DefaultPageController
-      return new DefaultPageController(this, pageDef)
-    }
-
-    return new PageControllerBase(this, pageDef)
+    const PageController = getPageController(pageDef.controller)
+    return new PageController(this, pageDef)
   }
 
   /**

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -1,4 +1,3 @@
-import { type Request } from '@hapi/hapi'
 import { type ValidationResult } from 'joi'
 
 import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
@@ -11,6 +10,10 @@ import {
 import { RepeatPageController } from '~/src/server/plugins/engine/pageControllers/RepeatPageController.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import { type FormSubmissionState } from '~/src/server/plugins/engine/types.js'
+import {
+  type FormRequest,
+  type FormRequestPayload
+} from '~/src/server/routes/types.js'
 
 export class SummaryViewModel {
   /**
@@ -44,7 +47,7 @@ export class SummaryViewModel {
     model: FormModel,
     state: FormSubmissionState,
     relevantState: FormSubmissionState,
-    request: Request
+    request: FormRequest | FormRequestPayload
   ) {
     this.pageTitle = pageTitle
     this.serviceUrl = `/${model.basePath}`
@@ -105,7 +108,7 @@ export class SummaryViewModel {
   }
 
   private summaryDetails(
-    request: Request,
+    request: FormRequest | FormRequestPayload,
     model: FormModel,
     state: FormSubmissionState,
     relevantPages: PageControllerClass[]
@@ -162,7 +165,7 @@ export class SummaryViewModel {
 
 function addRepeaterItem(
   page: RepeatPageController,
-  request: Request,
+  request: FormRequest | FormRequestPayload,
   model: FormModel,
   state: FormSubmissionState,
   items: DetailItem[]

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -124,7 +124,7 @@ export class SummaryViewModel {
           addRepeaterItem(page, request, model, state, items)
         } else {
           for (const component of page.components.formItems) {
-            const item = Item(request, component, state, page, model)
+            const item = Item(component, state, page, model)
             if (items.find((cbItem) => cbItem.name === item.name)) return
             items.push(item)
           }
@@ -174,8 +174,8 @@ function addRepeaterItem(
   const rawValue = page.getListFromState(state)
   const hasItems = rawValue.length > 0
   const value = hasItems ? rawValue.length.toString() : '0'
-  const url = redirectUrl(request, hasItems ? repeatSummaryPath : path, {
-    returnUrl: redirectUrl(request, `/${model.basePath}/summary`)
+  const url = redirectUrl(hasItems ? repeatSummaryPath : path, {
+    returnUrl: redirectUrl(`/${model.basePath}/summary`)
   })
 
   const subItems: DetailItem[][] = []
@@ -183,7 +183,7 @@ function addRepeaterItem(
   rawValue.forEach((itemState) => {
     const sub: DetailItem[] = []
     for (const component of page.components.formItems) {
-      const item = Item(request, component, itemState, page, model)
+      const item = Item(component, itemState, page, model)
       if (sub.find((cbItem) => cbItem.name === item.name)) return
       sub.push(item)
     }
@@ -206,13 +206,12 @@ function addRepeaterItem(
  * Creates an Item object for Details
  */
 function Item(
-  request: Request,
   component: FormComponentFieldClass,
   state: FormSubmissionState,
   page: PageControllerClass,
   model: FormModel,
   params: { returnUrl: string } = {
-    returnUrl: redirectUrl(request, `/${model.basePath}/summary`)
+    returnUrl: redirectUrl(`/${model.basePath}/summary`)
   }
 ): DetailItem {
   return {
@@ -221,7 +220,7 @@ function Item(
     label: component.title,
     value: component.getDisplayStringFromState(state),
     rawValue: state[component.name],
-    url: redirectUrl(request, `/${model.basePath}${page.path}`, params),
+    url: redirectUrl(`/${model.basePath}${page.path}`, params),
     type: component.type,
     title: component.title,
     dataType: component.dataType

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -55,7 +55,7 @@ export class SummaryViewModel {
     this.declaration = def.declaration
     this.skipSummary = def.skipSummary
 
-    const schema = model.makeFilteredSchema(state, relevantPages)
+    const schema = model.makeFilteredSchema(relevantPages)
     const result = schema.validate(state, {
       abortEarly: false,
       stripUnknown: true

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -5,7 +5,7 @@ import {
   type Page
 } from '@defra/forms-model'
 import Boom from '@hapi/boom'
-import { type Request, type ResponseToolkit } from '@hapi/hapi'
+import { type ResponseToolkit } from '@hapi/hapi'
 import { type ValidationResult } from 'joi'
 
 import {
@@ -31,6 +31,12 @@ import {
   type UploadState,
   type UploadStatusResponse
 } from '~/src/server/plugins/engine/types.js'
+import {
+  type FormRequest,
+  type FormRequestPayload,
+  type FormRequestPayloadRefs,
+  type FormRequestRefs
+} from '~/src/server/routes/types.js'
 import { type CacheService } from '~/src/server/services/cacheService.js'
 
 const MAX_UPLOADS = 25
@@ -86,7 +92,7 @@ export class FileUploadPageController extends PageController {
     this.fileUploadComponent = fileUploadComponents[0]
   }
 
-  async getState(request: Request) {
+  async getState(request: FormRequest) {
     // Get the actual state
     const state = await super.getState(request)
     const name = this.getComponentName()
@@ -99,7 +105,10 @@ export class FileUploadPageController extends PageController {
   }
 
   makeGetRouteHandler() {
-    return async (request: Request, h: ResponseToolkit) => {
+    return async (
+      request: FormRequest,
+      h: ResponseToolkit<FormRequestRefs>
+    ) => {
       const { cacheService } = request.services([])
       const state = await cacheService.getUploadState(request)
 
@@ -110,7 +119,10 @@ export class FileUploadPageController extends PageController {
   }
 
   makePostRouteHandler() {
-    return async (request: Request, h: ResponseToolkit) => {
+    return async (
+      request: FormRequestPayload,
+      h: ResponseToolkit<FormRequestPayloadRefs>
+    ) => {
       const { cacheService } = request.services([])
       const state = await cacheService.getUploadState(request)
 
@@ -127,7 +139,7 @@ export class FileUploadPageController extends PageController {
     }
   }
 
-  protected getPayload(request: Request) {
+  protected getPayload(request: FormRequestPayload) {
     const payload = super.getPayload(request)
     const name = this.getComponentName()
     const files = request.app.files ?? []
@@ -182,7 +194,7 @@ export class FileUploadPageController extends PageController {
   }
 
   getViewModel(
-    request: Request,
+    request: FormRequest | FormRequestPayload,
     payload: FormPayload,
     errors?: FormSubmissionErrors
   ): FileUploadPageViewModel {
@@ -223,7 +235,7 @@ export class FileUploadPageController extends PageController {
    * @param cacheService - the cache service
    */
   private async refreshUpload(
-    request: Request,
+    request: FormRequest | FormRequestPayload,
     state: TempFileState,
     cacheService: CacheService
   ) {
@@ -246,7 +258,7 @@ export class FileUploadPageController extends PageController {
    * @param cacheService - the cache service
    */
   private async checkUploadStatus(
-    request: Request,
+    request: FormRequest | FormRequestPayload,
     state: TempFileState,
     cacheService: CacheService
   ) {
@@ -300,7 +312,7 @@ export class FileUploadPageController extends PageController {
    * @param cacheService - the cache service
    */
   private async refreshPendingFiles(
-    request: Request,
+    request: FormRequest | FormRequestPayload,
     state: TempFileState,
     cacheService: CacheService
   ) {
@@ -350,7 +362,7 @@ export class FileUploadPageController extends PageController {
    * @returns true if any files have been removed otherwise false
    */
   private async checkRemovedFiles(
-    request: Request,
+    request: FormRequestPayload,
     state: TempFileState,
     cacheService: CacheService
   ) {
@@ -381,7 +393,7 @@ export class FileUploadPageController extends PageController {
    * @param cacheService - the cache service
    */
   private async initiateAndStoreNewUpload(
-    request: Request,
+    request: FormRequest | FormRequestPayload,
     state: TempFileState,
     cacheService: CacheService
   ) {

--- a/src/server/plugins/engine/pageControllers/HomePageController.ts
+++ b/src/server/plugins/engine/pageControllers/HomePageController.ts
@@ -1,9 +1,13 @@
 import { type RouteOptions } from '@hapi/hapi'
 
 import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
+import {
+  type FormRequestPayloadRefs,
+  type FormRequestRefs
+} from '~/src/server/routes/types.js'
 
 export class HomePageController extends PageController {
-  get getRouteOptions(): RouteOptions {
+  get getRouteOptions(): RouteOptions<FormRequestRefs> {
     return {
       ext: {
         onPostHandler: {
@@ -15,7 +19,7 @@ export class HomePageController extends PageController {
     }
   }
 
-  get postRouteOptions(): RouteOptions {
+  get postRouteOptions(): RouteOptions<FormRequestPayloadRefs> {
     return {
       ext: {
         onPostHandler: {

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -1,12 +1,16 @@
 import { type RouteOptions } from '@hapi/hapi'
 
 import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
+import {
+  type FormRequestPayloadRefs,
+  type FormRequestRefs
+} from '~/src/server/routes/types.js'
 
 export class PageController extends PageControllerBase {
   /**
    * {@link https://hapi.dev/api/?v=20.1.2#route-options}
    */
-  get getRouteOptions(): RouteOptions {
+  get getRouteOptions(): RouteOptions<FormRequestRefs> {
     return {
       ext: {
         onPostHandler: {
@@ -21,7 +25,7 @@ export class PageController extends PageControllerBase {
   /**
    * {@link https://hapi.dev/api/?v=20.1.2#route-options}
    */
-  get postRouteOptions(): RouteOptions {
+  get postRouteOptions(): RouteOptions<FormRequestPayloadRefs> {
     return {
       payload: {
         parse: true,

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -400,15 +400,15 @@ export class PageControllerBase {
 
       if (shouldRedirectToStartPage) {
         return startPage?.startsWith('http')
-          ? redirectTo(request, h, startPage)
-          : redirectTo(request, h, `/${this.model.basePath}${startPage}`)
+          ? redirectTo(h, startPage)
+          : redirectTo(h, `/${this.model.basePath}${startPage}`)
       }
 
       const viewModel = this.getViewModel(request, payload)
 
       viewModel.startPage = startPage?.startsWith('http')
-        ? redirectTo(request, h, startPage)
-        : redirectTo(request, h, `/${this.model.basePath}${startPage}`)
+        ? redirectTo(h, startPage)
+        : redirectTo(h, `/${this.model.basePath}${startPage}`)
 
       /**
        * Content components can be hidden based on a condition. If the condition evaluates to true, it is safe to be kept, otherwise discard it

--- a/src/server/plugins/engine/pageControllers/StartPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StartPageController.ts
@@ -1,10 +1,9 @@
-import { type Request } from '@hapi/hapi'
-
 import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import {
   type FormPayload,
   type FormSubmissionErrors
 } from '~/src/server/plugins/engine/types.js'
+import { type FormRequest } from '~/src/server/routes/types.js'
 
 export class StartPageController extends PageController {
   /**
@@ -14,7 +13,7 @@ export class StartPageController extends PageController {
    */
 
   getViewModel(
-    request: Request,
+    request: FormRequest,
     payload: FormPayload,
     errors?: FormSubmissionErrors
   ) {

--- a/src/server/plugins/engine/pageControllers/StatusPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StatusPageController.ts
@@ -1,17 +1,17 @@
 import { type Boom } from '@hapi/boom'
-import {
-  type Request,
-  type ResponseObject,
-  type ResponseToolkit
-} from '@hapi/hapi'
+import { type ResponseObject, type ResponseToolkit } from '@hapi/hapi'
 
 import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
+import {
+  type FormRequest,
+  type FormRequestRefs
+} from '~/src/server/routes/types.js'
 
 export class StatusPageController extends PageController {
   makeGetRouteHandler(): (
-    request: Request,
-    h: ResponseToolkit
+    request: FormRequest,
+    h: ResponseToolkit<FormRequestRefs>
   ) => Promise<ResponseObject | Boom> {
     return async (request, h) => {
       const model = this.model

--- a/src/server/plugins/engine/pageControllers/StatusPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StatusPageController.ts
@@ -20,7 +20,7 @@ export class StatusPageController extends PageController {
 
       // If there's no confirmation state, then
       // redirect the user back to the start of the form
-      if (!confirmationState) {
+      if (!confirmationState.confirmed) {
         return h.redirect(`/${model.basePath}`).temporary()
       }
 

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
@@ -3,7 +3,6 @@ import {
   type ComponentDef,
   type FormDefinition
 } from '@defra/forms-model'
-import { type Request } from '@hapi/hapi'
 import { format } from 'date-fns'
 
 import {
@@ -15,6 +14,7 @@ import {
   getPersonalisation,
   getQuestions
 } from '~/src/server/plugins/engine/pageControllers/SummaryPageController.js'
+import { type FormRequest } from '~/src/server/routes/types.js'
 
 describe('SummaryPageController', () => {
   describe('getPersonalisation', () => {
@@ -49,7 +49,7 @@ describe('SummaryPageController', () => {
       model,
       {},
       {},
-      {} as Request
+      {} as FormRequest
     )
 
     const formStatus = (previewStatus: boolean) => ({

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -5,7 +5,6 @@ import {
 } from '@defra/forms-model'
 import { badRequest, internal, type Boom } from '@hapi/boom'
 import {
-  type Request,
   type ResponseObject,
   type ResponseToolkit,
   type RouteOptions
@@ -39,6 +38,12 @@ import {
   type FileState,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
+import {
+  type FormRequest,
+  type FormRequestPayload,
+  type FormRequestPayloadRefs,
+  type FormRequestRefs
+} from '~/src/server/routes/types.js'
 import { type Field } from '~/src/server/schemas/types.js'
 import { sendNotification } from '~/src/server/utils/notify.js'
 
@@ -60,7 +65,7 @@ export class SummaryPageController extends PageController {
     title: string,
     model: FormModel,
     state: FormSubmissionState,
-    request: Request
+    request: FormRequest | FormRequestPayload
   ): SummaryViewModel {
     const relevantState = this.getConditionEvaluationContext(model, state)
 
@@ -84,8 +89,8 @@ export class SummaryPageController extends PageController {
    * Returns an async function. This is called in plugin.ts when there is a GET request at `/{id}/{path*}`,
    */
   makeGetRouteHandler(): (
-    request: Request,
-    h: ResponseToolkit
+    request: FormRequest,
+    h: ResponseToolkit<FormRequestRefs>
   ) => Promise<ResponseObject | Boom> {
     return async (request, h) => {
       const { cacheService } = request.services([])
@@ -162,8 +167,8 @@ export class SummaryPageController extends PageController {
    * If a form is incomplete, a user will be redirected to the start page.
    */
   makePostRouteHandler(): (
-    request: Request,
-    h: ResponseToolkit
+    request: FormRequestPayload,
+    h: ResponseToolkit<FormRequestPayloadRefs>
   ) => Promise<ResponseObject | Boom> {
     return async (request, h) => {
       const { cacheService } = request.services([])
@@ -208,7 +213,7 @@ export class SummaryPageController extends PageController {
     }
   }
 
-  get postRouteOptions(): RouteOptions {
+  get postRouteOptions(): RouteOptions<FormRequestPayloadRefs> {
     return {
       ext: {
         onPreHandler: {
@@ -222,7 +227,7 @@ export class SummaryPageController extends PageController {
 }
 
 async function submitForm(
-  request: Request,
+  request: FormRequestPayload,
   summaryViewModel: SummaryViewModel,
   model: FormModel,
   state: FormSubmissionState,
@@ -298,7 +303,7 @@ function submitData(
 }
 
 async function sendEmail(
-  request: Request,
+  request: FormRequestPayload,
   summaryViewModel: SummaryViewModel,
   model: FormModel,
   emailAddress: string

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -137,10 +137,9 @@ export class SummaryPageController extends PageController {
         })
         if (pageWithError) {
           const params = {
-            returnUrl: redirectUrl(request, `/${model.basePath}/summary`)
+            returnUrl: redirectUrl(`/${model.basePath}/summary`)
           }
           return redirectTo(
-            request,
             h,
             `/${model.basePath}${pageWithError.path}`,
             params
@@ -205,7 +204,7 @@ export class SummaryPageController extends PageController {
       // Clear all form data
       await cacheService.clearState(request)
 
-      return redirectTo(request, h, `/${model.basePath}/status`)
+      return redirectTo(h, `/${model.basePath}/status`)
     }
   }
 

--- a/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.ts
@@ -20,13 +20,11 @@ export type PageControllerType =
 /**
  * Gets the class for the controller defined in a {@link Page}
  */
-export function getPageController(
-  nameOrPath: string
-): PageControllerType | undefined {
+export function getPageController(nameOrPath?: string): PageControllerType {
   const controllerName = controllerNameFromPath(nameOrPath)
 
   if (!isPageController(controllerName)) {
-    return
+    return PageControllers.PageController
   }
 
   return PageControllers[controllerName]

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -203,6 +203,8 @@ export const plugin = {
       if (page) {
         return page.makePostRouteHandler()(request, h)
       }
+
+      throw Boom.notFound('No form or page found')
     }
 
     const dispatchRouteOptions: RouteOptions<FormRequestRefs> = {

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -32,7 +32,10 @@ function normalisePath(path: string) {
   return path.replace(/^\//, '').replace(/\/$/, '')
 }
 
-function getPage(model: FormModel | undefined, path: string) {
+function getPage(request: FormRequest | FormRequestPayload) {
+  const { model } = request.app
+  const { path } = request.params
+
   return model?.pages.find(
     (page) => normalisePath(page.path) === normalisePath(path)
   )
@@ -178,7 +181,7 @@ export const plugin = {
     ) => {
       const { model } = request.app
       const { path } = request.params
-      const page = getPage(model, path)
+      const page = getPage(request)
 
       if (page) {
         return page.makeGetRouteHandler()(request, h)
@@ -195,11 +198,7 @@ export const plugin = {
       request: FormRequestPayload,
       h: ResponseToolkit<FormRequestPayloadRefs>
     ) => {
-      const { path } = request.params
-      const model = request.app.model
-      const page = model?.pages.find(
-        (page) => page.path.replace(/^\//, '') === path
-      )
+      const page = getPage(request)
 
       if (page) {
         return page.makePostRouteHandler()(request, h)
@@ -337,9 +336,7 @@ export const plugin = {
       request: FormRequest,
       h: ResponseToolkit<FormRequestRefs>
     ) => {
-      const { model } = request.app
-      const { path } = request.params
-      const page = getPage(model, path)
+      const page = getPage(request)
 
       if (page && page instanceof RepeatPageController) {
         return page.makeGetListSummaryRouteHandler()(request, h)
@@ -384,9 +381,7 @@ export const plugin = {
       request: FormRequestPayload,
       h: ResponseToolkit<FormRequestPayloadRefs>
     ) => {
-      const { model } = request.app
-      const { path } = request.params
-      const page = getPage(model, path)
+      const page = getPage(request)
 
       if (page && page instanceof RepeatPageController) {
         return page.makePostListSummaryRouteHandler()(request, h)
@@ -443,9 +438,7 @@ export const plugin = {
       request: FormRequest,
       h: ResponseToolkit<FormRequestRefs>
     ) => {
-      const { model } = request.app
-      const { path } = request.params
-      const page = getPage(model, path)
+      const page = getPage(request)
 
       if (page && page instanceof RepeatPageController) {
         return page.makeGetListDeleteRouteHandler()(request, h)
@@ -492,9 +485,7 @@ export const plugin = {
       request: FormRequestPayload,
       h: ResponseToolkit<FormRequestPayloadRefs>
     ) => {
-      const { model } = request.app
-      const { path } = request.params
-      const page = getPage(model, path)
+      const page = getPage(request)
 
       if (page && page instanceof RepeatPageController) {
         return page.makePostListDeleteRouteHandler()(request, h)

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -428,7 +428,7 @@ export const plugin = {
       path: '/{slug}/{path}/summary',
       handler: postListSummaryHandler,
       options: {
-        ...getRouteOptions,
+        ...postRouteOptions,
         validate: {
           params: Joi.object().keys({
             slug: slugSchema,
@@ -449,7 +449,7 @@ export const plugin = {
       path: '/preview/{state}/{slug}/{path}/summary',
       handler: postListSummaryHandler,
       options: {
-        ...getRouteOptions,
+        ...postRouteOptions,
         validate: {
           params: Joi.object().keys({
             state: stateSchema,
@@ -550,7 +550,7 @@ export const plugin = {
       path: '/{slug}/{path}/{itemId}/confirm-delete',
       handler: postListDeleteHandler,
       options: {
-        ...getRouteOptions,
+        ...postRouteOptions,
         validate: {
           params: Joi.object().keys({
             slug: slugSchema,
@@ -572,7 +572,7 @@ export const plugin = {
       path: '/preview/{state}/{slug}/{path}/{itemId}/confirm-delete',
       handler: postListDeleteHandler,
       options: {
-        ...getRouteOptions,
+        ...postRouteOptions,
         validate: {
           params: Joi.object().keys({
             state: stateSchema,

--- a/src/server/plugins/views.ts
+++ b/src/server/plugins/views.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
 
 import { markdownToHtml } from '@defra/forms-model'
-import { type Request, type ServerRegisterPluginObject } from '@hapi/hapi'
+import { type ServerRegisterPluginObject } from '@hapi/hapi'
 import vision, { type ServerViewsConfiguration } from '@hapi/vision'
 import capitalize from 'lodash/capitalize.js'
 import nunjucks from 'nunjucks'
@@ -13,6 +13,10 @@ import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
 import { encodeUrl } from '~/src/server/plugins/engine/helpers.js'
+import {
+  type FormRequest,
+  type FormRequestPayload
+} from '~/src/server/routes/types.js'
 
 const logger = createLogger()
 
@@ -40,14 +44,7 @@ nunjucksEnvironment.addFilter('markdown', markdownToHtml)
 
 let webpackManifest: Record<string, string> | undefined
 
-function nunjucksContext(
-  request: Request<{
-    Params: {
-      slug?: string
-      state?: 'draft' | 'live'
-    }
-  }> | null
-) {
+function nunjucksContext(request: FormRequest | FormRequestPayload | null) {
   const manifestPath = join(config.get('publicDir'), 'assets-manifest.json')
 
   if (!webpackManifest) {

--- a/src/server/routes/types.ts
+++ b/src/server/routes/types.ts
@@ -1,0 +1,29 @@
+import { type ReqRefDefaults, type Request } from '@hapi/hapi'
+
+import { type FormPayload } from '~/src/server/plugins/engine/types.js'
+
+export interface FormQuery extends Partial<Record<string, string>> {
+  returnUrl?: string
+}
+
+export interface FormParams extends Partial<Record<string, string>> {
+  path: string
+  slug: string
+  state?: 'draft' | 'live'
+}
+
+export interface FormRequestRefs
+  extends Omit<ReqRefDefaults, 'Params' | 'Query'> {
+  Params: FormParams
+  Query: FormQuery
+}
+
+export interface FormRequestPayloadRefs extends FormRequestRefs {
+  Payload: {
+    action?: string
+    confirm?: boolean
+  } & FormPayload
+}
+
+export type FormRequest = Request<FormRequestRefs>
+export type FormRequestPayload = Request<FormRequestPayloadRefs>

--- a/src/server/services/cacheService.ts
+++ b/src/server/services/cacheService.ts
@@ -3,7 +3,6 @@ import { merge } from '@hapi/hoek'
 
 import { config } from '~/src/config/index.js'
 import { type createServer } from '~/src/server/index.js'
-import { type ViewModel } from '~/src/server/plugins/engine/components/types.js'
 import {
   type FormSubmissionState,
   type TempFileState
@@ -47,20 +46,16 @@ export class CacheService {
     return this.getState(request)
   }
 
-  async getConfirmationState(request: Request) {
+  async getConfirmationState(request: Request): Promise<{ confirmed?: true }> {
     const key = this.Key(request, ADDITIONAL_IDENTIFIER.Confirmation)
+    const value = await this.cache.get(key)
 
-    return await this.cache.get(key)
+    return value || {}
   }
 
-  async setConfirmationState(request: Request, viewModel: ViewModel) {
+  async setConfirmationState(request: Request, value: { confirmed?: true }) {
     const key = this.Key(request, ADDITIONAL_IDENTIFIER.Confirmation)
-
-    return this.cache.set(
-      key,
-      viewModel,
-      config.get('confirmationSessionTimeout')
-    )
+    return this.cache.set(key, value, config.get('confirmationSessionTimeout'))
   }
 
   async getUploadState(request: Request) {

--- a/test/form/file-upload.test.js
+++ b/test/form/file-upload.test.js
@@ -208,7 +208,8 @@ describe('File upload POST tests', () => {
     const { container, response } = await renderResponse(server, {
       method: 'POST',
       url,
-      headers
+      headers,
+      payload: {}
     })
 
     expect(response.statusCode).toBe(okStatusCode)
@@ -261,7 +262,8 @@ describe('File upload POST tests', () => {
     const res3 = await server.inject({
       method: 'POST',
       url,
-      headers
+      headers,
+      payload: {}
     })
 
     expect(res3.statusCode).toBe(redirectStatusCode)

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -304,7 +304,8 @@ describe('Submission journey test', () => {
     const res = await server.inject({
       method: 'POST',
       url: fileUploadPath,
-      headers
+      headers,
+      payload: {}
     })
 
     expect(res.statusCode).toEqual(redirectStatusCode)


### PR DESCRIPTION
Lots of commits I'd recommend going through one by one. Stacked on top of:

* https://github.com/DEFRA/forms-runner/pull/471

The main addition is for `FormRequest` (GET) and `FormRequestPayload` (POST) types for Hapi

```patch
  private summaryDetails(
-   request: Request,
+   request: FormRequest | FormRequestPayload,
    model: FormModel,
    state: FormSubmissionState,
    relevantPages: PageControllerClass[]
  ) {
```

Or to fix a few POST routes accidentally using GET options

```patch
      path: '/{slug}/{path}/summary',
      handler: postListSummaryHandler,
      options: {
-       ...getRouteOptions,
+       ...postRouteOptions,
        validate: {
          params: Joi.object().keys({
            slug: slugSchema,
```

## Before
Output from `npm run lint:js`

```console
✖ 115 problems (7 errors, 108 warnings)
```

## After
Output from `npm run lint:js`

```console
✖ 100 problems (7 errors, 93 warnings)
```