### PR TITLE
458970 Validate nested fields when optional but partially entered

### DIFF
--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -101,10 +101,3 @@ export type ComponentSchema =
   | NumberSchema
   | ObjectSchema
   | StringSchema
-
-export type ComponentSchemaNested = Record<string, ComponentSchema | undefined>
-
-export type ComponentSchemaKeys = Record<
-  string,
-  ComponentSchema | ComponentSchemaNested | undefined
->

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -3,10 +3,15 @@ import joi, {
   type Context,
   type CustomHelpers,
   type CustomValidator,
+  type ErrorReportCollection,
   type ObjectSchema,
   type State
 } from 'joi'
 
+import {
+  isFormState,
+  isFormValue
+} from '~/src/server/plugins/engine/components/FormComponent.js'
 import {
   createComponentField,
   type ComponentFieldClass,
@@ -36,6 +41,15 @@ export class ComponentCollection {
       model: FormModel
     },
     schema?: {
+      /**
+       * Defines an all-or-nothing relationship between keys where if one
+       * of the peers is present, all of them are required as well
+       */
+      peers?: string[]
+
+      /**
+       * Defines a custom validation rule for the object schema
+       */
       custom?: CustomValidator
     }
   ) {
@@ -67,6 +81,44 @@ export class ComponentCollection {
       stateSchema = children
         ? stateSchema.concat(children.stateSchema)
         : stateSchema.keys({ [name]: field.stateSchema })
+    }
+
+    // Add parent field title to collection field errors
+    if (!options.parent) {
+      formSchema = formSchema.error((errors) =>
+        errors.map((error) => {
+          if (
+            !isCollectionContext(error.local) ||
+            !error.local.missing?.length ||
+            !error.local.present?.length
+          ) {
+            return error
+          }
+
+          const { missing, present } = error.local
+
+          // Find the parent field
+          const name = present[0].split('__').shift()
+          const parent = formItems.find((item) => item.name === name)
+          const child = parent?.children?.formItems[0]
+
+          // Update error with parent title etc
+          if (parent && child) {
+            error.path = missing
+            error.local.key = missing[0]
+            error.local.title = parent.title
+            error.local.label = child.title.toLowerCase()
+          }
+
+          return error
+        })
+      )
+    }
+
+    if (schema?.peers) {
+      formSchema = formSchema.and(...schema.peers, {
+        isPresent: isFormValue
+      })
     }
 
     if (schema?.custom) {
@@ -170,4 +222,13 @@ export class ComponentCollection {
 
     return helpers.error(code, local, localState)
   }
+}
+
+/**
+ * Check for nested field local state with unknown label
+ */
+export function isCollectionContext(
+  value?: unknown
+): value is ErrorReportCollection['local'] {
+  return isFormState(value) && value.label === 'value'
 }

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -16,6 +16,8 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class ComponentCollection {
+  parent?: ComponentFieldClass
+
   items: ComponentFieldClass[]
   formItems: FormComponentFieldClass[]
   formSchema: ObjectSchema<FormPayload>
@@ -23,8 +25,13 @@ export class ComponentCollection {
 
   constructor(
     componentDefs: ComponentDef[],
-    options: { model: FormModel },
-    schema?: { custom?: CustomValidator }
+    options: {
+      parent?: ComponentFieldClass
+      model: FormModel
+    },
+    schema?: {
+      custom?: CustomValidator
+    }
   ) {
     const items = componentDefs.map((def) => {
       const component = createComponentField(def, options.model)
@@ -59,6 +66,8 @@ export class ComponentCollection {
     if (schema?.custom) {
       formSchema = formSchema.custom(schema.custom)
     }
+
+    this.parent = options.parent
 
     this.items = items
     this.formItems = formItems

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -1,5 +1,11 @@
 import { type ComponentDef } from '@defra/forms-model'
-import joi, { type CustomValidator, type ObjectSchema } from 'joi'
+import joi, {
+  type Context,
+  type CustomHelpers,
+  type CustomValidator,
+  type ObjectSchema,
+  type State
+} from 'joi'
 
 import {
   createComponentField,
@@ -137,5 +143,31 @@ export class ComponentCollection {
     }
 
     return result
+  }
+
+  /**
+   * Return error by code for collection fields
+   * For example, 'date.min', 'date.max'
+   */
+  error(helpers: CustomHelpers, code: string, context?: Context) {
+    const { formItems, parent } = this
+    const [field] = formItems
+
+    // Use collection parent name/title when available
+    const key = parent?.name ?? field.name
+    const title = parent?.title ?? field.title
+
+    // Support collection parent {{#title}} in messages
+    const local: Context = {
+      title: title.toLowerCase(),
+      ...context
+    }
+
+    // Error summary links to first collection field
+    const localState: State = parent
+      ? { key, path: [parent.name, field.name] } // For example, `#dateField__day`
+      : { key, path: [field.name] } // Otherwise `#dateField` for single fields
+
+    return helpers.error(code, local, localState)
   }
 }

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -75,7 +75,7 @@ export class DatePartsField extends FormComponent {
           }
         }
       ],
-      { model },
+      { model, parent: this },
       { custom: getValidatorDate(this) }
     )
 

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -195,16 +195,16 @@ interface DatePartsState extends Record<string, number> {
 }
 
 export function getValidatorDate(component: DatePartsField) {
-  const { options } = component
-
   const validator: CustomValidator = (payload: FormPayload, helpers) => {
+    const { children, options } = component
+
     const values = component.getFormValueFromState(
       component.getStateFromValidForm(payload)
     )
 
     if (!DatePartsField.isDateParts(values)) {
       return options.required !== false
-        ? helpers.error('date.base') // Date required
+        ? children.error(helpers, 'date.base') // Date required
         : payload
     }
 
@@ -215,7 +215,7 @@ export function getValidatorDate(component: DatePartsField) {
     )
 
     if (!isValid(date)) {
-      return helpers.error('date.format')
+      return children.error(helpers, 'date.format')
     }
 
     // Minimum date from today
@@ -229,17 +229,11 @@ export function getValidatorDate(component: DatePartsField) {
       : undefined
 
     if (dateMin && date < dateMin) {
-      return helpers.error('date.min', {
-        label: helpers.state.key,
-        limit: dateMin
-      })
+      return children.error(helpers, 'date.min', { limit: dateMin })
     }
 
     if (dateMax && date > dateMax) {
-      return helpers.error('date.max', {
-        label: helpers.state.key,
-        limit: dateMax
-      })
+      return children.error(helpers, 'date.max', { limit: dateMax })
     }
 
     return payload

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -13,6 +13,7 @@ import {
   type DateInputItem
 } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
+import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 import {
   type FormPayload,
   type FormState,
@@ -47,7 +48,9 @@ export class DatePartsField extends FormComponent {
             required: isRequired,
             optionalText: true,
             classes: 'govuk-input--width-2',
-            customValidationMessage: `${title} must include a {{#label}}`
+            customValidationMessage: messageTemplate.objectMissing
+              .replace('{{#title}}', title)
+              .replace('{{#missingWithLabels}}', 'day')
           }
         },
         {
@@ -59,7 +62,9 @@ export class DatePartsField extends FormComponent {
             required: isRequired,
             optionalText: true,
             classes: 'govuk-input--width-2',
-            customValidationMessage: `${title} must include a {{#label}}`
+            customValidationMessage: messageTemplate.objectMissing
+              .replace('{{#title}}', title)
+              .replace('{{#missingWithLabels}}', 'month')
           }
         },
         {
@@ -71,12 +76,17 @@ export class DatePartsField extends FormComponent {
             required: isRequired,
             optionalText: true,
             classes: 'govuk-input--width-4',
-            customValidationMessage: `${title} must include a {{#label}}`
+            customValidationMessage: messageTemplate.objectMissing
+              .replace('{{#title}}', title)
+              .replace('{{#missingWithLabels}}', 'year')
           }
         }
       ],
       { model, parent: this },
-      { custom: getValidatorDate(this) }
+      {
+        peers: [`${name}__day`, `${name}__month`, `${name}__year`],
+        custom: getValidatorDate(this)
+      }
     )
 
     this.options = options
@@ -202,9 +212,9 @@ export function getValidatorDate(component: DatePartsField) {
       component.getStateFromValidForm(payload)
     )
 
-    if (!DatePartsField.isDateParts(values)) {
+    if (!component.isState(values)) {
       return options.required !== false
-        ? children.error(helpers, 'date.base') // Date required
+        ? children.error(helpers, 'object.required')
         : payload
     }
 

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -128,15 +128,15 @@ export class DatePartsField extends FormComponent {
     const viewModel = super.getViewModel(payload, errors)
     let { fieldset, label } = viewModel
 
-    // Filter component and children errors only
+    // Filter component and child errors only
     const componentErrors = errors?.errorList.filter(
       (error) =>
-        error.name === name || // Errors for parent component only
+        error.path.includes(name) || // Errors for parent component
         error.name.startsWith(`${name}__`) // Plus `${name}__year` etc fields
     )
 
     // Check for component errors only
-    const hasError = componentErrors?.some((error) => error.name === name)
+    const hasError = componentErrors?.some((error) => error.path.includes(name))
 
     // Use the component collection to generate the subitems
     const items: DateInputItem[] = children

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -75,26 +75,13 @@ export class DatePartsField extends FormComponent {
           }
         }
       ],
-      model
+      { model },
+      { custom: getValidatorDate(this) }
     )
 
-    let { formSchema, stateSchema } = this.children
-
-    // Update child schema
-    formSchema = formSchema
-      .custom(getValidatorDate(this), 'date validation')
-      .label(title.toLowerCase())
-
-    stateSchema = stateSchema
-      .custom(getValidatorDate(this), 'date validation')
-      .label(title.toLowerCase())
-
     this.options = options
-    this.formSchema = formSchema
-    this.stateSchema = stateSchema
-
-    this.children.formSchema = formSchema
-    this.children.stateSchema = stateSchema
+    this.formSchema = this.children.formSchema
+    this.stateSchema = this.children.stateSchema
   }
 
   getFormValueFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -1,10 +1,7 @@
 import { type FormComponentsDef } from '@defra/forms-model'
 import upperFirst from 'lodash/upperFirst.js'
 
-import {
-  ComponentBase,
-  type ComponentSchemaKeys
-} from '~/src/server/plugins/engine/components/ComponentBase.js'
+import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { type ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
@@ -105,30 +102,6 @@ export class FormComponent extends ComponentBase {
       id: name,
       name,
       value: payload[name]
-    }
-  }
-
-  getFormSchemaKeys(): ComponentSchemaKeys {
-    const { children, name, formSchema } = this
-
-    if (children) {
-      return children.getFormSchemaKeys()
-    }
-
-    return {
-      [name]: formSchema
-    }
-  }
-
-  getStateSchemaKeys(): ComponentSchemaKeys {
-    const { children, name, stateSchema } = this
-
-    if (children) {
-      return children.getStateSchemaKeys()
-    }
-
-    return {
-      [name]: stateSchema
     }
   }
 

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -85,7 +85,7 @@ export class FormComponent extends ComponentBase {
     }
 
     errors?.errorList.forEach((err) => {
-      if (err.name === name) {
+      if (err.name === name || err.path.includes(name)) {
         err.text = upperFirst(err.text)
 
         viewModel.errorMessage = {

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -62,21 +62,12 @@ export class MonthYearField extends FormComponent {
           }
         }
       ],
-      model
+      { model }
     )
 
-    let { formSchema, stateSchema } = this.children
-
-    // Update child schema
-    formSchema = formSchema.label(title.toLowerCase())
-    stateSchema = stateSchema.label(title.toLowerCase())
-
     this.options = options
-    this.formSchema = formSchema
-    this.stateSchema = stateSchema
-
-    this.children.formSchema = formSchema
-    this.children.stateSchema = stateSchema
+    this.formSchema = this.children.formSchema
+    this.stateSchema = this.children.stateSchema
   }
 
   getFormValueFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -104,15 +104,15 @@ export class MonthYearField extends FormComponent {
     const viewModel = super.getViewModel(payload, errors)
     let { fieldset, label } = viewModel
 
-    // Filter component and children errors only
+    // Filter component and child errors only
     const componentErrors = errors?.errorList.filter(
       (error) =>
-        error.name === name || // Errors for parent component only
+        error.path.includes(name) || // Errors for parent component
         error.name.startsWith(`${name}__`) // Plus `${name}__year` etc fields
     )
 
     // Check for component errors only
-    const hasError = componentErrors?.some((error) => error.name === name)
+    const hasError = componentErrors?.some((error) => error.path.includes(name))
 
     // Use the component collection to generate the subitems
     const items: DateInputItem[] = children

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -62,7 +62,7 @@ export class MonthYearField extends FormComponent {
           }
         }
       ],
-      { model }
+      { model, parent: this }
     )
 
     this.options = options

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -103,18 +103,9 @@ export class MultilineTextField extends FormComponent {
 }
 
 function getValidatorMaxWords(component: MultilineTextField) {
-  const { options } = component
-
-  /**
-   * Count the number of words in the given text
-   * @see GOV.UK Frontend {@link https://github.com/alphagov/govuk-frontend/blob/v5.4.0/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs#L343 | Character count `maxwords` implementation}
-   */
-  function count(text: string) {
-    const tokens = text.match(/\S+/g) ?? []
-    return tokens.length
-  }
-
   const validator: CustomValidator = (value: string, helpers) => {
+    const { options } = component
+
     const {
       customValidationMessage: custom,
       maxWords: limit // See {{#limit}} variable
@@ -127,6 +118,15 @@ function getValidatorMaxWords(component: MultilineTextField) {
     return custom
       ? helpers.message({ custom }, { limit })
       : helpers.error('string.maxWords', { limit })
+  }
+
+  /**
+   * Count the number of words in the given text
+   * @see GOV.UK Frontend {@link https://github.com/alphagov/govuk-frontend/blob/v5.4.0/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs#L343 | Character count `maxwords` implementation}
+   */
+  function count(text: string) {
+    const tokens = text.match(/\S+/g) ?? []
+    return tokens.length
   }
 
   return validator

--- a/src/server/plugins/engine/components/UkAddressField.test.ts
+++ b/src/server/plugins/engine/components/UkAddressField.test.ts
@@ -4,7 +4,8 @@ import {
   type UkAddressFieldComponent
 } from '@defra/forms-model'
 
-import { UkAddressField } from '~/src/server/plugins/engine/components/UkAddressField.js'
+import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
+import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
 import { type ViewModel } from '~/src/server/plugins/engine/components/types.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { validationOptions as opts } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
@@ -31,7 +32,8 @@ describe('UkAddressField', () => {
 
   describe('Defaults', () => {
     let def: UkAddressFieldComponent
-    let component: UkAddressField
+    let collection: ComponentCollection
+    let component: FormComponentFieldClass
 
     beforeEach(() => {
       def = {
@@ -41,12 +43,13 @@ describe('UkAddressField', () => {
         options: {}
       } satisfies UkAddressFieldComponent
 
-      component = new UkAddressField(def, formModel)
+      collection = new ComponentCollection([def], { model: formModel })
+      component = collection.formItems[0]
     })
 
     describe('Schema', () => {
       it('uses collection titles as labels', () => {
-        const { formSchema } = component
+        const { formSchema } = collection
 
         expect(formSchema.describe().keys).toEqual(
           expect.objectContaining({
@@ -67,7 +70,7 @@ describe('UkAddressField', () => {
       })
 
       it('is required by default', () => {
-        const { formSchema } = component
+        const { formSchema } = collection
 
         expect(formSchema.describe().flags).toEqual(
           expect.objectContaining({
@@ -77,17 +80,19 @@ describe('UkAddressField', () => {
       })
 
       it('is optional when configured', () => {
-        const componentOptional = new UkAddressField(
-          {
-            title: 'Example UK address',
-            name: 'myComponent',
-            type: ComponentType.UkAddressField,
-            options: { required: false }
-          },
-          formModel
+        const collectionOptional = new ComponentCollection(
+          [
+            {
+              title: 'Example UK address',
+              name: 'myComponent',
+              type: ComponentType.UkAddressField,
+              options: { required: false }
+            }
+          ],
+          { model: formModel }
         )
 
-        const { formSchema } = componentOptional
+        const { formSchema } = collectionOptional
 
         expect(formSchema.describe().keys).toEqual(
           expect.objectContaining({
@@ -120,7 +125,7 @@ describe('UkAddressField', () => {
       })
 
       it('accepts valid values', () => {
-        const { formSchema } = component
+        const { formSchema } = collection
 
         const result1 = formSchema.validate(
           getFormData({
@@ -147,7 +152,7 @@ describe('UkAddressField', () => {
       })
 
       it('adds errors for empty value', () => {
-        const { formSchema } = component
+        const { formSchema } = collection
 
         const result = formSchema.validate(
           getFormData({
@@ -171,7 +176,7 @@ describe('UkAddressField', () => {
       })
 
       it('adds errors for invalid values', () => {
-        const { formSchema } = component
+        const { formSchema } = collection
 
         const result1 = formSchema.validate(['invalid'], opts)
         const result2 = formSchema.validate({ unknown: 'invalid' }, opts)
@@ -451,16 +456,16 @@ describe('UkAddressField', () => {
         ]
       }
     ])('$description', ({ component: def, assertions }) => {
-      let component: UkAddressField
+      let collection: ComponentCollection
 
       beforeEach(() => {
-        component = new UkAddressField(def, formModel)
+        collection = new ComponentCollection([def], { model: formModel })
       })
 
       it.each([...assertions])(
         'validates custom example',
         ({ input, output }) => {
-          const { formSchema } = component
+          const { formSchema } = collection
 
           const result = formSchema.validate(input, opts)
           expect(result).toEqual(output)

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -27,7 +27,7 @@ export class UkAddressField extends FormComponent {
   constructor(def: UkAddressFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { name, options, title } = def
+    const { name, options } = def
 
     const isRequired = options.required !== false
     const hideOptional = !!options.optionalText
@@ -84,21 +84,12 @@ export class UkAddressField extends FormComponent {
           }
         }
       ],
-      model
+      { model }
     )
 
-    let { formSchema, stateSchema } = this.children
-
-    // Update child schema
-    formSchema = formSchema.label(title.toLowerCase())
-    stateSchema = stateSchema.label(title.toLowerCase())
-
     this.options = options
-    this.formSchema = formSchema
-    this.stateSchema = stateSchema
-
-    this.children.formSchema = formSchema
-    this.children.stateSchema = stateSchema
+    this.formSchema = this.children.formSchema
+    this.stateSchema = this.children.stateSchema
   }
 
   getFormValueFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -84,7 +84,7 @@ export class UkAddressField extends FormComponent {
           }
         }
       ],
-      { model }
+      { model, parent: this }
     )
 
     this.options = options

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -11,6 +11,7 @@ import { RepeatPageController } from '~/src/server/plugins/engine/pageController
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import {
   type FormState,
+  type FormSubmissionError,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
 import {
@@ -35,13 +36,7 @@ export class SummaryViewModel {
   backLink?: string
   feedbackLink?: string
   phaseTag?: string
-  errors:
-    | {
-        path: string
-        name: string
-        message: string
-      }[]
-    | undefined
+  errors: FormSubmissionError[] | undefined
 
   serviceUrl: string
   showErrorSummary?: boolean
@@ -85,17 +80,19 @@ export class SummaryViewModel {
 
   private processErrors(result: ValidationResult, details: Detail[]) {
     this.errors = result.error?.details.map((err) => {
-      const name = err.path[err.path.length - 1] ?? ''
+      const name = err.context?.key ?? ''
 
       return {
-        path: err.path.join('.'),
-        name: name.toString(),
-        message: err.message
+        path: err.path,
+        href: `#${name}`,
+        name,
+        text: err.message,
+        context: err.context
       }
     })
 
     details.forEach((detail) => {
-      const sectionErr = this.errors?.find((err) => err.path === detail.name)
+      const sectionErr = this.errors?.find(({ name }) => name === detail.name)
 
       detail.items.forEach((item) => {
         if (sectionErr) {
@@ -103,11 +100,12 @@ export class SummaryViewModel {
           return
         }
 
-        const err = this.errors?.find(
-          (err) =>
-            err.path ===
-            (detail.name ? detail.name + '.' + item.name : item.name)
-        )
+        const err = this.errors?.find(({ name }) => {
+          return (
+            name === (detail.name ? `${detail.name}.${item.name}` : item.name)
+          )
+        })
+
         if (err) {
           item.inError = true
         }

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
@@ -7,6 +7,7 @@ import {
 
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { FileUploadPageController } from '~/src/server/plugins/engine/pageControllers/FileUploadPageController.js'
+import { type FormSubmissionErrors } from '~/src/server/plugins/engine/types.js'
 
 describe('FileUploadPageController', () => {
   const component1: ComponentDef = {
@@ -100,14 +101,18 @@ describe('FileUploadPageController', () => {
       const result = controller.validateForm({})
 
       expect(result.errors).toEqual(
-        expect.objectContaining({
+        expect.objectContaining<FormSubmissionErrors>({
           titleText: 'There is a problem',
           errorList: [
             {
-              path: 'fileUpload',
+              path: ['fileUpload'],
               href: '#fileUpload',
               name: 'fileUpload',
-              text: 'Select methodology statement'
+              text: 'Select methodology statement',
+              context: {
+                key: 'fileUpload',
+                label: 'methodology statement'
+              }
             }
           ]
         })

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -165,19 +165,18 @@ export class FileUploadPageController extends PageController {
           // field on the page so defer to the standard getError
           errorList.push(this.getError(err))
         } else {
-          const type = err.type
-          const path = err.path.join('.')
+          const { context, path, type } = err
+
           const formatter = (name: string | number, index: number) =>
             index > 0 ? `__${name}` : name
-          const name = err.path.map(formatter).join('')
-          const lastPath = err.path[err.path.length - 1]
 
-          if (type === 'object.unknown' && lastPath === 'errorMessage') {
-            const value = err.context?.value
+          if (type === 'object.unknown' && path.at(-1) === 'errorMessage') {
+            const name = path.map(formatter).join('')
+            const value = context?.value
 
             if (value) {
               const text = typeof value === 'string' ? value : 'Unknown error'
-              const href = `#${err.path.slice(0, 2).map(formatter).join('')}`
+              const href = `#${path.slice(0, 2).map(formatter).join('')}`
 
               errorList.push({ path, href, name, text })
             }

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
@@ -76,14 +76,21 @@ describe('PageControllerBase', () => {
           [
             {
               message:
-                '"Date of marriage" must be on or before 2021-12-25T00:00:00.000Z',
+                'Date of marriage must be on or before 2021-12-25T00:00:00.000Z',
               path: ['dateField'],
-              type: 'date.max'
+              type: 'date.max',
+              context: {
+                key: 'dateField',
+                title: 'date of marriage'
+              }
             },
             {
               message: 'something invalid',
               path: ['yesNoField'],
-              type: 'string.pattern.base'
+              type: 'string.pattern.base',
+              context: {
+                key: 'yesNoField'
+              }
             }
           ],
           undefined
@@ -93,16 +100,23 @@ describe('PageControllerBase', () => {
       expect(errors?.errorList).toEqual(
         expect.arrayContaining([
           {
-            path: 'dateField',
+            path: ['dateField'],
             href: '#dateField',
             name: 'dateField',
-            text: `"Date of marriage" must be on or before 25 December 2021`
+            text: 'Date of marriage must be on or before 25 December 2021',
+            context: {
+              key: 'dateField',
+              title: 'date of marriage'
+            }
           },
           {
-            path: 'yesNoField',
+            path: ['yesNoField'],
             href: '#yesNoField',
             name: 'yesNoField',
-            text: 'something invalid'
+            text: 'something invalid',
+            context: {
+              key: 'yesNoField'
+            }
           }
         ])
       )

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -17,8 +17,12 @@ import {
 } from '@hapi/hapi'
 import { merge } from '@hapi/hoek'
 import { format, parseISO } from 'date-fns'
-import type joi from 'joi'
-import { type ObjectSchema, type ValidationResult } from 'joi'
+import {
+  type ObjectSchema,
+  type Schema,
+  type ValidationErrorItem,
+  type ValidationResult
+} from 'joi'
 
 import { config } from '~/src/config/index.js'
 import { CheckboxesField } from '~/src/server/plugins/engine/components/CheckboxesField.js'
@@ -256,8 +260,8 @@ export class PageControllerBase {
   }
 
   /**
-   * Parses the errors from joi.validate so they can be rendered by govuk-frontend templates
-   * @param validationResult - provided by joi.validate
+   * Parses the errors from {@link Schema.validate} so they can be rendered by govuk-frontend templates
+   * @param validationResult - provided by {@link Schema.validate}
    */
   getErrors(
     validationResult?: Pick<ValidationResult, 'error'>
@@ -274,7 +278,7 @@ export class PageControllerBase {
     return undefined
   }
 
-  protected getError(err: joi.ValidationErrorItem) {
+  protected getError(err: ValidationErrorItem) {
     const isoRegex =
       /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
 
@@ -293,7 +297,7 @@ export class PageControllerBase {
   }
 
   /**
-   * Runs {@link joi.validate}
+   * Runs {@link Schema.validate}
    * @param value - user's answers
    * @param schema - which schema to validate against
    */

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -43,6 +43,7 @@ import {
   type FormPayload,
   type FormState,
   type FormStateValue,
+  type FormSubmissionError,
   type FormSubmissionErrors,
   type FormSubmissionState,
   type FormValidationResult,
@@ -278,21 +279,20 @@ export class PageControllerBase {
     return undefined
   }
 
-  protected getError(err: ValidationErrorItem) {
+  protected getError(err: ValidationErrorItem): FormSubmissionError {
+    const name = err.context?.key ?? ''
+
     const isoRegex =
       /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
 
-    const name = err.path
-      .map((name, index) => (index > 0 ? `__${name}` : name))
-      .join('')
-
     return {
-      path: err.path.join('.'),
+      path: err.path,
       href: `#${name}`,
       name,
       text: err.message.replace(isoRegex, (text) => {
         return format(parseISO(text), 'd MMMM yyyy')
-      })
+      }),
+      context: err.context
     }
   }
 

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -17,7 +17,7 @@ import {
 } from '@hapi/hapi'
 import { merge } from '@hapi/hoek'
 import { format, parseISO } from 'date-fns'
-import {
+import joi, {
   type ObjectSchema,
   type Schema,
   type ValidationErrorItem,
@@ -100,10 +100,13 @@ export class PageControllerBase {
     // Components collection
     const components = hasComponents(pageDef) ? pageDef.components : []
 
-    this.components = new ComponentCollection(components, model)
+    this.components = new ComponentCollection(components, { model })
     this.hasFormComponents = !!this.components.formItems.length
 
-    this[FORM_SCHEMA] = this.components.formSchema
+    this[FORM_SCHEMA] = this.components.formSchema.keys({
+      crumb: joi.string().optional().allow('')
+    })
+
     this[STATE_SCHEMA] = this.components.stateSchema
   }
 

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
@@ -8,6 +8,7 @@ import {
 
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { RepeatPageController } from '~/src/server/plugins/engine/pageControllers/RepeatPageController.js'
+import { type FormSubmissionErrors } from '~/src/server/plugins/engine/types.js'
 
 describe('RepeatPageController', () => {
   const component1: ComponentDef = {
@@ -78,26 +79,38 @@ describe('RepeatPageController', () => {
       const result = controller.validateForm({})
 
       expect(result.errors).toEqual(
-        expect.objectContaining({
+        expect.objectContaining<FormSubmissionErrors>({
           titleText: 'There is a problem',
           errorList: [
             {
-              path: 'toppings',
+              path: ['toppings'],
               href: '#toppings',
               name: 'toppings',
-              text: 'Select toppings'
+              text: 'Select toppings',
+              context: {
+                key: 'toppings',
+                label: 'toppings'
+              }
             },
             {
-              path: 'quantity',
+              path: ['quantity'],
               href: '#quantity',
               name: 'quantity',
-              text: 'Enter quantity'
+              text: 'Enter quantity',
+              context: {
+                key: 'quantity',
+                label: 'quantity'
+              }
             },
             {
+              path: ['itemId'],
               href: '#itemId',
               name: 'itemId',
-              path: 'itemId',
-              text: 'Select itemId'
+              text: 'Select itemId',
+              context: {
+                key: 'itemId',
+                label: 'itemId'
+              }
             }
           ]
         })

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -230,17 +230,18 @@ export class RepeatPageController extends PageController {
 
         // Show error if repeat max limit reached
         if (list.length >= schema.max) {
-          const errors = {
+          const errors: FormSubmissionErrors = {
             titleText: this.errorSummaryTitle,
             errorList: [
               {
-                path: '',
+                path: [],
                 href: '',
                 name: '',
                 text: `You can only add up to ${schema.max} ${options.title}${schema.max === 1 ? '' : 's'}`
               }
             ]
           }
+
           const viewModel = this.getListSummaryViewModel(request, list, errors)
 
           return h.view(this.listSummaryViewName, viewModel)

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -113,8 +113,7 @@ export class SummaryPageController extends PageController {
        */
       if (viewModel.errors) {
         const errorToFix = viewModel.errors[0]
-        const { path } = errorToFix
-        const parts = path.split('.')
+        const { path: parts } = errorToFix
         const section = parts[0]
         const property = parts.length > 1 ? parts[parts.length - 1] : null
         const pageWithError = model.pages.find((page) => {

--- a/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -1,4 +1,5 @@
 import { type LanguageMessages, type ValidationOptions } from 'joi'
+
 /**
  * see @link https://joi.dev/api/?v=17.4.2#template-syntax for template syntax
  */
@@ -15,10 +16,12 @@ export const messageTemplate = {
   numberMin: '{{#label}} must be {{#limit}} or higher',
   numberMax: '{{#label}} must be {{#limit}} or lower',
   maxWords: '{{#label}} must be {{#limit}} words or fewer',
-  dateRequired: '{{#label}} must be a real date',
-  dateFormat: '{{#label}} must be a real date',
-  dateMin: '{{#label}} must be the same as or after {{#limit}}',
-  dateMax: '{{#label}} must be the same as or before {{#limit}}'
+
+  // Nested fields use component title
+  dateRequired: '{{#title}} must be a real date',
+  dateFormat: '{{#title}} must be a real date',
+  dateMin: '{{#title}} must be the same as or after {{#limit}}',
+  dateMax: '{{#title}} must be the same as or before {{#limit}}'
 }
 
 export const messages: LanguageMessages = {

--- a/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -18,7 +18,8 @@ export const messageTemplate = {
   maxWords: '{{#label}} must be {{#limit}} words or fewer',
 
   // Nested fields use component title
-  dateRequired: '{{#title}} must be a real date',
+  objectRequired: 'Enter {{#title}}',
+  objectMissing: '{{#title}} must include a {{#missingWithLabels}}',
   dateFormat: '{{#title}} must be a real date',
   dateMin: '{{#title}} must be the same as or after {{#limit}}',
   dateMax: '{{#title}} must be the same as or before {{#limit}}'
@@ -40,11 +41,14 @@ export const messages: LanguageMessages = {
   'number.min': messageTemplate.numberMin,
   'number.max': messageTemplate.numberMax,
 
+  'object.required': messageTemplate.objectRequired,
+  'object.and': messageTemplate.objectMissing,
+
   'any.only': messageTemplate.selectRequired,
   'any.required': messageTemplate.selectRequired,
   'any.empty': messageTemplate.required,
 
-  'date.base': messageTemplate.dateRequired,
+  'date.base': messageTemplate.dateFormat,
   'date.format': messageTemplate.dateFormat,
   'date.min': messageTemplate.dateMin,
   'date.max': messageTemplate.dateMax
@@ -56,6 +60,7 @@ export const validationOptions: ValidationOptions = {
   dateFormat: 'iso',
   errors: {
     wrap: {
+      array: false,
       label: false
     }
   }

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -1,5 +1,6 @@
 import { type Item } from '@defra/forms-model'
 import { type ResponseObject } from '@hapi/hapi'
+import { type ValidationErrorItem } from 'joi'
 
 import { type ComponentViewModel } from '~/src/server/plugins/engine/components/types.js'
 import {
@@ -61,11 +62,11 @@ export type FormSubmissionState = {
   upload?: Record<string, TempFileState>
 } & FormState
 
-export interface FormSubmissionError {
-  path: string // e.g: "firstName"
-  href: string // e.g: "#firstName"
-  name: string // e.g: "firstName"
-  text: string // e.g: '"First name" is not allowed to be empty'
+export interface FormSubmissionError
+  extends Pick<ValidationErrorItem, 'context' | 'path'> {
+  href: string // e.g: '#dateField__day'
+  name: string // e.g: 'dateField__day'
+  text: string // e.g: 'Date field must be a real date'
 }
 
 export interface FormSubmissionErrors {

--- a/src/typings/joi/index.d.ts
+++ b/src/typings/joi/index.d.ts
@@ -1,0 +1,22 @@
+import { type FormPayload } from '~/src/server/plugins/engine/types.ts'
+
+declare module 'joi' {
+  interface Context {
+    present?: string[]
+    presentWithLabels?: string[]
+    missing?: string[]
+    missingWithLabels?: string[]
+  }
+
+  /**
+   * Add context types for `object.and` error reports
+   * {@link https://joi.dev/api/?v=17.13.3#objectand}
+   */
+  interface ErrorReportCollection extends ErrorReport {
+    local: Context & {
+      value: FormPayload
+      label?: string
+      title?: string
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes an existing bug as part of [story #458970](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/458970)

E.g. If you set a Month/Year or UK Address field to “optional” you can store partial values in the state:

* Month but no Year
* Year but no Month

This is because the `ComponentCollection` children are all valid—they’re checked one-by-one not as a whole

This fix is necessary as session changes in PR https://github.com/DEFRA/forms-runner/pull/470 start affecting the Date field too

## Joi object peers

This is fixed by adding `peers` to a Joi schema

>[`object.and(...peers, [options])`](https://joi.dev/api/?v=17.13.3#objectandpeers-options) — Defines an all-or-nothing relationship between keys where if one of the peers is present, all of them are required as well

```js
formSchema = formSchema.and(
  `${name}__day`,
  `${name}__month`,
  `${name}__year`,
  {
    isPresent: isFormValue
  }
)
```