### PR TITLE
Fix clash on `FormState` type name

### DIFF
--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -5,6 +5,7 @@ import {
   getFormDefinition,
   getFormMetadata
 } from '~/src/server/plugins/engine/services/formsService.js'
+import { FormStatus } from '~/src/server/routes/types.js'
 import * as fixtures from '~/test/fixtures/index.js'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
@@ -238,7 +239,7 @@ describe('Model cache', () => {
       // Expect `getFormDefinition` to be called as the updatedAt has moved on
       expect(getFormDefinition).toHaveBeenLastCalledWith(
         fixtures.form.metadata.id,
-        'live'
+        FormStatus.Live
       )
 
       // Assert the live/live cache item has the correct updatedAt timestamp

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -10,6 +10,7 @@ import {
   redirectTo,
   redirectUrl
 } from '~/src/server/plugins/engine/helpers.js'
+import { FormStatus } from '~/src/server/routes/types.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
 
 describe('Helpers', () => {
@@ -139,7 +140,7 @@ describe('Helpers', () => {
     it('should return true/live for paths starting with PREVIEW_PATH_PREFIX and form is live', () => {
       const path = `${PREVIEW_PATH_PREFIX}/live/another/segment`
       expect(checkFormStatus(path)).toStrictEqual({
-        state: 'live',
+        state: FormStatus.Live,
         isPreview: true
       })
     })
@@ -147,7 +148,7 @@ describe('Helpers', () => {
     it('should return false for paths not starting with PREVIEW_PATH_PREFIX', () => {
       const path = '/some/other/path'
       expect(checkFormStatus(path)).toStrictEqual({
-        state: 'live',
+        state: FormStatus.Live,
         isPreview: false
       })
     })
@@ -155,7 +156,7 @@ describe('Helpers', () => {
     it('should be case insensitive and return draft when form is draft', () => {
       const path = `${PREVIEW_PATH_PREFIX.toUpperCase()}/draft/path`
       expect(checkFormStatus(path)).toStrictEqual({
-        state: 'draft',
+        state: FormStatus.Draft,
         isPreview: true
       })
     })

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -4,10 +4,7 @@ import { type ResponseToolkit } from '@hapi/hapi'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
 import { RelativeUrl } from '~/src/server/plugins/engine/feedback/index.js'
-import {
-  FormState,
-  type FormStatus
-} from '~/src/server/plugins/engine/models/types.js'
+import { FormStatus } from '~/src/server/routes/types.js'
 import {
   type FormQuery,
   type FormRequest,
@@ -85,15 +82,15 @@ export const filesize = (bytes: number) => {
   return Math.max(bytes, 0.1).toFixed(1) + byteUnits[i]
 }
 
-export function checkFormStatus(path: string): FormStatus {
+export function checkFormStatus(path: string) {
   const isPreview = path.toLowerCase().startsWith(PREVIEW_PATH_PREFIX)
 
-  let state: FormState | undefined
+  let state: FormStatus | undefined
 
   if (isPreview) {
     const previewState = path.split('/')[2]
 
-    for (const formState of Object.values(FormState)) {
+    for (const formState of Object.values(FormStatus)) {
       if (previewState === formState.toString()) {
         state = formState
         break
@@ -107,7 +104,7 @@ export function checkFormStatus(path: string): FormStatus {
 
   return {
     isPreview,
-    state: state ?? FormState.LIVE
+    state: state ?? FormStatus.Live
   }
 }
 

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -88,23 +88,26 @@ export const filesize = (bytes: number) => {
 export function checkFormStatus(path: string): FormStatus {
   const isPreview = path.toLowerCase().startsWith(PREVIEW_PATH_PREFIX)
 
-  let state: FormState
+  let state: FormState | undefined
 
   if (isPreview) {
     const previewState = path.split('/')[2]
 
-    if (!Object.values(FormState).includes(previewState as FormState)) {
-      throw new Error(`Invalid form state: ${previewState}`)
+    for (const formState of Object.values(FormState)) {
+      if (previewState === formState.toString()) {
+        state = formState
+        break
+      }
     }
 
-    state = previewState as FormState
-  } else {
-    state = FormState.LIVE
+    if (!state) {
+      throw new Error(`Invalid form state: ${previewState}`)
+    }
   }
 
   return {
     isPreview,
-    state
+    state: state ?? FormState.LIVE
   }
 }
 

--- a/src/server/plugins/engine/models/types.ts
+++ b/src/server/plugins/engine/models/types.ts
@@ -128,13 +128,3 @@ export interface Detail {
   title?: Section['title']
   items: DetailItem[]
 }
-
-export enum FormState {
-  DRAFT = 'draft',
-  LIVE = 'live'
-}
-
-export interface FormStatus {
-  isPreview: boolean
-  state: FormState
-}

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
@@ -9,12 +9,11 @@ import {
   FormModel,
   SummaryViewModel
 } from '~/src/server/plugins/engine/models/index.js'
-import { FormState } from '~/src/server/plugins/engine/models/types.js'
 import {
   getPersonalisation,
   getQuestions
 } from '~/src/server/plugins/engine/pageControllers/SummaryPageController.js'
-import { type FormRequest } from '~/src/server/routes/types.js'
+import { FormStatus, type FormRequest } from '~/src/server/routes/types.js'
 
 describe('SummaryPageController', () => {
   describe('getPersonalisation', () => {
@@ -53,7 +52,7 @@ describe('SummaryPageController', () => {
     )
 
     const formStatus = (previewStatus: boolean) => ({
-      state: FormState.DRAFT,
+      state: FormStatus.Draft,
       isPreview: previewStatus
     })
 

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -25,8 +25,7 @@ import {
 } from '~/src/server/plugins/engine/models/index.js'
 import {
   type Detail,
-  type DetailItem,
-  type FormStatus
+  type DetailItem
 } from '~/src/server/plugins/engine/models/types.js'
 import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
@@ -405,7 +404,7 @@ export function getPersonalisation(
   questions: QuestionRecord[],
   model: FormModel,
   submitResponse: SubmitResponsePayload,
-  formStatus: FormStatus
+  formStatus: ReturnType<typeof checkFormStatus>
 ) {
   /**
    * @todo Refactor this below but the code to

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -22,6 +22,7 @@ import {
   getFormDefinition,
   getFormMetadata
 } from '~/src/server/plugins/engine/services/formsService.js'
+import { FormStatus } from '~/src/server/routes/types.js'
 import {
   type FormRequest,
   type FormRequestPayload,
@@ -60,7 +61,9 @@ export interface PluginOptions {
   modelOptions?: ConstructorParameters<typeof FormModel>[1]
 }
 
-const stateSchema = Joi.string().valid('draft', 'live').required()
+const stateSchema = Joi.string()
+  .valid(FormStatus.Draft, FormStatus.Live)
+  .required()
 const pathSchema = Joi.string().required()
 const itemIdSchema = Joi.string().uuid().required()
 const crumbSchema = Joi.string().optional().allow('')
@@ -95,8 +98,7 @@ export const plugin = {
 
       const { params, path } = request
       const { slug } = params
-      const { isPreview } = checkFormStatus(path)
-      const formState = isPreview && params.state ? params.state : 'live'
+      const { isPreview, state: formState } = checkFormStatus(path)
 
       // Get the form metadata using the `slug` param
       const metadata = await getFormMetadata(slug)

--- a/src/server/plugins/engine/services/formsService.js
+++ b/src/server/plugins/engine/services/formsService.js
@@ -1,6 +1,7 @@
 import { formMetadataSchema } from '@defra/forms-model'
 
 import { config } from '~/src/config/index.js'
+import { FormStatus } from '~/src/server/routes/types.js'
 import { getJson } from '~/src/server/services/httpService.js'
 
 /**
@@ -27,12 +28,12 @@ export async function getFormMetadata(slug) {
 /**
  * Retrieves a form definition from the form manager for a given id
  * @param {string} id - the id of the form
- * @param {'draft'|'live'} state - the state of the form
+ * @param {FormStatus} state - the state of the form
  */
 export async function getFormDefinition(id, state) {
   const getJsonByType = /** @type {typeof getJson<FormDefinition>} */ (getJson)
 
-  const suffix = state === 'draft' ? '/draft' : ''
+  const suffix = state === FormStatus.Draft ? `/${state}` : ''
   const { payload: definition } = await getJsonByType(
     `${config.get('managerUrl')}/forms/${id}/definition${suffix}`
   )

--- a/src/server/plugins/engine/services/formsService.test.js
+++ b/src/server/plugins/engine/services/formsService.test.js
@@ -1,0 +1,82 @@
+import {
+  getFormDefinition,
+  getFormMetadata
+} from '~/src/server/plugins/engine/services/formsService.js'
+import { FormStatus } from '~/src/server/routes/types.js'
+import { getJson } from '~/src/server/services/httpService.js'
+import * as fixtures from '~/test/fixtures/index.js'
+
+const { MANAGER_URL } = process.env
+
+jest.mock('~/src/server/services/httpService')
+
+describe('Forms service', () => {
+  const { definition, metadata } = fixtures.form
+
+  describe('getFormMetadata', () => {
+    beforeEach(() => {
+      jest.mocked(getJson).mockResolvedValue({
+        res: /** @type {IncomingMessage} */ ({ statusCode: 200 }),
+        payload: metadata
+      })
+    })
+
+    it('requests JSON via form slug', async () => {
+      await getFormMetadata(metadata.slug)
+
+      expect(getJson).toHaveBeenCalledWith(
+        `${MANAGER_URL}/forms/slug/${metadata.slug}`
+      )
+    })
+
+    it('coerces timestamps from string to Date', async () => {
+      const payload = {
+        ...structuredClone(metadata),
+
+        // JSON payload uses string dates in transit
+        createdAt: metadata.createdAt.toISOString(),
+        updatedAt: metadata.updatedAt.toISOString()
+      }
+
+      jest.mocked(getJson).mockResolvedValue({
+        res: /** @type {IncomingMessage} */ ({ statusCode: 200 }),
+        payload
+      })
+
+      await expect(getFormMetadata(metadata.slug)).resolves.toEqual({
+        ...metadata,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date)
+      })
+    })
+  })
+
+  describe('getFormDefinition', () => {
+    beforeEach(() => {
+      jest.mocked(getJson).mockResolvedValue({
+        res: /** @type {IncomingMessage} */ ({ statusCode: 200 }),
+        payload: definition
+      })
+    })
+
+    it('requests JSON via form ID (draft)', async () => {
+      await getFormDefinition(metadata.id, FormStatus.Draft)
+
+      expect(getJson).toHaveBeenCalledWith(
+        `${MANAGER_URL}/forms/${metadata.id}/definition/draft`
+      )
+    })
+
+    it('requests JSON via form ID (live)', async () => {
+      await getFormDefinition(metadata.id, FormStatus.Live)
+
+      expect(getJson).toHaveBeenCalledWith(
+        `${MANAGER_URL}/forms/${metadata.id}/definition`
+      )
+    })
+  })
+})
+
+/**
+ * @import { IncomingMessage } from 'node:http'
+ */

--- a/src/server/routes/types.ts
+++ b/src/server/routes/types.ts
@@ -27,3 +27,8 @@ export interface FormRequestPayloadRefs extends FormRequestRefs {
 
 export type FormRequest = Request<FormRequestRefs>
 export type FormRequestPayload = Request<FormRequestPayloadRefs>
+
+export enum FormStatus {
+  Draft = 'draft',
+  Live = 'live'
+}

--- a/src/server/routes/types.ts
+++ b/src/server/routes/types.ts
@@ -9,7 +9,7 @@ export interface FormQuery extends Partial<Record<string, string>> {
 export interface FormParams extends Partial<Record<string, string>> {
   path: string
   slug: string
-  state?: 'draft' | 'live'
+  state?: FormStatus
 }
 
 export interface FormRequestRefs


### PR DESCRIPTION
Quick PR to rename the new `FormState` enum to `FormStatus` and use it across the repo

It clashed with the `FormState` type we use for Redis session state

Fixes [bug #465015](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/465015)