### PR TITLE
Fix number `schema.precision` not being applied etc

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -164,9 +164,9 @@ describe('DatePartsField', () => {
         expect(result.error).toEqual(
           expect.objectContaining({
             message: [
-              'day must be a number',
-              'month must be a number',
-              'year must be a number'
+              'Example date parts field must include a day',
+              'Example date parts field must include a month',
+              'Example date parts field must include a year'
             ].join('. ')
           })
         )
@@ -401,7 +401,7 @@ describe('DatePartsField', () => {
                 month: 1,
                 year: 2024
               }),
-              error: new Error('day must be 31 or lower')
+              error: new Error('Example date parts field must include a day')
             }
           },
           {
@@ -416,7 +416,7 @@ describe('DatePartsField', () => {
                 month: 13,
                 year: 2024
               }),
-              error: new Error('month must be 12 or lower')
+              error: new Error('Example date parts field must include a month')
             }
           },
           {
@@ -431,7 +431,7 @@ describe('DatePartsField', () => {
                 month: 1,
                 year: 999
               }),
-              error: new Error('year must be 1000 or higher')
+              error: new Error('Example date parts field must include a year')
             }
           }
         ]

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -339,6 +339,27 @@ describe('DatePartsField', () => {
         ]
       },
       {
+        description: 'Trim decimals',
+        component: {
+          title: 'Example date parts field',
+          name: 'myComponent',
+          type: ComponentType.DatePartsField,
+          options: {}
+        } satisfies DatePartsFieldComponent,
+        assertions: [
+          {
+            input: getFormData({
+              day: '1.1',
+              month: '1.2',
+              year: '2001.3'
+            }),
+            output: {
+              value: getFormData(date)
+            }
+          }
+        ]
+      },
+      {
         description: 'Leap years',
         component: {
           title: 'Example date parts field',

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -46,9 +46,9 @@ export class DatePartsField extends FormComponent {
           options: {
             required: isRequired,
             optionalText: !isRequired && hideOptional,
-            classes: 'govuk-input--width-2'
-          },
-          hint: ''
+            classes: 'govuk-input--width-2',
+            customValidationMessage: `${title} must include a {{#label}}`
+          }
         },
         {
           type: ComponentType.NumberField,
@@ -58,9 +58,9 @@ export class DatePartsField extends FormComponent {
           options: {
             required: isRequired,
             optionalText: !isRequired && hideOptional,
-            classes: 'govuk-input--width-2'
-          },
-          hint: ''
+            classes: 'govuk-input--width-2',
+            customValidationMessage: `${title} must include a {{#label}}`
+          }
         },
         {
           type: ComponentType.NumberField,
@@ -70,9 +70,9 @@ export class DatePartsField extends FormComponent {
           options: {
             required: isRequired,
             optionalText: !isRequired && hideOptional,
-            classes: 'govuk-input--width-4'
-          },
-          hint: ''
+            classes: 'govuk-input--width-4',
+            customValidationMessage: `${title} must include a {{#label}}`
+          }
         }
       ],
       model

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -42,7 +42,7 @@ export class DatePartsField extends FormComponent {
           type: ComponentType.NumberField,
           name: `${name}__day`,
           title: 'Day',
-          schema: { min: 1, max: 31 },
+          schema: { min: 1, max: 31, precision: 0 },
           options: {
             required: isRequired,
             optionalText: !isRequired && hideOptional,
@@ -54,7 +54,7 @@ export class DatePartsField extends FormComponent {
           type: ComponentType.NumberField,
           name: `${name}__month`,
           title: 'Month',
-          schema: { min: 1, max: 12 },
+          schema: { min: 1, max: 12, precision: 0 },
           options: {
             required: isRequired,
             optionalText: !isRequired && hideOptional,
@@ -66,7 +66,7 @@ export class DatePartsField extends FormComponent {
           type: ComponentType.NumberField,
           name: `${name}__year`,
           title: 'Year',
-          schema: { min: 1000, max: 3000 },
+          schema: { min: 1000, max: 3000, precision: 0 },
           options: {
             required: isRequired,
             optionalText: !isRequired && hideOptional,

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -142,7 +142,10 @@ describe('MonthYearField', () => {
 
         expect(result.error).toEqual(
           expect.objectContaining({
-            message: 'month must be between 1 and 12. year must be a number'
+            message: [
+              'Example month/year field must include a month',
+              'Example month/year field must include a year'
+            ].join('. ')
           })
         )
       })
@@ -307,7 +310,7 @@ describe('MonthYearField', () => {
                 month: 13,
                 year: 2024
               }),
-              error: new Error('month must be between 1 and 12')
+              error: new Error('Example month/year field must include a month')
             }
           },
           {
@@ -320,7 +323,7 @@ describe('MonthYearField', () => {
                 month: 1,
                 year: 999
               }),
-              error: new Error('year must be 1000 or higher')
+              error: new Error('Example month/year field must include a year')
             }
           }
         ]

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -292,6 +292,26 @@ describe('MonthYearField', () => {
         ]
       },
       {
+        description: 'Trim decimals',
+        component: {
+          title: 'Example month/year field',
+          name: 'myComponent',
+          type: ComponentType.MonthYearField,
+          options: {}
+        } satisfies MonthYearFieldComponent,
+        assertions: [
+          {
+            input: getFormData({
+              month: '1.2',
+              year: '2001.3'
+            }),
+            output: {
+              value: getFormData(date)
+            }
+          }
+        ]
+      },
+      {
         description: 'Out of range values',
         component: {
           title: 'Example month/year field',

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -33,7 +33,7 @@ export class MonthYearField extends FormComponent {
           type: ComponentType.NumberField,
           name: `${name}__month`,
           title: 'Month',
-          schema: { min: 1, max: 12 },
+          schema: { min: 1, max: 12, precision: 0 },
           options: {
             required: isRequired,
             optionalText: !isRequired && hideOptional,
@@ -45,7 +45,7 @@ export class MonthYearField extends FormComponent {
           type: ComponentType.NumberField,
           name: `${name}__year`,
           title: 'Year',
-          schema: { min: 1000, max: 3000 },
+          schema: { min: 1000, max: 3000, precision: 0 },
           options: {
             required: isRequired,
             optionalText: !isRequired && hideOptional,

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -23,7 +23,9 @@ export class MonthYearField extends FormComponent {
     super(def, model)
 
     const { name, options, title } = def
+
     const isRequired = options.required !== false
+    const hideOptional = options.optionalText
 
     this.children = new ComponentCollection(
       [
@@ -34,8 +36,9 @@ export class MonthYearField extends FormComponent {
           schema: { min: 1, max: 12 },
           options: {
             required: isRequired,
+            optionalText: !isRequired && hideOptional,
             classes: 'govuk-input--width-2',
-            customValidationMessage: '{{#label}} must be between 1 and 12'
+            customValidationMessage: `${title} must include a {{#label}}`
           }
         },
         {
@@ -45,7 +48,9 @@ export class MonthYearField extends FormComponent {
           schema: { min: 1000, max: 3000 },
           options: {
             required: isRequired,
-            classes: 'govuk-input--width-4'
+            optionalText: !isRequired && hideOptional,
+            classes: 'govuk-input--width-4',
+            customValidationMessage: `${title} must include a {{#label}}`
           }
         }
       ],

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -100,7 +100,7 @@ describe('NumberField', () => {
 
         expect(result.error).toEqual(
           expect.objectContaining({
-            message: `${label} must be a number`
+            message: `Enter ${label}`
           })
         )
       })

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -237,6 +237,72 @@ describe('NumberField', () => {
         ]
       },
       {
+        description: 'Schema precision (integers only)',
+        component: {
+          title: 'Example number field',
+          name: 'myComponent',
+          type: ComponentType.NumberField,
+          options: {},
+          schema: {
+            precision: 0
+          }
+        } satisfies NumberFieldComponent,
+        assertions: [
+          {
+            input: '100.55',
+            output: { value: 101 }
+          },
+          {
+            input: '3.14159',
+            output: { value: 3 }
+          }
+        ]
+      },
+      {
+        description: 'Schema precision (1 decimal place)',
+        component: {
+          title: 'Example number field',
+          name: 'myComponent',
+          type: ComponentType.NumberField,
+          options: {},
+          schema: {
+            precision: 1
+          }
+        } satisfies NumberFieldComponent,
+        assertions: [
+          {
+            input: '100.555',
+            output: { value: 100.6 }
+          },
+          {
+            input: '3.14159',
+            output: { value: 3.1 }
+          }
+        ]
+      },
+      {
+        description: 'Schema precision (2 decimal places)',
+        component: {
+          title: 'Example number field',
+          name: 'myComponent',
+          type: ComponentType.NumberField,
+          options: {},
+          schema: {
+            precision: 2
+          }
+        } satisfies NumberFieldComponent,
+        assertions: [
+          {
+            input: '100.555',
+            output: { value: 100.56 }
+          },
+          {
+            input: '3.14159',
+            output: { value: 3.14 }
+          }
+        ]
+      },
+      {
         description: 'Schema min and max',
         component: {
           title: 'Example number field',

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -3,6 +3,7 @@ import joi, { type NumberSchema } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
+import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 import {
   type FormPayload,
   type FormSubmissionErrors
@@ -22,6 +23,10 @@ export class NumberField extends FormComponent {
 
     if (options.required === false) {
       formSchema = formSchema.allow('')
+    } else {
+      formSchema = formSchema.empty('').messages({
+        'any.required': messageTemplate.required
+      })
     }
 
     if (typeof schema.min === 'number') {

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -37,6 +37,10 @@ export class NumberField extends FormComponent {
       formSchema = formSchema.max(schema.max)
     }
 
+    if (typeof schema.precision === 'number') {
+      formSchema = formSchema.precision(schema.precision)
+    }
+
     if (options.customValidationMessage) {
       const message = options.customValidationMessage
 

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
@@ -91,7 +91,7 @@ describe('RepeatPageController', () => {
               path: 'quantity',
               href: '#quantity',
               name: 'quantity',
-              text: 'Select quantity'
+              text: 'Enter quantity'
             },
             {
               href: '#itemId',


### PR DESCRIPTION
This PR closes [bug #414012](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/414012) and includes:

* Number field `schema.precision` is applied
* Number field error messages are consistent
* Date field decimal places are removed

## Number fields
When empty, we said "XXX must be a number" rather than the default "Enter XXX"

### Before

<img width="669" alt="Number field before" src="https://github.com/user-attachments/assets/495112fb-3ea6-4596-a1c5-22c1be63f795">

### After

<img width="669" alt="Number field after" src="https://github.com/user-attachments/assets/88b2b6ab-4142-4377-9d3d-59cbf6802eea">

## Date fields
For all child number fields used by date or month/year field, we didn't include the parent label in the message

### Before

<img width="292" alt="Date input before" src="https://github.com/user-attachments/assets/8eefbf23-fbf9-4bd6-ad02-4009f7914ee9">


### After

<img width="309" alt="Date input after" src="https://github.com/user-attachments/assets/06ba3ea9-f63e-4249-9817-be491f62322b">
