### PR TITLE
Add tests for `UkAddressField` and other fields

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -78,24 +78,22 @@ export class DatePartsField extends FormComponent {
       model
     )
 
+    let { formSchema } = this.children
+
+    // Update child schema
+    formSchema = formSchema
+      .custom(getCustomDateValidator(this))
+      .label(title.toLowerCase())
+
     this.options = options
+    this.formSchema = formSchema
     this.stateSchema = stateSchema
+
+    this.children.formSchema = formSchema
   }
 
   getFormSchemaKeys() {
     return this.children.getFormSchemaKeys()
-  }
-
-  getStateSchemaKeys() {
-    const { options } = this
-    const { maxDaysInPast, maxDaysInFuture } = options
-    let schema = this.stateSchema
-
-    schema = schema.custom(
-      getCustomDateValidator(maxDaysInPast, maxDaysInFuture)
-    )
-
-    return { [this.name]: schema }
   }
 
   getFormDataFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -149,6 +149,16 @@ export class DatePartsField extends FormComponent {
     const viewModel = super.getViewModel(payload, errors)
     let { fieldset, label } = viewModel
 
+    // Filter component and children errors only
+    const componentErrors = errors?.errorList.filter(
+      (error) =>
+        error.name === name || // Errors for parent component only
+        error.name.startsWith(`${name}__`) // Plus `${name}__year` etc fields
+    )
+
+    // Check for component errors only
+    const hasError = componentErrors?.some((error) => error.name === name)
+
     // Use the component collection to generate the subitems
     const items: DateInputItem[] = children
       .getViewModel(payload, errors)
@@ -160,7 +170,7 @@ export class DatePartsField extends FormComponent {
           label.toString = () => label.text // Date component uses string labels
         }
 
-        if (errorMessage) {
+        if (hasError || errorMessage) {
           classes = `${classes} govuk-input--error`.trim()
         }
 
@@ -177,11 +187,6 @@ export class DatePartsField extends FormComponent {
           classes
         }
       })
-
-    // Filter errors for this component only
-    const componentErrors = errors?.errorList.filter(
-      (error) => error.name.startsWith(`${name}__`) // E.g. `${name}__year`
-    )
 
     const errorMessage = componentErrors?.[0] && {
       text: componentErrors[0].text

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -198,6 +198,43 @@ describe('EmailAddressField', () => {
             output: { value: 'defra.helpline@defra.gov.uk' }
           }
         ]
+      },
+      {
+        description: 'Custom validation',
+        component: {
+          title: 'Example email address field',
+          name: 'myComponent',
+          type: ComponentType.EmailAddressField,
+          options: {
+            customValidationMessage: 'This is a custom error'
+          }
+        } satisfies EmailAddressFieldComponent,
+        assertions: [
+          {
+            input: 'invalid',
+            output: {
+              value: 'invalid',
+              error: new Error('This is a custom error')
+            }
+          }
+        ]
+      },
+      {
+        description: 'Optional field',
+        component: {
+          title: 'Example email address field',
+          name: 'myComponent',
+          type: ComponentType.EmailAddressField,
+          options: {
+            required: false
+          }
+        } satisfies EmailAddressFieldComponent,
+        assertions: [
+          {
+            input: '',
+            output: { value: '' }
+          }
+        ]
       }
     ])('$description', ({ component: def, assertions }) => {
       let component: EmailAddressField

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -112,7 +112,7 @@ describe('EmailAddressField', () => {
     })
 
     describe('State', () => {
-      it('Returns text from state value', () => {
+      it('returns text from state value', () => {
         const text = component.getDisplayStringFromState({
           [def.name]: 'Text field'
         })

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -201,24 +201,9 @@ describe('EmailAddressField', () => {
       }
     ])('$description', ({ component: def, assertions }) => {
       let component: EmailAddressField
-      let label: string
 
       beforeEach(() => {
         component = new EmailAddressField(def, formModel)
-        label = def.title.toLowerCase()
-      })
-
-      it('validates empty value', () => {
-        const { formSchema } = component
-
-        const input = ''
-        const output = {
-          value: '',
-          error: new Error(`Enter ${label}`)
-        }
-
-        const result = formSchema.validate(input, opts)
-        expect(result).toEqual(output)
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/FileUploadField.test.ts
+++ b/src/server/plugins/engine/components/FileUploadField.test.ts
@@ -243,7 +243,7 @@ describe('FileUploadField', () => {
     })
 
     describe('State', () => {
-      it('Returns text from state value', () => {
+      it('returns text from state value', () => {
         const text = component.getDisplayStringFromState({
           [def.name]: [{}, {}]
         })

--- a/src/server/plugins/engine/components/FileUploadField.test.ts
+++ b/src/server/plugins/engine/components/FileUploadField.test.ts
@@ -588,28 +588,16 @@ describe('FileUploadField', () => {
       }
     ])('$description', ({ component: def, assertions }) => {
       let component: FileUploadField
-      let label: string
+
       beforeEach(() => {
         component = new FileUploadField(def, formModel)
-        label = def.title.toLowerCase()
       })
-      it('validates empty value', () => {
-        const { formSchema } = component
-        const input = null
-        const output = {
-          value: undefined,
-          error:
-            component.options.required === false
-              ? undefined
-              : new Error(`Select ${label}`)
-        }
-        const result = formSchema.validate(input, opts)
-        expect(result).toEqual(output)
-      })
+
       it.each([...assertions])(
         'validates custom example',
         ({ input, output }) => {
           const { formSchema } = component
+
           const result = formSchema.validate(input, opts)
           expect(result).toEqual(output)
         }

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -1,57 +1,426 @@
-import { ComponentType, type ComponentDef } from '@defra/forms-model'
-import joi, { type ObjectSchema } from 'joi'
+import {
+  ComponentType,
+  type FormDefinition,
+  type MonthYearFieldComponent
+} from '@defra/forms-model'
+import { startOfDay } from 'date-fns'
 
-import { type ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { MonthYearField } from '~/src/server/plugins/engine/components/MonthYearField.js'
-import { type PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
-import { messages } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
+import { type DateInputItem } from '~/src/server/plugins/engine/components/types.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import { validationOptions as opts } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
+import {
+  type FormData,
+  type FormState
+} from '~/src/server/plugins/engine/types.js'
 
-/**
- * This replicates {@link PageControllerBase.validate}
- */
-const validate = (schema: ObjectSchema, value: object) => {
-  return schema.validate(value, { messages })
-}
+describe('MonthYearField', () => {
+  const definition = {
+    pages: [],
+    lists: [],
+    sections: [],
+    conditions: []
+  } satisfies FormDefinition
 
-describe('Month Year Field', () => {
-  test('Should validate month and year correctly', () => {
-    const def: ComponentDef = {
-      name: 'myComponent',
-      title: 'My component',
-      hint: 'a hint',
-      type: ComponentType.MonthYearField,
-      options: {}
-    }
+  let formModel: FormModel
 
-    const monthYearField = new MonthYearField(def)
+  beforeEach(() => {
+    formModel = new FormModel(definition, {
+      basePath: 'test'
+    })
+  })
 
-    /**
-     * This replicates {@link ComponentCollection.formSchema}
-     */
-    const schema = joi
-      .object()
-      .keys(monthYearField.getFormSchemaKeys())
-      .required()
+  describe('Defaults', () => {
+    let def: MonthYearFieldComponent
+    let component: MonthYearField
 
-    expect(
-      validate(schema, {
-        myComponent__year: 2000,
-        myComponent__month: 0
-      }).error?.message
-    ).toContain('must be between 1 and 12')
+    beforeEach(() => {
+      def = {
+        title: 'Example month/year field',
+        name: 'myComponent',
+        type: ComponentType.MonthYearField,
+        options: {}
+      } satisfies MonthYearFieldComponent
 
-    expect(
-      validate(schema, {
-        myComponent__year: 1,
-        myComponent__month: 12
-      }).error?.message
-    ).toContain('must be 1000 or higher')
+      component = new MonthYearField(def, formModel)
+    })
 
-    expect(
-      validate(schema, {
-        myComponent__year: 2000,
-        myComponent__month: 12
-      }).error
-    ).toBeUndefined()
+    describe('Schema', () => {
+      it('uses collection titles as labels', () => {
+        const { formSchema } = component.children
+
+        expect(formSchema.describe().keys).toEqual(
+          expect.objectContaining({
+            myComponent__month: expect.objectContaining({
+              flags: expect.objectContaining({ label: 'month' })
+            }),
+            myComponent__year: expect.objectContaining({
+              flags: expect.objectContaining({ label: 'year' })
+            })
+          })
+        )
+      })
+
+      it('is required by default', () => {
+        const { formSchema } = component.children
+
+        expect(formSchema.describe().flags).toEqual(
+          expect.objectContaining({
+            presence: 'required'
+          })
+        )
+      })
+
+      it('is optional when configured', () => {
+        const componentOptional = new MonthYearField(
+          {
+            title: 'Example month/year field',
+            name: 'myComponent',
+            type: ComponentType.MonthYearField,
+            options: { required: false }
+          },
+          formModel
+        )
+
+        const { formSchema } = componentOptional.children
+
+        expect(formSchema.describe().keys).toEqual(
+          expect.objectContaining({
+            myComponent__month: expect.objectContaining({
+              allow: ['']
+            }),
+            myComponent__year: expect.objectContaining({
+              allow: ['']
+            })
+          })
+        )
+
+        const result = formSchema.validate(
+          getFormData({
+            month: '',
+            year: ''
+          }),
+          opts
+        )
+
+        expect(result.error).toBeUndefined()
+      })
+
+      it('accepts valid values', () => {
+        const { formSchema } = component.children
+
+        const result1 = formSchema.validate(
+          getFormData({
+            month: '12',
+            year: '2024'
+          }),
+          opts
+        )
+
+        const result2 = formSchema.validate(
+          getFormData({
+            month: '2',
+            year: '2024'
+          }),
+          opts
+        )
+
+        expect(result1.error).toBeUndefined()
+        expect(result2.error).toBeUndefined()
+      })
+
+      it('adds errors for empty value', () => {
+        const { formSchema } = component.children
+
+        const result = formSchema.validate(
+          getFormData({
+            month: '',
+            year: ''
+          }),
+          opts
+        )
+
+        expect(result.error).toEqual(
+          expect.objectContaining({
+            message: 'month must be between 1 and 12. year must be a number'
+          })
+        )
+      })
+
+      it('adds errors for invalid values', () => {
+        const { formSchema } = component.children
+
+        const result1 = formSchema.validate(['invalid'], opts)
+        const result2 = formSchema.validate({ unknown: 'invalid' }, opts)
+        const result3 = formSchema.validate(
+          getFormData({
+            month: 'invalid',
+            year: 'invalid'
+          }),
+          opts
+        )
+
+        expect(result1.error).toBeTruthy()
+        expect(result2.error).toBeTruthy()
+        expect(result3.error).toBeTruthy()
+      })
+    })
+
+    describe('State', () => {
+      const date = new Date('2024-12-31')
+
+      it('returns text from state', () => {
+        const state = getFormState(date)
+        const text = component.getDisplayStringFromState(state)
+
+        expect(text).toBe('December 2024')
+      })
+
+      it.skip('returns payload from state', () => {
+        const state = getFormState(startOfDay(date))
+        const payload = component.getFormDataFromState(state)
+
+        // TODO: Fix empty form data
+        expect(payload).toEqual(getFormData(date))
+      })
+
+      it('returns state from payload (object)', () => {
+        const payload = getFormData(date)
+        const value = component.getStateFromValidForm(payload)
+
+        expect(value).toEqual(getFormState(date))
+      })
+
+      it('returns state from payload (value)', () => {
+        const payload = getFormData(date)
+        const value = component.getStateValueFromValidForm(payload)
+
+        expect(value).toEqual(getFormState(date).myComponent)
+      })
+    })
+
+    describe('View model', () => {
+      const date = new Date('2024-12-31')
+
+      it('sets Nunjucks component defaults', () => {
+        const payload = getFormData(date)
+        const viewModel = component.getViewModel(payload)
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            label: { text: def.title },
+            name: 'myComponent',
+            id: 'myComponent',
+            value: undefined,
+            items: [
+              expect.objectContaining(
+                getViewModel(date, 'month', {
+                  label: { text: 'Month' },
+                  classes: 'govuk-input--width-2',
+                  value: 12
+                })
+              ),
+
+              expect.objectContaining(
+                getViewModel(date, 'year', {
+                  label: { text: 'Year' },
+                  classes: 'govuk-input--width-4',
+                  value: 2024
+                })
+              )
+            ]
+          })
+        )
+      })
+
+      it('sets Nunjucks component fieldset', () => {
+        const payload = getFormData(date)
+        const viewModel = component.getViewModel(payload)
+
+        expect(viewModel.fieldset).toEqual({
+          legend: {
+            text: def.title,
+            classes: 'govuk-fieldset__legend--m'
+          }
+        })
+      })
+    })
+  })
+
+  describe('Validation', () => {
+    const date = new Date('2001-01-01')
+
+    describe.each([
+      {
+        description: 'Trim empty spaces',
+        component: {
+          title: 'Example month/year field',
+          name: 'myComponent',
+          type: ComponentType.MonthYearField,
+          options: {}
+        } satisfies MonthYearFieldComponent,
+        assertions: [
+          {
+            input: getFormData({
+              month: ' 01',
+              year: ' 2001'
+            }),
+            output: {
+              value: getFormData(date)
+            }
+          },
+          {
+            input: getFormData({
+              month: '01 ',
+              year: '2001 '
+            }),
+            output: {
+              value: getFormData(date)
+            }
+          },
+          {
+            input: getFormData({
+              month: ' 01 \n\n',
+              year: ' 2001 \n\n'
+            }),
+            output: {
+              value: getFormData(date)
+            }
+          }
+        ]
+      },
+      {
+        description: 'Out of range values',
+        component: {
+          title: 'Example month/year field',
+          name: 'myComponent',
+          type: ComponentType.MonthYearField,
+          options: {}
+        } satisfies MonthYearFieldComponent,
+        assertions: [
+          {
+            input: getFormData({
+              month: '13',
+              year: '2024'
+            }),
+            output: {
+              value: getFormData({
+                month: 13,
+                year: 2024
+              }),
+              error: new Error('month must be between 1 and 12')
+            }
+          },
+          {
+            input: getFormData({
+              month: '1',
+              year: '999'
+            }),
+            output: {
+              value: getFormData({
+                month: 1,
+                year: 999
+              }),
+              error: new Error('year must be 1000 or higher')
+            }
+          }
+        ]
+      },
+      {
+        description: 'Optional fields',
+        component: {
+          title: 'Example month/year field',
+          name: 'myComponent',
+          type: ComponentType.MonthYearField,
+          options: {
+            required: false
+          }
+        } satisfies MonthYearFieldComponent,
+        assertions: [
+          {
+            input: getFormData({
+              month: '',
+              year: ''
+            }),
+            output: {
+              value: getFormData({
+                month: '',
+                year: ''
+              })
+            }
+          }
+        ]
+      }
+    ])('$description', ({ component: def, assertions }) => {
+      let component: MonthYearField
+
+      beforeEach(() => {
+        component = new MonthYearField(def, formModel)
+      })
+
+      it.each([...assertions])(
+        'validates custom example',
+        ({ input, output }) => {
+          const { formSchema } = component.children
+
+          const result = formSchema.validate(input, opts)
+          expect(result).toEqual(output)
+        }
+      )
+    })
   })
 })
+
+/**
+ * Month & year field view model
+ */
+function getViewModel(
+  date: Date,
+  name: string,
+  overrides?: Partial<DateInputItem>
+): DateInputItem {
+  const payload = getFormData(date)
+  const fieldName = `myComponent__${name}`
+  const fieldClasses = overrides?.classes ?? expect.any(String)
+
+  return {
+    label: expect.objectContaining(
+      overrides?.label ?? {
+        text: expect.any(String)
+      }
+    ),
+    name: fieldName,
+    id: fieldName,
+    value: payload[fieldName] as number,
+    classes: fieldClasses,
+    type: 'number'
+  }
+}
+
+/**
+ * Month & year form data
+ */
+function getFormData(date: Date | FormData): FormData {
+  if (date instanceof Date) {
+    date = {
+      month: date.getMonth() + 1,
+      year: date.getFullYear()
+    }
+  }
+
+  return {
+    myComponent__month: date.month,
+    myComponent__year: date.year
+  }
+}
+
+/**
+ * Month & year session state
+ */
+function getFormState(date: Date | FormData): FormState {
+  const payload = getFormData(date)
+
+  return {
+    myComponent: payload
+  }
+}

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -176,11 +176,10 @@ describe('MonthYearField', () => {
         expect(text).toBe('December 2024')
       })
 
-      it.skip('returns payload from state', () => {
+      it('returns payload from state', () => {
         const state = getFormState(startOfDay(date))
         const payload = component.getFormDataFromState(state)
 
-        // TODO: Fix empty form data
         expect(payload).toEqual(getFormData(date))
       })
 

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -77,7 +77,7 @@ export class MonthYearField extends FormComponent {
   }
 
   getFormDataFromState(state: FormSubmissionState) {
-    return this.children.getFormDataFromState(state)
+    return this.children.getFormDataFromState(state[this.name] ?? {})
   }
 
   getStateValueFromValidForm(payload: FormPayload) {

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -22,7 +22,7 @@ export class MonthYearField extends FormComponent {
   constructor(def: MonthYearFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { name, options } = def
+    const { name, options, title } = def
     const isRequired = options.required !== false
 
     this.children = new ComponentCollection(
@@ -52,7 +52,18 @@ export class MonthYearField extends FormComponent {
       model
     )
 
+    let { formSchema, stateSchema } = this.children
+
+    // Update child schema
+    formSchema = formSchema.label(title.toLowerCase())
+    stateSchema = stateSchema.label(title.toLowerCase())
+
     this.options = options
+    this.formSchema = formSchema
+    this.stateSchema = stateSchema
+
+    this.children.formSchema = formSchema
+    this.children.stateSchema = stateSchema
   }
 
   getFormSchemaKeys() {

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -105,6 +105,16 @@ export class MonthYearField extends FormComponent {
     const viewModel = super.getViewModel(payload, errors)
     let { fieldset, label } = viewModel
 
+    // Filter component and children errors only
+    const componentErrors = errors?.errorList.filter(
+      (error) =>
+        error.name === name || // Errors for parent component only
+        error.name.startsWith(`${name}__`) // Plus `${name}__year` etc fields
+    )
+
+    // Check for component errors only
+    const hasError = componentErrors?.some((error) => error.name === name)
+
     // Use the component collection to generate the subitems
     const items: DateInputItem[] = children
       .getViewModel(payload, errors)
@@ -116,7 +126,7 @@ export class MonthYearField extends FormComponent {
           label.toString = () => label.text // Date component uses string labels
         }
 
-        if (errorMessage) {
+        if (hasError || errorMessage) {
           classes = `${classes} govuk-input--error`.trim()
         }
 
@@ -133,11 +143,6 @@ export class MonthYearField extends FormComponent {
           classes
         }
       })
-
-    // Filter errors for this component only
-    const componentErrors = errors?.errorList.filter(
-      (error) => error.name.startsWith(`${name}__`) // E.g. `${name}__year`
-    )
 
     const errorMessage = componentErrors?.[0] && {
       text: componentErrors[0].text

--- a/src/server/plugins/engine/components/MultilineTextField.test.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.test.ts
@@ -1,140 +1,370 @@
-import { ComponentType, type ComponentDef } from '@defra/forms-model'
+import {
+  ComponentType,
+  type FormDefinition,
+  type MultilineTextFieldComponent
+} from '@defra/forms-model'
 
 import { MultilineTextField } from '~/src/server/plugins/engine/components/MultilineTextField.js'
-import { validationOptions } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import { validationOptions as opts } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 
-describe('Multiline text field', () => {
-  test('Should supply custom validation message if defined', () => {
-    const def: ComponentDef = {
-      name: 'myComponent',
-      title: 'My component',
-      hint: 'a hint',
-      type: ComponentType.MultilineTextField,
-      options: {
-        required: false,
-        customValidationMessage: 'This is a custom error'
+describe('MultilineTextField', () => {
+  const definition = {
+    pages: [],
+    lists: [],
+    sections: [],
+    conditions: []
+  } satisfies FormDefinition
+
+  let formModel: FormModel
+
+  beforeEach(() => {
+    formModel = new FormModel(definition, {
+      basePath: 'test'
+    })
+  })
+
+  describe('Defaults', () => {
+    let def: MultilineTextFieldComponent
+    let component: MultilineTextField
+    let label: string
+
+    beforeEach(() => {
+      def = {
+        title: 'Example textarea',
+        name: 'myComponent',
+        type: ComponentType.MultilineTextField,
+        options: {},
+        schema: {}
+      } satisfies MultilineTextFieldComponent
+
+      component = new MultilineTextField(def, formModel)
+      label = def.title.toLowerCase()
+    })
+
+    describe('Schema', () => {
+      it('uses component title as label', () => {
+        const { formSchema } = component
+
+        expect(formSchema.describe().flags).toEqual(
+          expect.objectContaining({ label })
+        )
+      })
+
+      it('is required by default', () => {
+        const { formSchema } = component
+
+        expect(formSchema.describe().flags).toEqual(
+          expect.objectContaining({
+            presence: 'required'
+          })
+        )
+      })
+
+      it('is optional when configured', () => {
+        const componentOptional = new MultilineTextField(
+          { ...def, options: { required: false } },
+          formModel
+        )
+
+        const { formSchema } = componentOptional
+
+        expect(formSchema.describe()).toEqual(
+          expect.objectContaining({
+            allow: ['']
+          })
+        )
+
+        const result = formSchema.validate('', opts)
+        expect(result.error).toBeUndefined()
+      })
+
+      it('accepts valid values', () => {
+        const { formSchema } = component
+
+        const result1 = formSchema.validate('Text', opts)
+        const result2 = formSchema.validate('Textarea', opts)
+
+        expect(result1.error).toBeUndefined()
+        expect(result2.error).toBeUndefined()
+      })
+
+      it('adds errors for empty value', () => {
+        const { formSchema } = component
+
+        const result = formSchema.validate('', opts)
+
+        expect(result.error).toEqual(
+          expect.objectContaining({
+            message: `Enter ${label}`
+          })
+        )
+      })
+
+      it('adds errors for invalid values', () => {
+        const { formSchema } = component
+
+        const result1 = formSchema.validate(['invalid'], opts)
+        const result2 = formSchema.validate({ unknown: 'invalid' }, opts)
+
+        expect(result1.error).toBeTruthy()
+        expect(result2.error).toBeTruthy()
+      })
+    })
+
+    describe('State', () => {
+      it('returns text from state value', () => {
+        const text = component.getDisplayStringFromState({
+          [def.name]: 'Textarea'
+        })
+
+        expect(text).toBe('Textarea')
+      })
+    })
+
+    describe('View model', () => {
+      it('sets Nunjucks component defaults', () => {
+        const viewModel = component.getViewModel({
+          [def.name]: 'Textarea'
+        })
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            label: { text: def.title },
+            name: 'myComponent',
+            id: 'myComponent',
+            value: 'Textarea'
+          })
+        )
+      })
+
+      it('sets Nunjucks component isCharacterOrWordCount: true', () => {
+        const componentCustom1 = new MultilineTextField(
+          { ...def, options: { maxWords: 10 } },
+          formModel
+        )
+
+        const componentCustom2 = new MultilineTextField(
+          { ...def, schema: { max: 10 } },
+          formModel
+        )
+
+        const viewModel = component.getViewModel({
+          [def.name]: 'Textarea'
+        })
+
+        const viewModel1 = componentCustom1.getViewModel({
+          [def.name]: 'Textarea custom #1'
+        })
+
+        const viewModel2 = componentCustom2.getViewModel({
+          [def.name]: 'Textarea custom #2'
+        })
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({ isCharacterOrWordCount: false })
+        )
+
+        expect(viewModel1).toEqual(
+          expect.objectContaining({ isCharacterOrWordCount: true })
+        )
+
+        expect(viewModel2).toEqual(
+          expect.objectContaining({ isCharacterOrWordCount: true })
+        )
+      })
+    })
+  })
+
+  describe('Validation', () => {
+    describe.each([
+      {
+        description: 'Trim empty spaces',
+        component: {
+          title: 'Example textarea',
+          name: 'myComponent',
+          type: ComponentType.MultilineTextField,
+          options: {},
+          schema: {}
+        } satisfies MultilineTextFieldComponent,
+        assertions: [
+          {
+            input: '  Leading spaces',
+            output: { value: 'Leading spaces' }
+          },
+          {
+            input: 'Trailing spaces  ',
+            output: { value: 'Trailing spaces' }
+          },
+          {
+            input: '  Mixed spaces and new lines \n\n',
+            output: { value: 'Mixed spaces and new lines' }
+          }
+        ]
       },
-      schema: {
-        max: 2
-      }
-    }
-    const multilineTextField = new MultilineTextField(def, {})
-    const { formSchema } = multilineTextField
-    expect(formSchema.validate('a').error).toBeUndefined()
-
-    expect(formSchema.validate('too many').error?.message).toBe(
-      'This is a custom error'
-    )
-  })
-
-  test('Should validate when schema options are supplied', () => {
-    const def: ComponentDef = {
-      name: 'myComponent',
-      title: 'My component',
-      hint: 'a hint',
-      type: ComponentType.MultilineTextField,
-      options: {},
-      schema: {
-        min: 4,
-        max: 5
-      }
-    }
-    const multilineTextField = new MultilineTextField(def, {})
-    const { formSchema } = multilineTextField
-
-    expect(formSchema.validate('yolk', validationOptions).error).toBeUndefined()
-
-    expect(formSchema.validate('egg', validationOptions).error?.message).toBe(
-      'my component must be 4 characters or more'
-    )
-    expect(
-      formSchema.validate('scrambled', validationOptions).error?.message
-    ).toBe('my component must be 5 characters or less')
-
-    expect(
-      formSchema.validate('scrambled', validationOptions).error?.message
-    ).toBe('my component must be 5 characters or less')
-  })
-
-  test('Should apply default schema if no options are passed', () => {
-    const def: ComponentDef = {
-      name: 'myComponent',
-      title: 'My component',
-      hint: 'a hint',
-      type: ComponentType.MultilineTextField,
-      options: {},
-      schema: {}
-    }
-    const multilineTextField = new MultilineTextField(def, {})
-    const { formSchema } = multilineTextField
-
-    expect(formSchema.validate('', validationOptions).error?.message).toBe(
-      'Enter my component'
-    )
-    expect(formSchema.validate('benedict').error).toBeUndefined()
-  })
-
-  test('should return correct view model when maxwords or schema.length configured', () => {
-    const multilineTextFieldMaxWordsDef: ComponentDef = {
-      name: 'myComponent',
-      title: 'My component',
-      hint: 'a hint',
-      type: ComponentType.MultilineTextField,
-      options: {
-        maxWords: 100
+      {
+        description: 'Option max words',
+        component: {
+          title: 'Example textarea',
+          name: 'myComponent',
+          type: ComponentType.MultilineTextField,
+          options: {
+            maxWords: 2
+          },
+          schema: {}
+        } satisfies MultilineTextFieldComponent,
+        assertions: [
+          {
+            input: 'Textarea words',
+            output: {
+              value: 'Textarea words'
+            }
+          },
+          {
+            input: 'Textarea too many words',
+            output: {
+              value: 'Textarea too many words',
+              error: new Error('example textarea must be 2 words or fewer')
+            }
+          }
+        ]
       },
-      schema: {
-        min: 2
+      {
+        description: 'Schema min and max',
+        component: {
+          title: 'Example textarea',
+          name: 'myComponent',
+          type: ComponentType.MultilineTextField,
+          options: {},
+          schema: {
+            min: 5,
+            max: 8
+          }
+        } satisfies MultilineTextFieldComponent,
+        assertions: [
+          {
+            input: 'Text',
+            output: {
+              value: 'Text',
+              error: new Error('example textarea must be 5 characters or more')
+            }
+          },
+          {
+            input: 'Textarea too long',
+            output: {
+              value: 'Textarea too long',
+              error: new Error('example textarea must be 8 characters or less')
+            }
+          }
+        ]
+      },
+      {
+        description: 'Schema length',
+        component: {
+          title: 'Example textarea',
+          name: 'myComponent',
+          type: ComponentType.MultilineTextField,
+          options: {},
+          schema: {
+            length: 4
+          }
+        } satisfies MultilineTextFieldComponent,
+        assertions: [
+          {
+            input: 'Text',
+            output: { value: 'Text' }
+          },
+          {
+            input: 'Textarea',
+            output: {
+              value: 'Textarea',
+              error: new Error(
+                'example textarea length must be 4 characters long'
+              )
+            }
+          }
+        ]
+      },
+      {
+        description: 'Schema regex',
+        component: {
+          title: 'Example textarea',
+          name: 'myComponent',
+          type: ComponentType.MultilineTextField,
+          options: {},
+          schema: {
+            regex: '^[a-zA-Z]{1,2}\\d[a-zA-Z\\d]?\\s?\\d[a-zA-Z]{2}$'
+          }
+        } satisfies MultilineTextFieldComponent,
+        assertions: [
+          {
+            input: 'SW1P',
+            output: {
+              value: 'SW1P',
+              error: new Error('Enter a valid example textarea')
+            }
+          },
+          {
+            input: 'SW1P 4DF',
+            output: { value: 'SW1P 4DF' }
+          }
+        ]
+      },
+      {
+        description: 'Custom validation',
+        component: {
+          title: 'Example textarea',
+          name: 'myComponent',
+          type: ComponentType.MultilineTextField,
+          options: {
+            customValidationMessage: 'This is a custom error'
+          },
+          schema: {}
+        } satisfies MultilineTextFieldComponent,
+        assertions: [
+          {
+            input: '',
+            output: {
+              value: '',
+              error: new Error('This is a custom error')
+            }
+          }
+        ]
+      },
+      {
+        description: 'Optional field',
+        component: {
+          title: 'Example textarea',
+          name: 'myComponent',
+          type: ComponentType.MultilineTextField,
+          options: {
+            required: false
+          },
+          schema: {}
+        } satisfies MultilineTextFieldComponent,
+        assertions: [
+          {
+            input: '',
+            output: { value: '' }
+          }
+        ]
       }
-    }
-    const multilineTextFieldMaxWords = new MultilineTextField(
-      multilineTextFieldMaxWordsDef,
-      {}
-    )
-    expect(multilineTextFieldMaxWords.getViewModel({})).toEqual(
-      expect.objectContaining({
-        isCharacterOrWordCount: true,
-        maxwords: 100
-      })
-    )
+    ])('$description', ({ component: def, assertions }) => {
+      let component: MultilineTextField
 
-    const multilineTextFieldMaxCharsDef: ComponentDef = {
-      name: 'myComponent',
-      title: 'My component',
-      hint: 'a hint',
-      type: ComponentType.MultilineTextField,
-      options: {},
-      schema: {
-        max: 5,
-        min: 2
-      }
-    }
-    const multilineTextFieldMaxChars = new MultilineTextField(
-      multilineTextFieldMaxCharsDef,
-      {}
-    )
-    expect(multilineTextFieldMaxChars.getViewModel({})).toEqual(
-      expect.objectContaining({
-        isCharacterOrWordCount: true,
-        maxlength: 5
+      beforeEach(() => {
+        component = new MultilineTextField(def, formModel)
       })
-    )
-  })
 
-  test('should return correct view model when not configured with maxwords or schema.length', () => {
-    const def: ComponentDef = {
-      name: 'myComponent',
-      title: 'My component',
-      hint: 'a hint',
-      type: ComponentType.MultilineTextField,
-      options: {},
-      schema: {}
-    }
-    const multilineTextFieldMaxWords = new MultilineTextField(def, {})
-    expect(multilineTextFieldMaxWords.getViewModel({})).toEqual(
-      expect.objectContaining({
-        isCharacterOrWordCount: false
-      })
-    )
+      it.each([...assertions])(
+        'validates custom example',
+        ({ input, output }) => {
+          const { formSchema } = component
+
+          const result = formSchema.validate(input, opts)
+          expect(result).toEqual(output)
+        }
+      )
+    })
   })
 })

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -264,6 +264,45 @@ describe('NumberField', () => {
             }
           }
         ]
+      },
+      {
+        description: 'Custom validation',
+        component: {
+          title: 'Example number field',
+          name: 'myComponent',
+          type: ComponentType.NumberField,
+          options: {
+            customValidationMessage: 'This is a custom error'
+          },
+          schema: {}
+        } satisfies NumberFieldComponent,
+        assertions: [
+          {
+            input: 'invalid',
+            output: {
+              value: 'invalid',
+              error: new Error('This is a custom error')
+            }
+          }
+        ]
+      },
+      {
+        description: 'Optional field',
+        component: {
+          title: 'Example number field',
+          name: 'myComponent',
+          type: ComponentType.NumberField,
+          options: {
+            required: false
+          },
+          schema: {}
+        } satisfies NumberFieldComponent,
+        assertions: [
+          {
+            input: '',
+            output: { value: '' }
+          }
+        ]
       }
     ])('$description', ({ component: def, assertions }) => {
       let component: NumberField

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -117,7 +117,7 @@ describe('NumberField', () => {
     })
 
     describe('State', () => {
-      it('Returns text from state value', () => {
+      it('returns text from state value', () => {
         const text = component.getDisplayStringFromState({
           [def.name]: 2024
         })

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -267,24 +267,9 @@ describe('NumberField', () => {
       }
     ])('$description', ({ component: def, assertions }) => {
       let component: NumberField
-      let label: string
 
       beforeEach(() => {
         component = new NumberField(def, formModel)
-        label = def.title.toLowerCase()
-      })
-
-      it('validates empty value', () => {
-        const { formSchema } = component
-
-        const input = ''
-        const output = {
-          value: '',
-          error: new Error(`${label} must be a number`)
-        }
-
-        const result = formSchema.validate(input, opts)
-        expect(result).toEqual(output)
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -253,24 +253,9 @@ describe('TextField', () => {
       }
     ])('$description', ({ component: def, assertions }) => {
       let component: TextField
-      let label: string
 
       beforeEach(() => {
         component = new TextField(def, formModel)
-        label = def.title.toLowerCase()
-      })
-
-      it('validates empty value', () => {
-        const { formSchema } = component
-
-        const input = ''
-        const output = {
-          value: '',
-          error: new Error(`Enter ${label}`)
-        }
-
-        const result = formSchema.validate(input, opts)
-        expect(result).toEqual(output)
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -250,6 +250,45 @@ describe('TextField', () => {
             output: { value: 'SW1P 4DF' }
           }
         ]
+      },
+      {
+        description: 'Custom validation',
+        component: {
+          title: 'Example text field',
+          name: 'myComponent',
+          type: ComponentType.TextField,
+          options: {
+            customValidationMessage: 'This is a custom error'
+          },
+          schema: {}
+        } satisfies TextFieldComponent,
+        assertions: [
+          {
+            input: '',
+            output: {
+              value: '',
+              error: new Error('This is a custom error')
+            }
+          }
+        ]
+      },
+      {
+        description: 'Optional field',
+        component: {
+          title: 'Example text field',
+          name: 'myComponent',
+          type: ComponentType.TextField,
+          options: {
+            required: false
+          },
+          schema: {}
+        } satisfies TextFieldComponent,
+        assertions: [
+          {
+            input: '',
+            output: { value: '' }
+          }
+        ]
       }
     ])('$description', ({ component: def, assertions }) => {
       let component: TextField

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -113,7 +113,7 @@ describe('TextField', () => {
     })
 
     describe('State', () => {
-      it('Returns text from state value', () => {
+      it('returns text from state value', () => {
         const text = component.getDisplayStringFromState({
           [def.name]: 'Text field'
         })

--- a/src/server/plugins/engine/components/UkAddressField.test.ts
+++ b/src/server/plugins/engine/components/UkAddressField.test.ts
@@ -1,0 +1,507 @@
+import {
+  ComponentType,
+  type FormDefinition,
+  type UkAddressFieldComponent
+} from '@defra/forms-model'
+
+import { UkAddressField } from '~/src/server/plugins/engine/components/UkAddressField.js'
+import { type ViewModel } from '~/src/server/plugins/engine/components/types.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import { validationOptions as opts } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
+import {
+  type FormData,
+  type FormState
+} from '~/src/server/plugins/engine/types.js'
+
+describe('UkAddressField', () => {
+  const definition = {
+    pages: [],
+    lists: [],
+    sections: [],
+    conditions: []
+  } satisfies FormDefinition
+
+  let formModel: FormModel
+
+  beforeEach(() => {
+    formModel = new FormModel(definition, {
+      basePath: 'test'
+    })
+  })
+
+  describe('Defaults', () => {
+    let def: UkAddressFieldComponent
+    let component: UkAddressField
+
+    beforeEach(() => {
+      def = {
+        title: 'Example UK address',
+        name: 'myComponent',
+        type: ComponentType.UkAddressField,
+        options: {}
+      } satisfies UkAddressFieldComponent
+
+      component = new UkAddressField(def, formModel)
+    })
+
+    describe('Schema', () => {
+      it('uses collection titles as labels', () => {
+        const { formSchema } = component
+
+        expect(formSchema.describe().keys).toEqual(
+          expect.objectContaining({
+            myComponent__addressLine1: expect.objectContaining({
+              flags: expect.objectContaining({ label: 'address line 1' })
+            }),
+            myComponent__addressLine2: expect.objectContaining({
+              flags: expect.objectContaining({ label: 'address line 2' })
+            }),
+            myComponent__town: expect.objectContaining({
+              flags: expect.objectContaining({ label: 'town or city' })
+            }),
+            myComponent__postcode: expect.objectContaining({
+              flags: expect.objectContaining({ label: 'postcode' })
+            })
+          })
+        )
+      })
+
+      it('is required by default', () => {
+        const { formSchema } = component
+
+        expect(formSchema.describe().flags).toEqual(
+          expect.objectContaining({
+            presence: 'required'
+          })
+        )
+      })
+
+      it('is optional when configured', () => {
+        const componentOptional = new UkAddressField(
+          {
+            title: 'Example UK address',
+            name: 'myComponent',
+            type: ComponentType.UkAddressField,
+            options: { required: false }
+          },
+          formModel
+        )
+
+        const { formSchema } = componentOptional
+
+        expect(formSchema.describe().keys).toEqual(
+          expect.objectContaining({
+            myComponent__addressLine1: expect.objectContaining({
+              allow: ['']
+            }),
+            myComponent__addressLine2: expect.objectContaining({
+              allow: ['']
+            }),
+            myComponent__town: expect.objectContaining({
+              allow: ['']
+            }),
+            myComponent__postcode: expect.objectContaining({
+              allow: ['']
+            })
+          })
+        )
+
+        const result = formSchema.validate(
+          getFormData({
+            addressLine1: '',
+            addressLine2: '',
+            town: '',
+            postcode: ''
+          }),
+          opts
+        )
+
+        expect(result.error).toBeUndefined()
+      })
+
+      it('accepts valid values', () => {
+        const { formSchema } = component
+
+        const result1 = formSchema.validate(
+          getFormData({
+            addressLine1: 'Richard Fairclough House',
+            addressLine2: 'Knutsford Road',
+            town: 'Warrington',
+            postcode: 'WA4 1HT'
+          }),
+          opts
+        )
+
+        const result2 = formSchema.validate(
+          getFormData({
+            addressLine1: 'Richard Fairclough House',
+            addressLine2: '', // Optional field
+            town: 'Warrington',
+            postcode: 'WA4 1HT'
+          }),
+          opts
+        )
+
+        expect(result1.error).toBeUndefined()
+        expect(result2.error).toBeUndefined()
+      })
+
+      it('adds errors for empty value', () => {
+        const { formSchema } = component
+
+        const result = formSchema.validate(
+          getFormData({
+            addressLine1: '',
+            addressLine2: '',
+            town: '',
+            postcode: ''
+          }),
+          opts
+        )
+
+        expect(result.error).toEqual(
+          expect.objectContaining({
+            message: [
+              'Enter address line 1',
+              'Enter town or city',
+              'Enter postcode'
+            ].join('. ')
+          })
+        )
+      })
+
+      it('adds errors for invalid values', () => {
+        const { formSchema } = component
+
+        const result1 = formSchema.validate(['invalid'], opts)
+        const result2 = formSchema.validate({ unknown: 'invalid' }, opts)
+
+        expect(result1.error).toBeTruthy()
+        expect(result2.error).toBeTruthy()
+      })
+    })
+
+    describe('State', () => {
+      const address: FormData = {
+        addressLine1: 'Richard Fairclough House',
+        addressLine2: 'Knutsford Road',
+        town: 'Warrington',
+        postcode: 'WA4 1HT'
+      }
+
+      it('returns text from state', () => {
+        const state = getFormState(address)
+        const text = component.getDisplayStringFromState(state)
+
+        expect(text).toBe(
+          'Richard Fairclough House, Knutsford Road, Warrington, WA4 1HT'
+        )
+      })
+
+      it('returns payload from state', () => {
+        const state = getFormState(address)
+        const payload = component.getFormDataFromState(state)
+
+        expect(payload).toEqual(getFormData(address))
+      })
+
+      it('returns state from payload (object)', () => {
+        const payload = getFormData(address)
+        const value = component.getStateFromValidForm(payload)
+
+        expect(value).toEqual(getFormState(address))
+      })
+
+      it('returns state from payload (value)', () => {
+        const payload = getFormData(address)
+        const value = component.getStateValueFromValidForm(payload)
+
+        expect(value).toEqual(address)
+      })
+    })
+
+    describe('View model', () => {
+      const address: FormData = {
+        addressLine1: 'Richard Fairclough House',
+        addressLine2: 'Knutsford Road',
+        town: 'Warrington',
+        postcode: 'WA4 1HT'
+      }
+
+      it('sets Nunjucks component defaults', () => {
+        const payload = getFormData(address)
+        const viewModel = component.getViewModel(payload)
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            label: { text: def.title },
+            name: 'myComponent',
+            id: 'myComponent',
+            value: undefined,
+            children: expect.arrayContaining([
+              expect.objectContaining({
+                model: getViewModel(address, 'addressLine1', {
+                  label: { text: 'Address line 1' },
+                  attributes: { autocomplete: 'address-line1' }
+                })
+              }),
+
+              expect.objectContaining({
+                model: getViewModel(address, 'addressLine2', {
+                  label: { text: 'Address line 2 (optional)' },
+                  attributes: { autocomplete: 'address-line2' },
+                  value: address.addressLine2
+                })
+              }),
+
+              expect.objectContaining({
+                model: getViewModel(address, 'town', {
+                  label: { text: 'Town or city' },
+                  classes: 'govuk-!-width-two-thirds',
+                  attributes: { autocomplete: 'address-level2' },
+                  value: address.town
+                })
+              }),
+
+              expect.objectContaining({
+                model: getViewModel(address, 'postcode', {
+                  label: { text: 'Postcode' },
+                  classes: 'govuk-input--width-10',
+                  attributes: { autocomplete: 'postal-code' },
+                  value: address.postcode
+                })
+              })
+            ])
+          })
+        )
+      })
+
+      it('sets Nunjucks component fieldset', () => {
+        const payload = getFormData(address)
+        const viewModel = component.getViewModel(payload)
+
+        expect(viewModel.fieldset).toEqual({
+          legend: {
+            text: def.title,
+            classes: 'govuk-fieldset__legend--m'
+          }
+        })
+      })
+    })
+  })
+
+  describe('Validation', () => {
+    const address: FormData = {
+      addressLine1: 'Richard Fairclough House',
+      addressLine2: 'Knutsford Road',
+      town: 'Warrington',
+      postcode: 'WA4 1HT'
+    }
+
+    const addressLine1Invalid =
+      'Address line 1000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+
+    const addressLine2Invalid =
+      'Address line 2000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+
+    const townInvalid =
+      'Town 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+
+    const postcodeInvalid = '111 XX2'
+
+    describe.each([
+      {
+        description: 'Trim empty spaces',
+        component: {
+          title: 'Example UK address',
+          name: 'myComponent',
+          type: ComponentType.UkAddressField,
+          options: {}
+        } satisfies UkAddressFieldComponent,
+        assertions: [
+          {
+            input: getFormData({
+              addressLine1: ' Richard Fairclough House',
+              addressLine2: ' Knutsford Road',
+              town: ' Warrington',
+              postcode: ' WA4 1HT'
+            }),
+            output: {
+              value: getFormData(address)
+            }
+          },
+          {
+            input: getFormData({
+              addressLine1: 'Richard Fairclough House ',
+              addressLine2: 'Knutsford Road ',
+              town: 'Warrington ',
+              postcode: 'WA4 1HT '
+            }),
+            output: {
+              value: getFormData(address)
+            }
+          },
+          {
+            input: getFormData({
+              addressLine1: ' Richard Fairclough House \n\n',
+              addressLine2: ' Knutsford Road \n\n',
+              town: ' Warrington \n\n',
+              postcode: ' WA4 1HT \n\n'
+            }),
+            output: {
+              value: getFormData(address)
+            }
+          }
+        ]
+      },
+      {
+        description: 'Out of range values',
+        component: {
+          title: 'Example UK address',
+          name: 'myComponent',
+          type: ComponentType.UkAddressField,
+          options: {}
+        } satisfies UkAddressFieldComponent,
+        assertions: [
+          {
+            input: getFormData({
+              addressLine1: addressLine1Invalid,
+              addressLine2: 'Knutsford Road',
+              town: 'Warrington',
+              postcode: 'WA4 1HT'
+            }),
+            output: {
+              value: getFormData({
+                addressLine1: addressLine1Invalid,
+                addressLine2: 'Knutsford Road',
+                town: 'Warrington',
+                postcode: 'WA4 1HT'
+              }),
+              error: new Error('address line 1 must be 100 characters or less')
+            }
+          },
+          {
+            input: getFormData({
+              addressLine1: 'Richard Fairclough House',
+              addressLine2: addressLine2Invalid,
+              town: 'Warrington',
+              postcode: 'WA4 1HT'
+            }),
+            output: {
+              value: getFormData({
+                addressLine1: 'Richard Fairclough House',
+                addressLine2: addressLine2Invalid,
+                town: 'Warrington',
+                postcode: 'WA4 1HT'
+              }),
+              error: new Error('address line 2 must be 100 characters or less')
+            }
+          },
+          {
+            input: getFormData({
+              addressLine1: 'Richard Fairclough House',
+              addressLine2: 'Knutsford Road',
+              town: townInvalid,
+              postcode: 'WA4 1HT'
+            }),
+            output: {
+              value: getFormData({
+                addressLine1: 'Richard Fairclough House',
+                addressLine2: 'Knutsford Road',
+                town: townInvalid,
+                postcode: 'WA4 1HT'
+              }),
+              error: new Error('town or city must be 100 characters or less')
+            }
+          },
+          {
+            input: getFormData({
+              addressLine1: 'Richard Fairclough House',
+              addressLine2: 'Knutsford Road',
+              town: 'Warrington',
+              postcode: postcodeInvalid
+            }),
+            output: {
+              value: getFormData({
+                addressLine1: 'Richard Fairclough House',
+                addressLine2: 'Knutsford Road',
+                town: 'Warrington',
+                postcode: postcodeInvalid
+              }),
+              error: new Error('Enter a valid postcode')
+            }
+          }
+        ]
+      }
+    ])('$description', ({ component: def, assertions }) => {
+      let component: UkAddressField
+
+      beforeEach(() => {
+        component = new UkAddressField(def, formModel)
+      })
+
+      it.each([...assertions])(
+        'validates custom example',
+        ({ input, output }) => {
+          const { formSchema } = component
+
+          const result = formSchema.validate(input, opts)
+          expect(result).toEqual(output)
+        }
+      )
+    })
+  })
+})
+
+/**
+ * UK address field view model
+ */
+function getViewModel(
+  address: FormData,
+  name: string,
+  overrides?: Partial<ViewModel>
+): Partial<ViewModel> {
+  const payload = getFormData(address)
+  const fieldName = `myComponent__${name}`
+  const fieldClasses = overrides?.classes ?? undefined
+  const fieldAttributes = overrides?.attributes ?? expect.any(Object)
+
+  return {
+    label: expect.objectContaining(
+      overrides?.label ?? {
+        text: expect.any(String)
+      }
+    ),
+    name: fieldName,
+    id: fieldName,
+    value: payload[fieldName],
+    classes: fieldClasses,
+    attributes: fieldAttributes
+  }
+}
+
+/**
+ * UK address form data
+ */
+function getFormData(address: FormData): FormData {
+  return {
+    myComponent__addressLine1: address.addressLine1,
+    myComponent__addressLine2: address.addressLine2,
+    myComponent__town: address.town,
+    myComponent__postcode: address.postcode
+  }
+}
+
+/**
+ * UK address session state
+ */
+function getFormState(address: FormData): FormState {
+  return {
+    myComponent: {
+      addressLine1: address.addressLine1,
+      addressLine2: address.addressLine2,
+      town: address.town,
+      postcode: address.postcode
+    }
+  }
+}

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -86,18 +86,24 @@ export class UkAddressField extends FormComponent {
       }
     ] satisfies ComponentDef[]
 
-    const stateChildren = new ComponentCollection(childrenList, model)
+    this.stateChildren = new ComponentCollection(childrenList, model)
 
     // Modify the name to add a prefix and reuse
     // the children to create the formComponents
     childrenList.forEach((child) => (child.name = `${name}__${child.name}`))
 
-    const formChildren = new ComponentCollection(childrenList, model)
+    this.children = new ComponentCollection(childrenList, model)
+
+    let { formSchema } = this.children
+
+    // Update child schema
+    formSchema = formSchema.label(title.toLowerCase())
 
     this.options = options
-    this.children = formChildren
-    this.stateChildren = stateChildren
+    this.formSchema = formSchema
     this.stateSchema = stateSchema
+
+    this.children.formSchema = formSchema
   }
 
   getFormSchemaKeys() {

--- a/src/server/plugins/engine/components/YesNoField.test.ts
+++ b/src/server/plugins/engine/components/YesNoField.test.ts
@@ -124,7 +124,7 @@ describe('YesNoField', () => {
   })
 
   describe('State', () => {
-    it('Returns text from state value', () => {
+    it('returns text from state value', () => {
       const textYes = component.getDisplayStringFromState({
         [def.name]: true
       })


### PR DESCRIPTION
This PR adds 80x new tests including coverage for `UkAddressField`, nested fields and others

## Payload versus state validation

So we can test UK Address as if "in the browser" I've switched validation from state to payload

See commit https://github.com/DEFRA/forms-runner/pull/497/commits/2da70c4eb99f6fd4badef5491119d74b1ec2f606 for more info