### PR TITLE
Add missing components to GOV.UK Notify tests

### DIFF
--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -455,7 +455,7 @@ export function getPersonalisation(
   })
 
   lines.push(
-    `[Download all](${designerUrl}/file-download/${submitResponse.result.files.main})`
+    `[Download all](${designerUrl}/file-download/${submitResponse.result.files.main})\n`
   )
 
   return {

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -405,8 +405,11 @@ export function getPersonalisation(
    * generate the question and answers works for now
    */
   const now = new Date()
+  const formattedNow = `${format(now, 'h:mmaaa')} on ${format(now, 'd MMMM yyyy')}`
+
   const fileExpiryDate = addDays(now, 30)
   const formattedExpiryDate = `${format(fileExpiryDate, 'h:mmaaa')} on ${format(fileExpiryDate, 'eeee d MMMM yyyy')}`
+
   const subject = formStatus.isPreview
     ? `TEST FORM SUBMISSION: ${model.name}`
     : `Form received: ${model.name}`
@@ -421,9 +424,7 @@ export function getPersonalisation(
     lines.push(`This is a test of the ${model.name} ${formStatus.state} form.`)
   }
 
-  lines.push(
-    `Form received at ${format(now, 'h:mmaaa')} on ${format(now, 'd MMMM yyyy')}.`
-  )
+  lines.push(`Form received at ${formattedNow}.\n`)
 
   questions.forEach((question) => {
     const { title, value, field } = question

--- a/test/form/definitions/components.json
+++ b/test/form/definitions/components.json
@@ -38,6 +38,13 @@
           "schema": {}
         },
         {
+          "type": "MonthYearField",
+          "name": "monthYearField",
+          "title": "Month year field",
+          "options": {},
+          "schema": {}
+        },
+        {
           "type": "YesNoField",
           "name": "yesNoField",
           "title": "Yes/No field",
@@ -77,6 +84,14 @@
           "type": "SelectField",
           "name": "selectField",
           "title": "Select field",
+          "list": "country",
+          "options": {},
+          "schema": {}
+        },
+        {
+          "type": "AutocompleteField",
+          "name": "autocompleteField",
+          "title": "Autocomplete field",
           "list": "country",
           "options": {},
           "schema": {}

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -140,6 +140,8 @@ Arabian,Shire,Race
 
 * [test.pdf](https://test-designer.cdp-int.defra.cloud/file-download/5a76a1a3-bc8a-4bc0-859a-116d775c7f15)
 
+
+[Download all](https://test-designer.cdp-int.defra.cloud/file-download/00000000-0000-0000-0000-000000000000)
 `
 
 const componentsPath = '/components/all-components'

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -29,12 +29,17 @@ const okStatusCode = 200
 const redirectStatusCode = 302
 const htmlContentType = 'text/html'
 
-const FILE_EXPIRY_DAYS = 30
-const now = new Date()
-const fileExpiryDate = addDays(now, FILE_EXPIRY_DAYS)
+const dateNow = new Date()
+const dateNowFormatted = `${format(dateNow, 'h:mmaaa')} on ${format(dateNow, 'd MMMM yyyy')}`
+
+const fileExpiryDate = addDays(dateNow, 30)
 const formattedExpiryDate = `${format(fileExpiryDate, 'h:mmaaa')} on ${format(fileExpiryDate, 'eeee d MMMM yyyy')}`
 
-const formResults = `## Text field
+const formResults = `^ For security reasons, the links in this email expire at ${formattedExpiryDate}
+
+Form received at ${dateNowFormatted}.
+
+## Text field
 \`\`\`
 Text field
 \`\`\`
@@ -232,7 +237,7 @@ describe('Submission journey test', () => {
       emailAddress: 'enrique.chase@defra.gov.uk',
       personalisation: {
         subject: 'Form received: All components',
-        body: expect.stringContaining(formResults)
+        body: formResults
       }
     })
 

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -58,6 +58,12 @@ Multiline text field
 \`\`\`
 
 
+## Month year field
+\`\`\`
+2012-12
+\`\`\`
+
+
 ## Yes/No field
 \`\`\`
 yes
@@ -91,6 +97,12 @@ privateLimitedCompany
 ## Select field
 \`\`\`
 910400000
+\`\`\`
+
+
+## Autocomplete field
+\`\`\`
+910400044
 \`\`\`
 
 
@@ -239,6 +251,8 @@ describe('Submission journey test', () => {
       datePartsField__day: '12',
       datePartsField__month: '12',
       datePartsField__year: '2012',
+      monthYearField__month: '12',
+      monthYearField__year: '2012',
       yesNoField: 'true',
       emailAddressField: 'user@email.com',
       telephoneNumberField: '+447900000000',
@@ -248,6 +262,7 @@ describe('Submission journey test', () => {
       addressField__postcode: 'CW1 1AB',
       radiosField: 'privateLimitedCompany',
       selectField: '910400000',
+      autocompleteField: '910400044',
       checkboxesSingle: 'Shetland',
       checkboxesMultiple: ['Arabian', 'Shire', 'Race'],
       checkboxesSingleNumber: 1,


### PR DESCRIPTION
Closes assurance ticket [#461367](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/461367)

Adds tests for the following components:

* Autocomplete
* Month & Year

Plus tests for the "Form received at" date and "Download all" link