### PR TITLE
Update components to ensure getDisplayStringFromState always returns a string

### DIFF
--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -43,8 +43,11 @@ export class CheckboxesField extends SelectionControlField {
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {
-    return state[this.name]
-      ?.map(
+    const value = state[this.name]
+    const values = [value ?? []].flat()
+
+    return values
+      .map(
         (value) =>
           this.items.find((item) => `${item.value}` === `${value}`)?.text ?? ''
       )

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -122,7 +122,17 @@ export class FormComponent extends ComponentBase {
     return { [this.name]: this.stateSchema }
   }
 
-  getDisplayStringFromState(state) {
-    return state[this.name] ?? ''
+  getDisplayStringFromState(state: FormSubmissionState) {
+    const value = state[this.name]
+
+    if (
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+    ) {
+      return value.toString()
+    }
+
+    return ''
   }
 }

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -79,6 +79,6 @@ export class NumberField extends FormComponent {
   getDisplayStringFromState(state: FormSubmissionState) {
     return state[this.name] || state[this.name] === 0
       ? state[this.name].toString()
-      : undefined
+      : ''
   }
 }


### PR DESCRIPTION
Update `NumberField`, `CheckboxesField` and `FormComponent` base class to always return a string