### PR TITLE
Fix month/year field not restoring payload from state

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -149,6 +149,16 @@ export class DatePartsField extends FormComponent {
     const viewModel = super.getViewModel(payload, errors)
     let { fieldset, label } = viewModel
 
+    // Filter component and children errors only
+    const componentErrors = errors?.errorList.filter(
+      (error) =>
+        error.name === name || // Errors for parent component only
+        error.name.startsWith(`${name}__`) // Plus `${name}__year` etc fields
+    )
+
+    // Check for component errors only
+    const hasError = componentErrors?.some((error) => error.name === name)
+
     // Use the component collection to generate the subitems
     const items: DateInputItem[] = children
       .getViewModel(payload, errors)
@@ -160,7 +170,7 @@ export class DatePartsField extends FormComponent {
           label.toString = () => label.text // Date component uses string labels
         }
 
-        if (errorMessage) {
+        if (hasError || errorMessage) {
           classes = `${classes} govuk-input--error`.trim()
         }
 
@@ -177,11 +187,6 @@ export class DatePartsField extends FormComponent {
           classes
         }
       })
-
-    // Filter errors for this component only
-    const componentErrors = errors?.errorList.filter(
-      (error) => error.name.startsWith(`${name}__`) // E.g. `${name}__year`
-    )
 
     const errorMessage = componentErrors?.[0] && {
       text: componentErrors[0].text

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -176,11 +176,10 @@ describe('MonthYearField', () => {
         expect(text).toBe('December 2024')
       })
 
-      it.skip('returns payload from state', () => {
+      it('returns payload from state', () => {
         const state = getFormState(startOfDay(date))
         const payload = component.getFormDataFromState(state)
 
-        // TODO: Fix empty form data
         expect(payload).toEqual(getFormData(date))
       })
 

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -77,7 +77,7 @@ export class MonthYearField extends FormComponent {
   }
 
   getFormDataFromState(state: FormSubmissionState) {
-    return this.children.getFormDataFromState(state)
+    return this.children.getFormDataFromState(state[this.name] ?? {})
   }
 
   getStateValueFromValidForm(payload: FormPayload) {

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -105,6 +105,16 @@ export class MonthYearField extends FormComponent {
     const viewModel = super.getViewModel(payload, errors)
     let { fieldset, label } = viewModel
 
+    // Filter component and children errors only
+    const componentErrors = errors?.errorList.filter(
+      (error) =>
+        error.name === name || // Errors for parent component only
+        error.name.startsWith(`${name}__`) // Plus `${name}__year` etc fields
+    )
+
+    // Check for component errors only
+    const hasError = componentErrors?.some((error) => error.name === name)
+
     // Use the component collection to generate the subitems
     const items: DateInputItem[] = children
       .getViewModel(payload, errors)
@@ -116,7 +126,7 @@ export class MonthYearField extends FormComponent {
           label.toString = () => label.text // Date component uses string labels
         }
 
-        if (errorMessage) {
+        if (hasError || errorMessage) {
           classes = `${classes} govuk-input--error`.trim()
         }
 
@@ -133,11 +143,6 @@ export class MonthYearField extends FormComponent {
           classes
         }
       })
-
-    // Filter errors for this component only
-    const componentErrors = errors?.errorList.filter(
-      (error) => error.name.startsWith(`${name}__`) // E.g. `${name}__year`
-    )
 
     const errorMessage = componentErrors?.[0] && {
       text: componentErrors[0].text


### PR DESCRIPTION
Fixes bug [#452104](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/452104)

Also found a new one, we didn't add red borders when the entire field was invalid

## Before

<img width="329" alt="Date field before" src="https://github.com/user-attachments/assets/1a3fcd3e-6633-4c97-a0a6-dff5c8fb5ccd">

## After

<img width="364" alt="Date field after" src="https://github.com/user-attachments/assets/3cea70da-9fa6-48b9-aa0d-21dea7033f3e">
