### PR TITLE
Share props between single and collection fields

### DIFF
--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -65,7 +65,7 @@ describe.each([
     })
 
     collection = new ComponentCollection([def], { model })
-    component = collection.questions[0]
+    component = collection.fields[0]
   })
 
   describe('Defaults', () => {

--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -55,17 +55,17 @@ describe.each([
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
   let collection: ComponentCollection
   let component: FormComponentFieldClass
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
 
-    collection = new ComponentCollection([def], { model: formModel })
-    component = collection.formItems[0]
+    collection = new ComponentCollection([def], { model })
+    component = collection.questions[0]
   })
 
   describe('Defaults', () => {
@@ -87,7 +87,7 @@ describe.each([
         const { keys } = formSchema.describe()
 
         expect(component.keys).toEqual(['myComponent'])
-        expect(component.children).toBeUndefined()
+        expect(component.collection).toBeUndefined()
 
         for (const key of component.keys) {
           expect(keys).toHaveProperty(key)
@@ -111,7 +111,7 @@ describe.each([
       it('is optional when configured', () => {
         const collectionOptional = new ComponentCollection(
           [{ ...def, options: { required: false } }],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -276,11 +276,11 @@ describe.each([
           conditions: []
         } satisfies FormDefinition
 
-        const formModel = new FormModel(definitionNoList, {
+        const model = new FormModel(definitionNoList, {
           basePath: 'test'
         })
 
-        const { items } = new AutocompleteField(def, formModel)
+        const { items } = new AutocompleteField(def, { model })
         expect(items).toEqual([])
       })
     })

--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -6,7 +6,7 @@ import {
 
 import { AutocompleteField } from '~/src/server/plugins/engine/components/AutocompleteField.js'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   listNumber,
@@ -57,7 +57,7 @@ describe.each([
 
   let model: FormModel
   let collection: ComponentCollection
-  let component: FormComponentFieldClass
+  let field: Field
 
   beforeEach(() => {
     model = new FormModel(definition, {
@@ -65,7 +65,7 @@ describe.each([
     })
 
     collection = new ComponentCollection([def], { model })
-    component = collection.fields[0]
+    field = collection.fields[0]
   })
 
   describe('Defaults', () => {
@@ -86,10 +86,10 @@ describe.each([
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual(['myComponent'])
-        expect(component.collection).toBeUndefined()
+        expect(field.keys).toEqual(['myComponent'])
+        expect(field.collection).toBeUndefined()
 
-        for (const key of component.keys) {
+        for (const key of field.keys) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -176,8 +176,8 @@ describe.each([
         const state1 = getFormState(item.state)
         const state2 = getFormState(null)
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe(item.text)
         expect(text2).toBe('')
@@ -187,8 +187,8 @@ describe.each([
         const state1 = getFormState(item.state)
         const state2 = getFormState(null)
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData(item.value))
         expect(payload2).toEqual(getFormData())
@@ -198,8 +198,8 @@ describe.each([
         const state1 = getFormState(item.state)
         const state2 = getFormState(null)
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toBe(item.value)
         expect(value2).toBeUndefined()
@@ -209,8 +209,8 @@ describe.each([
         const payload1 = getFormData(item.value)
         const payload2 = getFormData()
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState(item.state))
         expect(value2).toEqual(getFormState(null))
@@ -221,7 +221,7 @@ describe.each([
       it('sets Nunjucks component defaults', () => {
         const item = options.examples[0]
 
-        const viewModel = component.getViewModel(getFormData(item.value))
+        const viewModel = field.getViewModel(getFormData(item.value))
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -236,7 +236,7 @@ describe.each([
       it.each([...options.examples])(
         'sets Nunjucks component autocomplete suggestions',
         (item) => {
-          const viewModel = component.getViewModel(getFormData(item.value))
+          const viewModel = field.getViewModel(getFormData(item.value))
 
           expect(viewModel.items?.[0]).toMatchObject({
             value: '' // First item is always empty
@@ -257,13 +257,13 @@ describe.each([
 
     describe('Autocomplete suggestions', () => {
       it('returns autocomplete suggestions', () => {
-        expect(component).toMatchObject({
+        expect(field).toMatchObject({
           items: options.list.items
         })
       })
 
       it('returns autocomplete suggestions matching type', () => {
-        expect(component).toMatchObject({
+        expect(field).toMatchObject({
           values: expect.arrayContaining([])
         })
       })

--- a/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.ts
@@ -1,7 +1,6 @@
 import { type AutocompleteFieldComponent } from '@defra/forms-model'
 
 import { SelectField } from '~/src/server/plugins/engine/components/SelectField.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 import {
   type FormPayload,
@@ -11,8 +10,11 @@ import {
 export class AutocompleteField extends SelectField {
   declare options: AutocompleteFieldComponent['options']
 
-  constructor(def: AutocompleteFieldComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: AutocompleteFieldComponent,
+    props: ConstructorParameters<typeof SelectField>[1]
+  ) {
+    super(def, props)
 
     const { options } = def
     let { formSchema } = this

--- a/src/server/plugins/engine/components/CheckboxesField.test.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.test.ts
@@ -6,7 +6,7 @@ import {
 
 import { CheckboxesField } from '~/src/server/plugins/engine/components/CheckboxesField.js'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   listNumber,
@@ -59,7 +59,7 @@ describe.each([
 
   let model: FormModel
   let collection: ComponentCollection
-  let component: FormComponentFieldClass
+  let field: Field
 
   beforeEach(() => {
     model = new FormModel(definition, {
@@ -67,7 +67,7 @@ describe.each([
     })
 
     collection = new ComponentCollection([def], { model })
-    component = collection.fields[0]
+    field = collection.fields[0]
   })
 
   describe('Defaults', () => {
@@ -88,10 +88,10 @@ describe.each([
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual(['myComponent'])
-        expect(component.collection).toBeUndefined()
+        expect(field.keys).toEqual(['myComponent'])
+        expect(field.collection).toBeUndefined()
 
-        for (const key of component.keys) {
+        for (const key of field.keys) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -243,8 +243,8 @@ describe.each([
           const state1 = getFormState([item.state])
           const state2 = getFormState(null)
 
-          const text1 = component.getDisplayStringFromState(state1)
-          const text2 = component.getDisplayStringFromState(state2)
+          const text1 = field.getDisplayStringFromState(state1)
+          const text2 = field.getDisplayStringFromState(state2)
 
           expect(text1).toBe(item.text)
           expect(text2).toBe('')
@@ -256,7 +256,7 @@ describe.each([
         const item2 = options.examples[2]
 
         const state = getFormState([item1.state, item2.state])
-        const text = component.getDisplayStringFromState(state)
+        const text = field.getDisplayStringFromState(state)
 
         expect(text).toBe(`${item1.text}, ${item2.text}`)
       })
@@ -265,8 +265,8 @@ describe.each([
         const state1 = getFormState([item.state])
         const state2 = getFormState(null)
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData([item.value]))
         expect(payload2).toEqual(getFormData())
@@ -276,8 +276,8 @@ describe.each([
         const state1 = getFormState([item.state])
         const state2 = getFormState(null)
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toEqual([item.value])
         expect(value2).toBeUndefined()
@@ -287,8 +287,8 @@ describe.each([
         const payload1 = getFormData([item.value])
         const payload2 = getFormData()
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState([item.state]))
         expect(value2).toEqual(getFormState(null))
@@ -299,7 +299,7 @@ describe.each([
       it('sets Nunjucks component defaults', () => {
         const item = options.examples[0]
 
-        const viewModel = component.getViewModel(getFormData([item.value]))
+        const viewModel = field.getViewModel(getFormData([item.value]))
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -314,7 +314,7 @@ describe.each([
       it.each([...options.examples])(
         'sets Nunjucks component checkbox items',
         (item) => {
-          const viewModel = component.getViewModel(getFormData([item.value]))
+          const viewModel = field.getViewModel(getFormData([item.value]))
 
           expect(viewModel.items?.[0]).not.toMatchObject({
             value: '' // First item is never empty
@@ -335,11 +335,11 @@ describe.each([
 
     describe('Checkbox items', () => {
       it('returns checkbox items', () => {
-        expect(component).toHaveProperty('items', options.list.items)
+        expect(field).toHaveProperty('items', options.list.items)
       })
 
       it('returns checkbox items matching type', () => {
-        expect(component).toHaveProperty('values', expect.arrayContaining([]))
+        expect(field).toHaveProperty('values', expect.arrayContaining([]))
       })
 
       it('returns empty items when missing', () => {

--- a/src/server/plugins/engine/components/CheckboxesField.test.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.test.ts
@@ -67,7 +67,7 @@ describe.each([
     })
 
     collection = new ComponentCollection([def], { model })
-    component = collection.questions[0]
+    component = collection.fields[0]
   })
 
   describe('Defaults', () => {

--- a/src/server/plugins/engine/components/CheckboxesField.test.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.test.ts
@@ -57,17 +57,17 @@ describe.each([
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
   let collection: ComponentCollection
   let component: FormComponentFieldClass
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
 
-    collection = new ComponentCollection([def], { model: formModel })
-    component = collection.formItems[0]
+    collection = new ComponentCollection([def], { model })
+    component = collection.questions[0]
   })
 
   describe('Defaults', () => {
@@ -89,7 +89,7 @@ describe.each([
         const { keys } = formSchema.describe()
 
         expect(component.keys).toEqual(['myComponent'])
-        expect(component.children).toBeUndefined()
+        expect(component.collection).toBeUndefined()
 
         for (const key of component.keys) {
           expect(keys).toHaveProperty(key)
@@ -113,7 +113,7 @@ describe.each([
       it('is optional when configured', () => {
         const collectionOptional = new ComponentCollection(
           [{ ...def, options: { required: false } }],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -350,11 +350,11 @@ describe.each([
           conditions: []
         } satisfies FormDefinition
 
-        const formModel = new FormModel(definitionNoList, {
+        const model = new FormModel(definitionNoList, {
           basePath: 'test'
         })
 
-        const { items } = new CheckboxesField(def, formModel)
+        const { items } = new CheckboxesField(def, { model })
         expect(items).toEqual([])
       })
     })

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -3,7 +3,6 @@ import joi, { type ArraySchema } from 'joi'
 
 import { isFormValue } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormState,
   type FormStateValue
@@ -14,8 +13,11 @@ export class CheckboxesField extends SelectionControlField {
   declare formSchema: ArraySchema<string> | ArraySchema<number>
   declare stateSchema: ArraySchema<string> | ArraySchema<number>
 
-  constructor(def: CheckboxesFieldComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: CheckboxesFieldComponent,
+    props: ConstructorParameters<typeof SelectionControlField>[1]
+  ) {
+    super(def, props)
 
     const { listType: type } = this
     const { options, title } = def

--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -9,7 +9,7 @@ import joi, {
 } from 'joi'
 
 import { type ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-import { type ComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Component } from '~/src/server/plugins/engine/components/helpers.js'
 import {
   DataType,
   type ViewModel
@@ -22,7 +22,7 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class ComponentBase {
-  parent: ComponentFieldClass | undefined
+  parent: Component | undefined
   collection: ComponentCollection | undefined
 
   type: ComponentDef['type']
@@ -46,7 +46,7 @@ export class ComponentBase {
   constructor(
     def: ComponentDef,
     props: {
-      parent?: ComponentFieldClass
+      parent?: Component
       model: FormModel
     }
   ) {

--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -8,6 +8,8 @@ import joi, {
   type StringSchema
 } from 'joi'
 
+import { type ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
+import { type ComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
 import {
   DataType,
   type ViewModel
@@ -20,6 +22,9 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 
 export class ComponentBase {
+  parent: ComponentFieldClass | undefined
+  collection: ComponentCollection | undefined
+
   type: ComponentDef['type']
   name: ComponentDef['name']
   title: ComponentDef['title']
@@ -38,7 +43,13 @@ export class ComponentBase {
   formSchema: ComponentSchema = joi.string()
   stateSchema: ComponentSchema = joi.string()
 
-  constructor(def: ComponentDef, model: FormModel) {
+  constructor(
+    def: ComponentDef,
+    props: {
+      parent?: ComponentFieldClass
+      model: FormModel
+    }
+  ) {
     this.type = def.type
     this.name = def.name
     this.title = def.title
@@ -51,7 +62,8 @@ export class ComponentBase {
       this.options = def.options
     }
 
-    this.model = model
+    this.parent = props.parent
+    this.model = props.model
   }
 
   /**

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -33,7 +33,7 @@ export class ComponentCollection {
   parent?: ComponentFieldClass
 
   components: ComponentFieldClass[]
-  questions: FormComponentFieldClass[]
+  fields: FormComponentFieldClass[]
 
   formSchema: ObjectSchema<FormPayload>
   stateSchema: ObjectSchema<FormSubmissionState>
@@ -65,7 +65,7 @@ export class ComponentCollection {
   ) {
     const components = defs.map((def) => createComponentField(def, props))
 
-    const questions = components.filter(
+    const fields = components.filter(
       (component): component is FormComponentFieldClass =>
         component.isFormComponent
     )
@@ -74,7 +74,7 @@ export class ComponentCollection {
     let stateSchema = joi.object<FormSubmissionState>().required()
 
     // Add each field or concat collection
-    for (const field of questions) {
+    for (const field of fields) {
       const { collection, name } = field
 
       formSchema = collection
@@ -106,12 +106,12 @@ export class ComponentCollection {
         }
 
         // Find the parent field
-        const parent = questions.find(
+        const parent = fields.find(
           (item) => item.name === key?.split('__').shift()
         )
 
         // Find the child field
-        const child = (parent?.collection?.questions ?? questions).find(
+        const child = (parent?.collection?.fields ?? fields).find(
           (item) => item.name === key
         )
 
@@ -147,19 +147,19 @@ export class ComponentCollection {
     this.parent = props.parent
 
     this.components = components
-    this.questions = questions
+    this.fields = fields
     this.formSchema = formSchema
     this.stateSchema = stateSchema
   }
 
   get keys() {
-    return this.questions.map(({ name }) => name)
+    return this.fields.map(({ name }) => name)
   }
 
   getFormDataFromState(state: FormSubmissionState) {
     const payload: FormPayload = {}
 
-    this.questions.forEach((component) => {
+    this.fields.forEach((component) => {
       Object.assign(payload, component.getFormDataFromState(state))
     })
 
@@ -187,7 +187,7 @@ export class ComponentCollection {
   getStateFromValidForm(payload: FormPayload) {
     const state: FormState = {}
 
-    this.questions.forEach((component) => {
+    this.fields.forEach((component) => {
       Object.assign(state, component.getStateFromValidForm(payload))
     })
 
@@ -195,12 +195,12 @@ export class ComponentCollection {
   }
 
   getErrors(errors?: FormSubmissionError[]): FormSubmissionError[] | undefined {
-    const { questions } = this
+    const { fields } = this
 
     const list: FormSubmissionError[] = []
 
     // Add only one error per field
-    for (const field of questions) {
+    for (const field of fields) {
       const error = field.getError(errors)
 
       if (error) {

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -11,9 +11,9 @@ import {
   isFormValue
 } from '~/src/server/plugins/engine/components/FormComponent.js'
 import {
-  createComponentField,
-  type ComponentFieldClass,
-  type FormComponentFieldClass
+  createComponent,
+  type Component,
+  type Field
 } from '~/src/server/plugins/engine/components/helpers.js'
 import { type ComponentViewModel } from '~/src/server/plugins/engine/components/types.js'
 import { getErrors } from '~/src/server/plugins/engine/helpers.js'
@@ -30,10 +30,10 @@ import {
 
 export class ComponentCollection {
   page?: PageControllerClass
-  parent?: ComponentFieldClass
+  parent?: Component
 
-  components: ComponentFieldClass[]
-  fields: FormComponentFieldClass[]
+  components: Component[]
+  fields: Field[]
 
   formSchema: ObjectSchema<FormPayload>
   stateSchema: ObjectSchema<FormSubmissionState>
@@ -42,7 +42,7 @@ export class ComponentCollection {
     defs: ComponentDef[],
     props: {
       page?: PageControllerClass
-      parent?: ComponentFieldClass
+      parent?: Component
       model: FormModel
     },
     schema?: {
@@ -63,11 +63,10 @@ export class ComponentCollection {
       messages?: LanguageMessages
     }
   ) {
-    const components = defs.map((def) => createComponentField(def, props))
+    const components = defs.map((def) => createComponent(def, props))
 
     const fields = components.filter(
-      (component): component is FormComponentFieldClass =>
-        component.isFormComponent
+      (component): component is Field => component.isFormComponent
     )
 
     let formSchema = joi.object<FormPayload>().required()

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -6,7 +6,7 @@ import {
 import { addDays, format, startOfDay } from 'date-fns'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { type DateInputItem } from '~/src/server/plugins/engine/components/types.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
@@ -33,7 +33,7 @@ describe('DatePartsField', () => {
   describe('Defaults', () => {
     let def: DatePartsFieldComponent
     let collection: ComponentCollection
-    let component: FormComponentFieldClass
+    let field: Field
 
     beforeEach(() => {
       def = {
@@ -44,7 +44,7 @@ describe('DatePartsField', () => {
       } satisfies DatePartsFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.fields[0]
+      field = collection.fields[0]
     })
 
     describe('Schema', () => {
@@ -78,16 +78,16 @@ describe('DatePartsField', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual([
+        expect(field.keys).toEqual([
           'myComponent',
           'myComponent__day',
           'myComponent__month',
           'myComponent__year'
         ])
 
-        expect(component.collection?.keys).not.toHaveProperty('myComponent')
+        expect(field.collection?.keys).not.toHaveProperty('myComponent')
 
-        for (const key of component.collection?.keys ?? []) {
+        for (const key of field.collection?.keys ?? []) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -260,8 +260,8 @@ describe('DatePartsField', () => {
         const state1 = getFormState(date)
         const state2 = getFormState({})
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe('31 December 2024')
         expect(text2).toBe('')
@@ -271,8 +271,8 @@ describe('DatePartsField', () => {
         const state1 = getFormState(startOfDay(date))
         const state2 = getFormState({})
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData(date))
         expect(payload2).toEqual(getFormData({}))
@@ -282,8 +282,8 @@ describe('DatePartsField', () => {
         const state1 = getFormState(startOfDay(date))
         const state2 = getFormState({})
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toEqual({
           day: 31,
@@ -298,8 +298,8 @@ describe('DatePartsField', () => {
         const payload1 = getFormData(date)
         const payload2 = getFormData({})
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState(date))
         expect(value2).toEqual(getFormState({}))
@@ -309,8 +309,8 @@ describe('DatePartsField', () => {
         const state1 = getFormState(date)
         const state2 = getFormState({})
 
-        const value1 = component.getConditionEvaluationStateValue(state1)
-        const value2 = component.getConditionEvaluationStateValue(state2)
+        const value1 = field.getConditionEvaluationStateValue(state1)
+        const value2 = field.getConditionEvaluationStateValue(state2)
 
         expect(value1).toBe('2024-12-31')
         expect(value2).toBeNull()
@@ -322,7 +322,7 @@ describe('DatePartsField', () => {
 
       it('sets Nunjucks component defaults', () => {
         const payload = getFormData(date)
-        const viewModel = component.getViewModel(payload)
+        const viewModel = field.getViewModel(payload)
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -366,7 +366,7 @@ describe('DatePartsField', () => {
           year: 'YYYY'
         })
 
-        const viewModel = component.getViewModel(payload)
+        const viewModel = field.getViewModel(payload)
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -389,7 +389,7 @@ describe('DatePartsField', () => {
 
       it('sets Nunjucks component fieldset', () => {
         const payload = getFormData(date)
-        const viewModel = component.getViewModel(payload)
+        const viewModel = field.getViewModel(payload)
 
         expect(viewModel.fieldset).toEqual({
           legend: {

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -44,7 +44,7 @@ describe('DatePartsField', () => {
       } satisfies DatePartsFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.questions[0]
+      component = collection.fields[0]
     })
 
     describe('Schema', () => {

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -22,10 +22,10 @@ describe('DatePartsField', () => {
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
   })
@@ -43,8 +43,8 @@ describe('DatePartsField', () => {
         options: {}
       } satisfies DatePartsFieldComponent
 
-      collection = new ComponentCollection([def], { model: formModel })
-      component = collection.formItems[0]
+      collection = new ComponentCollection([def], { model })
+      component = collection.questions[0]
     })
 
     describe('Schema', () => {
@@ -85,9 +85,9 @@ describe('DatePartsField', () => {
           'myComponent__year'
         ])
 
-        expect(component.children?.keys).not.toHaveProperty('myComponent')
+        expect(component.collection?.keys).not.toHaveProperty('myComponent')
 
-        for (const key of component.children?.keys ?? []) {
+        for (const key of component.collection?.keys ?? []) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -128,7 +128,7 @@ describe('DatePartsField', () => {
               options: { required: false }
             }
           ],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -738,7 +738,7 @@ describe('DatePartsField', () => {
       let collection: ComponentCollection
 
       beforeEach(() => {
-        collection = new ComponentCollection([def], { model: formModel })
+        collection = new ComponentCollection([def], { model })
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/Details.ts
+++ b/src/server/plugins/engine/components/Details.ts
@@ -1,7 +1,6 @@
 import { type DetailsComponent } from '@defra/forms-model'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type FormPayload,
   type FormSubmissionError
@@ -11,8 +10,11 @@ export class Details extends ComponentBase {
   declare options: DetailsComponent['options']
   content: DetailsComponent['content']
 
-  constructor(def: DetailsComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: DetailsComponent,
+    props: ConstructorParameters<typeof ComponentBase>[1]
+  ) {
+    super(def, props)
 
     const { content, options } = def
 

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -39,7 +39,7 @@ describe('EmailAddressField', () => {
       } satisfies EmailAddressFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.questions[0]
+      component = collection.fields[0]
     })
 
     describe('Schema', () => {

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@defra/forms-model'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { getFormData, getFormState } from '~/test/helpers/component-helpers.js'
 
@@ -28,7 +28,7 @@ describe('EmailAddressField', () => {
   describe('Defaults', () => {
     let def: EmailAddressFieldComponent
     let collection: ComponentCollection
-    let component: FormComponentFieldClass
+    let field: Field
 
     beforeEach(() => {
       def = {
@@ -39,7 +39,7 @@ describe('EmailAddressField', () => {
       } satisfies EmailAddressFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.fields[0]
+      field = collection.fields[0]
     })
 
     describe('Schema', () => {
@@ -61,10 +61,10 @@ describe('EmailAddressField', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual(['myComponent'])
-        expect(component.collection).toBeUndefined()
+        expect(field.keys).toEqual(['myComponent'])
+        expect(field.collection).toBeUndefined()
 
-        for (const key of component.keys) {
+        for (const key of field.keys) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -139,8 +139,8 @@ describe('EmailAddressField', () => {
         const state1 = getFormState('defra.helpline@defra.gov.uk')
         const state2 = getFormState(null)
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe('defra.helpline@defra.gov.uk')
         expect(text2).toBe('')
@@ -150,8 +150,8 @@ describe('EmailAddressField', () => {
         const state1 = getFormState('defra.helpline@defra.gov.uk')
         const state2 = getFormState(null)
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData('defra.helpline@defra.gov.uk'))
         expect(payload2).toEqual(getFormData())
@@ -161,8 +161,8 @@ describe('EmailAddressField', () => {
         const state1 = getFormState('defra.helpline@defra.gov.uk')
         const state2 = getFormState(null)
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toBe('defra.helpline@defra.gov.uk')
         expect(value2).toBeUndefined()
@@ -172,8 +172,8 @@ describe('EmailAddressField', () => {
         const payload1 = getFormData('defra.helpline@defra.gov.uk')
         const payload2 = getFormData()
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState('defra.helpline@defra.gov.uk'))
         expect(value2).toEqual(getFormState(null))
@@ -182,7 +182,7 @@ describe('EmailAddressField', () => {
 
     describe('View model', () => {
       it('sets Nunjucks component defaults', () => {
-        const viewModel = component.getViewModel(
+        const viewModel = field.getViewModel(
           getFormData('defra.helpline@defra.gov.uk')
         )
 

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -17,10 +17,10 @@ describe('EmailAddressField', () => {
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
   })
@@ -38,8 +38,8 @@ describe('EmailAddressField', () => {
         options: {}
       } satisfies EmailAddressFieldComponent
 
-      collection = new ComponentCollection([def], { model: formModel })
-      component = collection.formItems[0]
+      collection = new ComponentCollection([def], { model })
+      component = collection.questions[0]
     })
 
     describe('Schema', () => {
@@ -62,7 +62,7 @@ describe('EmailAddressField', () => {
         const { keys } = formSchema.describe()
 
         expect(component.keys).toEqual(['myComponent'])
-        expect(component.children).toBeUndefined()
+        expect(component.collection).toBeUndefined()
 
         for (const key of component.keys) {
           expect(keys).toHaveProperty(key)
@@ -86,7 +86,7 @@ describe('EmailAddressField', () => {
       it('is optional when configured', () => {
         const collectionOptional = new ComponentCollection(
           [{ ...def, options: { required: false } }],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -373,7 +373,7 @@ describe('EmailAddressField', () => {
       let collection: ComponentCollection
 
       beforeEach(() => {
-        collection = new ComponentCollection([def], { model: formModel })
+        collection = new ComponentCollection([def], { model })
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -2,7 +2,6 @@ import { type EmailAddressFieldComponent } from '@defra/forms-model'
 import joi from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
   type FormSubmissionError
@@ -11,8 +10,11 @@ import {
 export class EmailAddressField extends FormComponent {
   declare options: EmailAddressFieldComponent['options']
 
-  constructor(def: EmailAddressFieldComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: EmailAddressFieldComponent,
+    props: ConstructorParameters<typeof FormComponent>[1]
+  ) {
+    super(def, props)
 
     const { options, title } = def
 

--- a/src/server/plugins/engine/components/FileUploadField.test.ts
+++ b/src/server/plugins/engine/components/FileUploadField.test.ts
@@ -6,7 +6,7 @@ import {
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { tempItemSchema } from '~/src/server/plugins/engine/components/FileUploadField.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { validationOptions as opts } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 import {
@@ -151,7 +151,7 @@ describe('FileUploadField', () => {
   describe('Defaults', () => {
     let def: FileUploadFieldComponent
     let collection: ComponentCollection
-    let component: FormComponentFieldClass
+    let field: Field
 
     beforeEach(() => {
       def = {
@@ -163,7 +163,7 @@ describe('FileUploadField', () => {
       } satisfies FileUploadFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.fields[0]
+      field = collection.fields[0]
     })
 
     describe('Schema', () => {
@@ -185,10 +185,10 @@ describe('FileUploadField', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual(['myComponent'])
-        expect(component.collection).toBeUndefined()
+        expect(field.keys).toEqual(['myComponent'])
+        expect(field.collection).toBeUndefined()
 
-        for (const key of component.keys) {
+        for (const key of field.keys) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -275,8 +275,8 @@ describe('FileUploadField', () => {
         const state1 = getFormState(validState)
         const state2 = getFormState(null)
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe('You uploaded 3 files')
         expect(text2).toBe('')
@@ -286,8 +286,8 @@ describe('FileUploadField', () => {
         const state1 = getFormState(validState)
         const state2 = getFormState(null)
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData(validState))
         expect(payload2).toEqual(getFormData())
@@ -297,8 +297,8 @@ describe('FileUploadField', () => {
         const state1 = getFormState(validState)
         const state2 = getFormState(null)
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toBe(validState)
         expect(value2).toBeUndefined()
@@ -308,8 +308,8 @@ describe('FileUploadField', () => {
         const payload1 = getFormData(validState)
         const payload2 = getFormData()
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState(validState))
         expect(value2).toEqual(getFormState(null))
@@ -318,7 +318,7 @@ describe('FileUploadField', () => {
 
     describe('View model', () => {
       it('sets Nunjucks component defaults', () => {
-        const viewModel = component.getViewModel(getFormData(validState))
+        const viewModel = field.getViewModel(getFormData(validState))
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -365,7 +365,7 @@ describe('FileUploadField', () => {
       })
 
       it('sets Nunjucks component defaults with temp valid state', () => {
-        const viewModel = component.getViewModel(getFormData(validTempState))
+        const viewModel = field.getViewModel(getFormData(validTempState))
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -412,10 +412,7 @@ describe('FileUploadField', () => {
       })
 
       it('sets Nunjucks component defaults with temp valid state with errors (on POST)', () => {
-        const viewModel = component.getViewModel(
-          getFormData(validTempState),
-          []
-        )
+        const viewModel = field.getViewModel(getFormData(validTempState), [])
 
         expect(viewModel).toEqual(
           expect.objectContaining({

--- a/src/server/plugins/engine/components/FileUploadField.test.ts
+++ b/src/server/plugins/engine/components/FileUploadField.test.ts
@@ -163,7 +163,7 @@ describe('FileUploadField', () => {
       } satisfies FileUploadFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.questions[0]
+      component = collection.fields[0]
     })
 
     describe('Schema', () => {

--- a/src/server/plugins/engine/components/FileUploadField.test.ts
+++ b/src/server/plugins/engine/components/FileUploadField.test.ts
@@ -24,7 +24,7 @@ describe('FileUploadField', () => {
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
 
   const validTempState: FileState[] = [
     {
@@ -143,7 +143,7 @@ describe('FileUploadField', () => {
   ]
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
   })
@@ -162,8 +162,8 @@ describe('FileUploadField', () => {
         schema: {}
       } satisfies FileUploadFieldComponent
 
-      collection = new ComponentCollection([def], { model: formModel })
-      component = collection.formItems[0]
+      collection = new ComponentCollection([def], { model })
+      component = collection.questions[0]
     })
 
     describe('Schema', () => {
@@ -186,7 +186,7 @@ describe('FileUploadField', () => {
         const { keys } = formSchema.describe()
 
         expect(component.keys).toEqual(['myComponent'])
-        expect(component.children).toBeUndefined()
+        expect(component.collection).toBeUndefined()
 
         for (const key of component.keys) {
           expect(keys).toHaveProperty(key)
@@ -210,7 +210,7 @@ describe('FileUploadField', () => {
       it('is optional when configured', () => {
         const collectionOptional = new ComponentCollection(
           [{ ...def, options: { required: false } }],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -681,7 +681,7 @@ describe('FileUploadField', () => {
       let collection: ComponentCollection
 
       beforeEach(() => {
-        collection = new ComponentCollection([def], { model: formModel })
+        collection = new ComponentCollection([def], { model })
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -4,7 +4,6 @@ import joi, { type ArraySchema } from 'joi'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { DataType } from '~/src/server/plugins/engine/components/types.js'
 import { filesize } from '~/src/server/plugins/engine/helpers.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   FileStatus,
   UploadStatus,
@@ -94,8 +93,11 @@ export class FileUploadField extends FormComponent {
 
   dataType: DataType = DataType.File
 
-  constructor(def: FileUploadFieldComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: FileUploadFieldComponent,
+    props: ConstructorParameters<typeof FormComponent>[1]
+  ) {
+    super(def, props)
 
     const { options, schema, title } = def
 

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -1,9 +1,7 @@
 import { type FormComponentsDef } from '@defra/forms-model'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
-import { type ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type FormPayload,
   type FormState,
@@ -16,12 +14,14 @@ import {
 export class FormComponent extends ComponentBase {
   type: FormComponentsDef['type']
   hint: FormComponentsDef['hint']
-  children: ComponentCollection | undefined
 
   isFormComponent = true
 
-  constructor(def: FormComponentsDef, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: FormComponentsDef,
+    props: ConstructorParameters<typeof ComponentBase>[1]
+  ) {
+    super(def, props)
 
     const { hint, type } = def
 
@@ -30,20 +30,20 @@ export class FormComponent extends ComponentBase {
   }
 
   get keys() {
-    const { children, name } = this
+    const { collection, name } = this
 
-    if (children) {
-      return [name, ...children.keys]
+    if (collection) {
+      return [name, ...collection.keys]
     }
 
     return [name]
   }
 
   getFormDataFromState(state: FormSubmissionState): FormPayload {
-    const { children, name } = this
+    const { collection, name } = this
 
-    if (children) {
-      return children.getFormDataFromState(state)
+    if (collection) {
+      return collection.getFormDataFromState(state)
     }
 
     const value = state[name]
@@ -54,10 +54,10 @@ export class FormComponent extends ComponentBase {
   }
 
   getFormValueFromState(state: FormSubmissionState): FormValue | FormPayload {
-    const { children, name } = this
+    const { collection, name } = this
 
-    if (children) {
-      return children.getFormValueFromState(state)
+    if (collection) {
+      return collection.getFormValueFromState(state)
     }
 
     const value = state[name]
@@ -65,10 +65,10 @@ export class FormComponent extends ComponentBase {
   }
 
   getStateFromValidForm(payload: FormPayload): FormState {
-    const { children, name } = this
+    const { collection, name } = this
 
-    if (children) {
-      return children.getStateFromValidForm(payload)
+    if (collection) {
+      return collection.getStateFromValidForm(payload)
     }
 
     const value = payload[name]

--- a/src/server/plugins/engine/components/Html.ts
+++ b/src/server/plugins/engine/components/Html.ts
@@ -1,7 +1,6 @@
 import { type HtmlComponent } from '@defra/forms-model'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type FormPayload,
   type FormSubmissionError
@@ -11,8 +10,11 @@ export class Html extends ComponentBase {
   declare options: HtmlComponent['options']
   content: HtmlComponent['content']
 
-  constructor(def: HtmlComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: HtmlComponent,
+    props: ConstructorParameters<typeof ComponentBase>[1]
+  ) {
+    super(def, props)
 
     const { content, options } = def
 

--- a/src/server/plugins/engine/components/InsetText.ts
+++ b/src/server/plugins/engine/components/InsetText.ts
@@ -1,7 +1,6 @@
 import { type InsetTextComponent } from '@defra/forms-model'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type FormPayload,
   type FormSubmissionError
@@ -10,8 +9,11 @@ import {
 export class InsetText extends ComponentBase {
   content: InsetTextComponent['content']
 
-  constructor(def: InsetTextComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: InsetTextComponent,
+    props: ConstructorParameters<typeof ComponentBase>[1]
+  ) {
+    super(def, props)
 
     const { content } = def
 

--- a/src/server/plugins/engine/components/List.ts
+++ b/src/server/plugins/engine/components/List.ts
@@ -6,7 +6,6 @@ import {
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { type ListItem } from '~/src/server/plugins/engine/components/types.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
   type FormSubmissionError
@@ -21,10 +20,14 @@ export class List extends ComponentBase {
     return this.list?.items ?? []
   }
 
-  constructor(def: ListComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: ListComponent,
+    props: ConstructorParameters<typeof ComponentBase>[1]
+  ) {
+    super(def, props)
 
     const { hint, list, options } = def
+    const { model } = props
 
     this.hint = hint
     this.list = model.getList(list)

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -17,7 +17,6 @@ import {
   DataType,
   type ListItem
 } from '~/src/server/plugins/engine/components/types.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
   type FormSubmissionError,
@@ -62,11 +61,12 @@ export class ListFormComponent extends FormComponent {
     def:
       | SelectionComponentsDef // Allow for Yes/No field custom list
       | (YesNoFieldComponent & Pick<ListComponentsDef, 'list'>),
-    model: FormModel
+    props: ConstructorParameters<typeof FormComponent>[1]
   ) {
-    super(def, model)
+    super(def, props)
 
     const { options, title } = def
+    const { model } = props
 
     if ('list' in def) {
       this.list = model.getList(def.list)

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -44,7 +44,7 @@ describe('MonthYearField', () => {
       } satisfies MonthYearFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.questions[0]
+      component = collection.fields[0]
     })
 
     describe('Schema', () => {

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -6,7 +6,7 @@ import {
 import { startOfDay } from 'date-fns'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { type DateInputItem } from '~/src/server/plugins/engine/components/types.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
@@ -33,7 +33,7 @@ describe('MonthYearField', () => {
   describe('Defaults', () => {
     let def: MonthYearFieldComponent
     let collection: ComponentCollection
-    let component: FormComponentFieldClass
+    let field: Field
 
     beforeEach(() => {
       def = {
@@ -44,7 +44,7 @@ describe('MonthYearField', () => {
       } satisfies MonthYearFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.fields[0]
+      field = collection.fields[0]
     })
 
     describe('Schema', () => {
@@ -68,15 +68,15 @@ describe('MonthYearField', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual([
+        expect(field.keys).toEqual([
           'myComponent',
           'myComponent__month',
           'myComponent__year'
         ])
 
-        expect(component.collection?.keys).not.toHaveProperty('myComponent')
+        expect(field.collection?.keys).not.toHaveProperty('myComponent')
 
-        for (const key of component.collection?.keys ?? []) {
+        for (const key of field.collection?.keys ?? []) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -215,8 +215,8 @@ describe('MonthYearField', () => {
         const state1 = getFormState(date)
         const state2 = getFormState({})
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe('December 2024')
         expect(text2).toBe('')
@@ -226,8 +226,8 @@ describe('MonthYearField', () => {
         const state1 = getFormState(startOfDay(date))
         const state2 = getFormState({})
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData(date))
         expect(payload2).toEqual({})
@@ -237,8 +237,8 @@ describe('MonthYearField', () => {
         const state1 = getFormState(startOfDay(date))
         const state2 = getFormState({})
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toEqual({
           month: 12,
@@ -252,8 +252,8 @@ describe('MonthYearField', () => {
         const payload1 = getFormData(date)
         const payload2 = {}
 
-        const state1 = component.getStateFromValidForm(payload1)
-        const state2 = component.getStateFromValidForm(payload2)
+        const state1 = field.getStateFromValidForm(payload1)
+        const state2 = field.getStateFromValidForm(payload2)
 
         expect(state1).toEqual(getFormState(date))
         expect(state2).toEqual(getFormState({}))
@@ -265,7 +265,7 @@ describe('MonthYearField', () => {
 
       it('sets Nunjucks component defaults', () => {
         const payload = getFormData(date)
-        const viewModel = component.getViewModel(payload)
+        const viewModel = field.getViewModel(payload)
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -300,7 +300,7 @@ describe('MonthYearField', () => {
           year: 'YYYY'
         })
 
-        const viewModel = component.getViewModel(payload)
+        const viewModel = field.getViewModel(payload)
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -319,7 +319,7 @@ describe('MonthYearField', () => {
 
       it('sets Nunjucks component fieldset', () => {
         const payload = getFormData(date)
-        const viewModel = component.getViewModel(payload)
+        const viewModel = field.getViewModel(payload)
 
         expect(viewModel.fieldset).toEqual({
           legend: {

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -22,10 +22,10 @@ describe('MonthYearField', () => {
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
   })
@@ -43,8 +43,8 @@ describe('MonthYearField', () => {
         options: {}
       } satisfies MonthYearFieldComponent
 
-      collection = new ComponentCollection([def], { model: formModel })
-      component = collection.formItems[0]
+      collection = new ComponentCollection([def], { model })
+      component = collection.questions[0]
     })
 
     describe('Schema', () => {
@@ -74,9 +74,9 @@ describe('MonthYearField', () => {
           'myComponent__year'
         ])
 
-        expect(component.children?.keys).not.toHaveProperty('myComponent')
+        expect(component.collection?.keys).not.toHaveProperty('myComponent')
 
-        for (const key of component.children?.keys ?? []) {
+        for (const key of component.collection?.keys ?? []) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -107,7 +107,7 @@ describe('MonthYearField', () => {
               options: { required: false }
             }
           ],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -478,7 +478,7 @@ describe('MonthYearField', () => {
       let collection: ComponentCollection
 
       beforeEach(() => {
-        collection = new ComponentCollection([def], { model: formModel })
+        collection = new ComponentCollection([def], { model })
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/MultilineTextField.test.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.test.ts
@@ -6,7 +6,7 @@ import {
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { MultilineTextField } from '~/src/server/plugins/engine/components/MultilineTextField.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { getFormData, getFormState } from '~/test/helpers/component-helpers.js'
 
@@ -29,7 +29,7 @@ describe('MultilineTextField', () => {
   describe('Defaults', () => {
     let def: MultilineTextFieldComponent
     let collection: ComponentCollection
-    let component: FormComponentFieldClass
+    let field: Field
 
     beforeEach(() => {
       def = {
@@ -41,7 +41,7 @@ describe('MultilineTextField', () => {
       } satisfies MultilineTextFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.fields[0]
+      field = collection.fields[0]
     })
 
     describe('Schema', () => {
@@ -63,10 +63,10 @@ describe('MultilineTextField', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual(['myComponent'])
-        expect(component.collection).toBeUndefined()
+        expect(field.keys).toEqual(['myComponent'])
+        expect(field.collection).toBeUndefined()
 
-        for (const key of component.keys) {
+        for (const key of field.keys) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -138,8 +138,8 @@ describe('MultilineTextField', () => {
         const state1 = getFormState('Textarea')
         const state2 = getFormState(null)
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe('Textarea')
         expect(text2).toBe('')
@@ -149,8 +149,8 @@ describe('MultilineTextField', () => {
         const state1 = getFormState('Textarea')
         const state2 = getFormState(null)
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData('Textarea'))
         expect(payload2).toEqual(getFormData())
@@ -160,8 +160,8 @@ describe('MultilineTextField', () => {
         const state1 = getFormState('Textarea')
         const state2 = getFormState(null)
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toBe('Textarea')
         expect(value2).toBeUndefined()
@@ -171,8 +171,8 @@ describe('MultilineTextField', () => {
         const payload1 = getFormData('Textarea')
         const payload2 = getFormData()
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState('Textarea'))
         expect(value2).toEqual(getFormState(null))
@@ -181,7 +181,7 @@ describe('MultilineTextField', () => {
 
     describe('View model', () => {
       it('sets Nunjucks component defaults', () => {
-        const viewModel = component.getViewModel(getFormData('Textarea'))
+        const viewModel = field.getViewModel(getFormData('Textarea'))
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -204,7 +204,7 @@ describe('MultilineTextField', () => {
           { model }
         )
 
-        const viewModel = component.getViewModel(getFormData('Textarea'))
+        const viewModel = field.getViewModel(getFormData('Textarea'))
 
         const viewModel1 = componentCustom1.getViewModel(
           getFormData('Textarea custom #1')

--- a/src/server/plugins/engine/components/MultilineTextField.test.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.test.ts
@@ -18,10 +18,10 @@ describe('MultilineTextField', () => {
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
   })
@@ -40,8 +40,8 @@ describe('MultilineTextField', () => {
         schema: {}
       } satisfies MultilineTextFieldComponent
 
-      collection = new ComponentCollection([def], { model: formModel })
-      component = collection.formItems[0]
+      collection = new ComponentCollection([def], { model })
+      component = collection.questions[0]
     })
 
     describe('Schema', () => {
@@ -64,7 +64,7 @@ describe('MultilineTextField', () => {
         const { keys } = formSchema.describe()
 
         expect(component.keys).toEqual(['myComponent'])
-        expect(component.children).toBeUndefined()
+        expect(component.collection).toBeUndefined()
 
         for (const key of component.keys) {
           expect(keys).toHaveProperty(key)
@@ -88,7 +88,7 @@ describe('MultilineTextField', () => {
       it('is optional when configured', () => {
         const collectionOptional = new ComponentCollection(
           [{ ...def, options: { required: false } }],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -196,12 +196,12 @@ describe('MultilineTextField', () => {
       it('sets Nunjucks component isCharacterOrWordCount: true', () => {
         const componentCustom1 = new MultilineTextField(
           { ...def, options: { maxWords: 10 } },
-          formModel
+          { model }
         )
 
         const componentCustom2 = new MultilineTextField(
           { ...def, schema: { max: 10 } },
-          formModel
+          { model }
         )
 
         const viewModel = component.getViewModel(getFormData('Textarea'))
@@ -536,7 +536,7 @@ describe('MultilineTextField', () => {
       let collection: ComponentCollection
 
       beforeEach(() => {
-        collection = new ComponentCollection([def], { model: formModel })
+        collection = new ComponentCollection([def], { model })
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/MultilineTextField.test.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.test.ts
@@ -41,7 +41,7 @@ describe('MultilineTextField', () => {
       } satisfies MultilineTextFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.questions[0]
+      component = collection.fields[0]
     })
 
     describe('Schema', () => {

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -1,8 +1,8 @@
 import { type MultilineTextFieldComponent } from '@defra/forms-model'
 import Joi, { type CustomValidator, type StringSchema } from 'joi'
 
+import { type ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
   type FormSubmissionError
@@ -16,8 +16,11 @@ export class MultilineTextField extends FormComponent {
 
   isCharacterOrWordCount = false
 
-  constructor(def: MultilineTextFieldComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: MultilineTextFieldComponent,
+    props: ConstructorParameters<typeof ComponentBase>[1]
+  ) {
+    super(def, props)
 
     const { schema, options, title } = def
 

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -18,10 +18,10 @@ describe('NumberField', () => {
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
   })
@@ -40,8 +40,8 @@ describe('NumberField', () => {
         schema: {}
       } satisfies NumberFieldComponent
 
-      collection = new ComponentCollection([def], { model: formModel })
-      component = collection.formItems[0]
+      collection = new ComponentCollection([def], { model })
+      component = collection.questions[0]
     })
 
     describe('Schema', () => {
@@ -64,7 +64,7 @@ describe('NumberField', () => {
         const { keys } = formSchema.describe()
 
         expect(component.keys).toEqual(['myComponent'])
-        expect(component.children).toBeUndefined()
+        expect(component.collection).toBeUndefined()
 
         for (const key of component.keys) {
           expect(keys).toHaveProperty(key)
@@ -88,7 +88,7 @@ describe('NumberField', () => {
       it('is optional when configured', () => {
         const collectionOptional = new ComponentCollection(
           [{ ...def, options: { required: false } }],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -206,7 +206,7 @@ describe('NumberField', () => {
       it('sets Nunjucks component prefix and suffix', () => {
         const componentCustom = new NumberField(
           { ...def, options: { prefix: '£', suffix: 'per item' } },
-          formModel
+          { model }
         )
 
         const viewModel = componentCustom.getViewModel(getFormData(99.99))
@@ -218,7 +218,7 @@ describe('NumberField', () => {
       it('sets Nunjucks component inputmode attribute when precision is not defined', () => {
         const componentCustom = new NumberField(
           { ...def, schema: { precision: undefined } },
-          formModel
+          { model }
         )
 
         const viewModel = componentCustom.getViewModel(getFormData(99))
@@ -229,7 +229,7 @@ describe('NumberField', () => {
       it('sets Nunjucks component inputmode attribute when precision is 0', () => {
         const componentCustom = new NumberField(
           { ...def, schema: { precision: 0 } },
-          formModel
+          { model }
         )
 
         const viewModel = componentCustom.getViewModel(getFormData(99))
@@ -240,7 +240,7 @@ describe('NumberField', () => {
       it('does not set Nunjucks component inputmode attribute when precision is positive', () => {
         const componentCustom = new NumberField(
           { ...def, schema: { precision: 2 } },
-          formModel
+          { model }
         )
 
         const viewModel = componentCustom.getViewModel(getFormData(99.99))
@@ -682,7 +682,7 @@ describe('NumberField', () => {
       let collection: ComponentCollection
 
       beforeEach(() => {
-        collection = new ComponentCollection([def], { model: formModel })
+        collection = new ComponentCollection([def], { model })
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -6,7 +6,7 @@ import {
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { NumberField } from '~/src/server/plugins/engine/components/NumberField.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { getFormData, getFormState } from '~/test/helpers/component-helpers.js'
 
@@ -29,7 +29,7 @@ describe('NumberField', () => {
   describe('Defaults', () => {
     let def: NumberFieldComponent
     let collection: ComponentCollection
-    let component: FormComponentFieldClass
+    let field: Field
 
     beforeEach(() => {
       def = {
@@ -41,7 +41,7 @@ describe('NumberField', () => {
       } satisfies NumberFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.fields[0]
+      field = collection.fields[0]
     })
 
     describe('Schema', () => {
@@ -63,10 +63,10 @@ describe('NumberField', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual(['myComponent'])
-        expect(component.collection).toBeUndefined()
+        expect(field.keys).toEqual(['myComponent'])
+        expect(field.collection).toBeUndefined()
 
-        for (const key of component.keys) {
+        for (const key of field.keys) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -148,8 +148,8 @@ describe('NumberField', () => {
         const state1 = getFormState(2024)
         const state2 = getFormState(null)
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe('2024')
         expect(text2).toBe('')
@@ -159,8 +159,8 @@ describe('NumberField', () => {
         const state1 = getFormState(2024)
         const state2 = getFormState(null)
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData(2024))
         expect(payload2).toEqual(getFormData())
@@ -170,8 +170,8 @@ describe('NumberField', () => {
         const state1 = getFormState(2024)
         const state2 = getFormState(null)
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toBe(2024)
         expect(value2).toBeUndefined()
@@ -181,8 +181,8 @@ describe('NumberField', () => {
         const payload1 = getFormData(2024)
         const payload2 = getFormData()
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState(2024))
         expect(value2).toEqual(getFormState(null))
@@ -191,7 +191,7 @@ describe('NumberField', () => {
 
     describe('View model', () => {
       it('sets Nunjucks component defaults', () => {
-        const viewModel = component.getViewModel(getFormData(2024))
+        const viewModel = field.getViewModel(getFormData(2024))
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -250,7 +250,7 @@ describe('NumberField', () => {
     })
 
     it('sets Nunjucks component value when invalid', () => {
-      const viewModel = component.getViewModel(getFormData('AA'))
+      const viewModel = field.getViewModel(getFormData('AA'))
 
       expect(viewModel).toHaveProperty('value', 'AA')
     })

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -41,7 +41,7 @@ describe('NumberField', () => {
       } satisfies NumberFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.questions[0]
+      component = collection.fields[0]
     })
 
     describe('Schema', () => {

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -5,7 +5,6 @@ import {
   FormComponent,
   isFormValue
 } from '~/src/server/plugins/engine/components/FormComponent.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 import {
   type FormPayload,
@@ -21,8 +20,11 @@ export class NumberField extends FormComponent {
   declare formSchema: NumberSchema
   declare stateSchema: NumberSchema
 
-  constructor(def: NumberFieldComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: NumberFieldComponent,
+    props: ConstructorParameters<typeof FormComponent>[1]
+  ) {
+    super(def, props)
 
     const { options, schema, title } = def
 

--- a/src/server/plugins/engine/components/RadiosField.test.ts
+++ b/src/server/plugins/engine/components/RadiosField.test.ts
@@ -6,7 +6,7 @@ import {
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { RadiosField } from '~/src/server/plugins/engine/components/RadiosField.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   listNumber,
@@ -57,7 +57,7 @@ describe.each([
 
   let model: FormModel
   let collection: ComponentCollection
-  let component: FormComponentFieldClass
+  let field: Field
 
   beforeEach(() => {
     model = new FormModel(definition, {
@@ -65,7 +65,7 @@ describe.each([
     })
 
     collection = new ComponentCollection([def], { model })
-    component = collection.fields[0]
+    field = collection.fields[0]
   })
 
   describe('Defaults', () => {
@@ -88,10 +88,10 @@ describe.each([
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual(['myComponent'])
-        expect(component.collection).toBeUndefined()
+        expect(field.keys).toEqual(['myComponent'])
+        expect(field.collection).toBeUndefined()
 
-        for (const key of component.keys) {
+        for (const key of field.keys) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -177,8 +177,8 @@ describe.each([
         const state1 = getFormState(item.state)
         const state2 = getFormState(null)
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe(item.text)
         expect(text2).toBe('')
@@ -188,8 +188,8 @@ describe.each([
         const state1 = getFormState(item.state)
         const state2 = getFormState(null)
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData(item.value))
         expect(payload2).toEqual(getFormData())
@@ -199,8 +199,8 @@ describe.each([
         const state1 = getFormState(item.state)
         const state2 = getFormState(null)
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toEqual(item.value)
         expect(value2).toBeUndefined()
@@ -210,8 +210,8 @@ describe.each([
         const payload1 = getFormData(item.value)
         const payload2 = getFormData()
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState(item.state))
         expect(value2).toEqual(getFormState(null))
@@ -222,7 +222,7 @@ describe.each([
       it('sets Nunjucks component defaults', () => {
         const item = options.examples[0]
 
-        const viewModel = component.getViewModel(getFormData(item.value))
+        const viewModel = field.getViewModel(getFormData(item.value))
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -237,7 +237,7 @@ describe.each([
       it.each([...options.examples])(
         'sets Nunjucks component radio items',
         (item) => {
-          const viewModel = component.getViewModel(getFormData(item.value))
+          const viewModel = field.getViewModel(getFormData(item.value))
 
           expect(viewModel.items?.[0]).not.toMatchObject({
             value: '' // First item is never empty
@@ -258,11 +258,11 @@ describe.each([
 
     describe('Radio items', () => {
       it('returns radio items', () => {
-        expect(component).toHaveProperty('items', options.list.items)
+        expect(field).toHaveProperty('items', options.list.items)
       })
 
       it('returns radio items matching type', () => {
-        expect(component).toHaveProperty('values', expect.arrayContaining([]))
+        expect(field).toHaveProperty('values', expect.arrayContaining([]))
       })
 
       it('returns empty items when missing', () => {

--- a/src/server/plugins/engine/components/RadiosField.test.ts
+++ b/src/server/plugins/engine/components/RadiosField.test.ts
@@ -55,17 +55,17 @@ describe.each([
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
   let collection: ComponentCollection
   let component: FormComponentFieldClass
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
 
-    collection = new ComponentCollection([def], { model: formModel })
-    component = collection.formItems[0]
+    collection = new ComponentCollection([def], { model })
+    component = collection.questions[0]
   })
 
   describe('Defaults', () => {
@@ -89,7 +89,7 @@ describe.each([
         const { keys } = formSchema.describe()
 
         expect(component.keys).toEqual(['myComponent'])
-        expect(component.children).toBeUndefined()
+        expect(component.collection).toBeUndefined()
 
         for (const key of component.keys) {
           expect(keys).toHaveProperty(key)
@@ -113,7 +113,7 @@ describe.each([
       it('is optional when configured', () => {
         const collectionOptional = new ComponentCollection(
           [{ ...def, options: { required: false } }],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -273,11 +273,11 @@ describe.each([
           conditions: []
         } satisfies FormDefinition
 
-        const formModel = new FormModel(definitionNoList, {
+        const model = new FormModel(definitionNoList, {
           basePath: 'test'
         })
 
-        const { items } = new RadiosField(def, formModel)
+        const { items } = new RadiosField(def, { model })
         expect(items).toEqual([])
       })
     })

--- a/src/server/plugins/engine/components/RadiosField.test.ts
+++ b/src/server/plugins/engine/components/RadiosField.test.ts
@@ -65,7 +65,7 @@ describe.each([
     })
 
     collection = new ComponentCollection([def], { model })
-    component = collection.questions[0]
+    component = collection.fields[0]
   })
 
   describe('Defaults', () => {

--- a/src/server/plugins/engine/components/RadiosField.ts
+++ b/src/server/plugins/engine/components/RadiosField.ts
@@ -1,13 +1,15 @@
 import { type RadiosFieldComponent } from '@defra/forms-model'
 
 import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 
 export class RadiosField extends SelectionControlField {
   declare options: RadiosFieldComponent['options']
 
-  constructor(def: RadiosFieldComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: RadiosFieldComponent,
+    props: ConstructorParameters<typeof SelectionControlField>[1]
+  ) {
+    super(def, props)
 
     const { options } = def
     let { formSchema } = this

--- a/src/server/plugins/engine/components/SelectField.test.ts
+++ b/src/server/plugins/engine/components/SelectField.test.ts
@@ -55,17 +55,17 @@ describe.each([
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
   let collection: ComponentCollection
   let component: FormComponentFieldClass
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
 
-    collection = new ComponentCollection([def], { model: formModel })
-    component = collection.formItems[0]
+    collection = new ComponentCollection([def], { model })
+    component = collection.questions[0]
   })
 
   describe('Defaults', () => {
@@ -89,7 +89,7 @@ describe.each([
         const { keys } = formSchema.describe()
 
         expect(component.keys).toEqual(['myComponent'])
-        expect(component.children).toBeUndefined()
+        expect(component.collection).toBeUndefined()
 
         for (const key of component.keys) {
           expect(keys).toHaveProperty(key)
@@ -113,7 +113,7 @@ describe.each([
       it('is optional when configured', () => {
         const collectionOptional = new ComponentCollection(
           [{ ...def, options: { required: false } }],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -273,11 +273,11 @@ describe.each([
           conditions: []
         } satisfies FormDefinition
 
-        const formModel = new FormModel(definitionNoList, {
+        const model = new FormModel(definitionNoList, {
           basePath: 'test'
         })
 
-        const { items } = new SelectField(def, formModel)
+        const { items } = new SelectField(def, { model })
         expect(items).toEqual([])
       })
     })

--- a/src/server/plugins/engine/components/SelectField.test.ts
+++ b/src/server/plugins/engine/components/SelectField.test.ts
@@ -6,7 +6,7 @@ import {
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { SelectField } from '~/src/server/plugins/engine/components/SelectField.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   listNumber,
@@ -57,7 +57,7 @@ describe.each([
 
   let model: FormModel
   let collection: ComponentCollection
-  let component: FormComponentFieldClass
+  let field: Field
 
   beforeEach(() => {
     model = new FormModel(definition, {
@@ -65,7 +65,7 @@ describe.each([
     })
 
     collection = new ComponentCollection([def], { model })
-    component = collection.fields[0]
+    field = collection.fields[0]
   })
 
   describe('Defaults', () => {
@@ -88,10 +88,10 @@ describe.each([
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual(['myComponent'])
-        expect(component.collection).toBeUndefined()
+        expect(field.keys).toEqual(['myComponent'])
+        expect(field.collection).toBeUndefined()
 
-        for (const key of component.keys) {
+        for (const key of field.keys) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -178,8 +178,8 @@ describe.each([
         const state1 = getFormState(item.state)
         const state2 = getFormState(null)
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe(item.text)
         expect(text2).toBe('')
@@ -189,8 +189,8 @@ describe.each([
         const state1 = getFormState(item.state)
         const state2 = getFormState(null)
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData(item.value))
         expect(payload2).toEqual(getFormData())
@@ -200,8 +200,8 @@ describe.each([
         const state1 = getFormState(item.state)
         const state2 = getFormState(null)
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toEqual(item.value)
         expect(value2).toBeUndefined()
@@ -211,8 +211,8 @@ describe.each([
         const payload1 = getFormData(item.value)
         const payload2 = getFormData()
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState(item.state))
         expect(value2).toEqual(getFormState(null))
@@ -222,7 +222,7 @@ describe.each([
     describe('View model', () => {
       it('sets Nunjucks component defaults', () => {
         const item = options.examples[0]
-        const viewModel = component.getViewModel(getFormData(item.value))
+        const viewModel = field.getViewModel(getFormData(item.value))
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -237,7 +237,7 @@ describe.each([
       it.each([...options.examples])(
         'sets Nunjucks component select options',
         (item) => {
-          const viewModel = component.getViewModel(getFormData(item.value))
+          const viewModel = field.getViewModel(getFormData(item.value))
 
           expect(viewModel.items?.[0]).toMatchObject({
             value: '' // First item is always empty
@@ -258,11 +258,11 @@ describe.each([
 
     describe('Select options', () => {
       it('returns select options', () => {
-        expect(component).toHaveProperty('items', options.list.items)
+        expect(field).toHaveProperty('items', options.list.items)
       })
 
       it('returns select options matching type', () => {
-        expect(component).toHaveProperty('values', expect.arrayContaining([]))
+        expect(field).toHaveProperty('values', expect.arrayContaining([]))
       })
 
       it('returns empty items when missing', () => {

--- a/src/server/plugins/engine/components/SelectField.test.ts
+++ b/src/server/plugins/engine/components/SelectField.test.ts
@@ -65,7 +65,7 @@ describe.each([
     })
 
     collection = new ComponentCollection([def], { model })
-    component = collection.questions[0]
+    component = collection.fields[0]
   })
 
   describe('Defaults', () => {

--- a/src/server/plugins/engine/components/SelectField.ts
+++ b/src/server/plugins/engine/components/SelectField.ts
@@ -4,7 +4,6 @@ import {
 } from '@defra/forms-model'
 
 import { ListFormComponent } from '~/src/server/plugins/engine/components/ListFormComponent.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type FormPayload,
   type FormSubmissionError
@@ -17,9 +16,9 @@ export class SelectField extends ListFormComponent {
 
   constructor(
     def: SelectFieldComponent | AutocompleteFieldComponent,
-    model: FormModel
+    props: ConstructorParameters<typeof ListFormComponent>[1]
   ) {
-    super(def, model)
+    super(def, props)
 
     const { options } = def
     let { formSchema } = this

--- a/src/server/plugins/engine/components/TelephoneNumberField.test.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.test.ts
@@ -17,10 +17,10 @@ describe('TelephoneNumberField', () => {
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
   })
@@ -38,8 +38,8 @@ describe('TelephoneNumberField', () => {
         options: {}
       } satisfies TelephoneNumberFieldComponent
 
-      collection = new ComponentCollection([def], { model: formModel })
-      component = collection.formItems[0]
+      collection = new ComponentCollection([def], { model })
+      component = collection.questions[0]
     })
 
     describe('Schema', () => {
@@ -62,7 +62,7 @@ describe('TelephoneNumberField', () => {
         const { keys } = formSchema.describe()
 
         expect(component.keys).toEqual(['myComponent'])
-        expect(component.children).toBeUndefined()
+        expect(component.collection).toBeUndefined()
 
         for (const key of component.keys) {
           expect(keys).toHaveProperty(key)
@@ -86,7 +86,7 @@ describe('TelephoneNumberField', () => {
       it('is optional when configured', () => {
         const collectionOptional = new ComponentCollection(
           [{ ...def, options: { required: false } }],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -334,7 +334,7 @@ describe('TelephoneNumberField', () => {
       let collection: ComponentCollection
 
       beforeEach(() => {
-        collection = new ComponentCollection([def], { model: formModel })
+        collection = new ComponentCollection([def], { model })
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/TelephoneNumberField.test.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.test.ts
@@ -39,7 +39,7 @@ describe('TelephoneNumberField', () => {
       } satisfies TelephoneNumberFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.questions[0]
+      component = collection.fields[0]
     })
 
     describe('Schema', () => {

--- a/src/server/plugins/engine/components/TelephoneNumberField.test.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@defra/forms-model'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { getFormData, getFormState } from '~/test/helpers/component-helpers.js'
 
@@ -28,7 +28,7 @@ describe('TelephoneNumberField', () => {
   describe('Defaults', () => {
     let def: TelephoneNumberFieldComponent
     let collection: ComponentCollection
-    let component: FormComponentFieldClass
+    let field: Field
 
     beforeEach(() => {
       def = {
@@ -39,7 +39,7 @@ describe('TelephoneNumberField', () => {
       } satisfies TelephoneNumberFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.fields[0]
+      field = collection.fields[0]
     })
 
     describe('Schema', () => {
@@ -61,10 +61,10 @@ describe('TelephoneNumberField', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual(['myComponent'])
-        expect(component.collection).toBeUndefined()
+        expect(field.keys).toEqual(['myComponent'])
+        expect(field.collection).toBeUndefined()
 
-        for (const key of component.keys) {
+        for (const key of field.keys) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -149,8 +149,8 @@ describe('TelephoneNumberField', () => {
         const state1 = getFormState('+447900000000')
         const state2 = getFormState(null)
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe('+447900000000')
         expect(text2).toBe('')
@@ -160,8 +160,8 @@ describe('TelephoneNumberField', () => {
         const state1 = getFormState('+447900000000')
         const state2 = getFormState(null)
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData('+447900000000'))
         expect(payload2).toEqual(getFormData())
@@ -171,8 +171,8 @@ describe('TelephoneNumberField', () => {
         const state1 = getFormState('+447900000000')
         const state2 = getFormState(null)
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toBe('+447900000000')
         expect(value2).toBeUndefined()
@@ -182,8 +182,8 @@ describe('TelephoneNumberField', () => {
         const payload1 = getFormData('+447900000000')
         const payload2 = getFormData()
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState('+447900000000'))
         expect(value2).toEqual(getFormState(null))
@@ -192,7 +192,7 @@ describe('TelephoneNumberField', () => {
 
     describe('View model', () => {
       it('sets Nunjucks component defaults', () => {
-        const viewModel = component.getViewModel(
+        const viewModel = field.getViewModel(
           getFormData('Telephone number field')
         )
 

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -3,7 +3,6 @@ import joi, { type StringSchema } from 'joi'
 
 import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { addClassOptionIfNone } from '~/src/server/plugins/engine/components/helpers.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormPayload,
   type FormSubmissionError
@@ -16,8 +15,11 @@ export class TelephoneNumberField extends FormComponent {
   declare formSchema: StringSchema
   declare stateSchema: StringSchema
 
-  constructor(def: TelephoneNumberFieldComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: TelephoneNumberFieldComponent,
+    props: ConstructorParameters<typeof FormComponent>[1]
+  ) {
+    super(def, props)
 
     const { options, title } = def
 

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@defra/forms-model'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { getFormData, getFormState } from '~/test/helpers/component-helpers.js'
 
@@ -28,7 +28,7 @@ describe('TextField', () => {
   describe('Defaults', () => {
     let def: TextFieldComponent
     let collection: ComponentCollection
-    let component: FormComponentFieldClass
+    let field: Field
 
     beforeEach(() => {
       def = {
@@ -40,7 +40,7 @@ describe('TextField', () => {
       } satisfies TextFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.fields[0]
+      field = collection.fields[0]
     })
 
     describe('Schema', () => {
@@ -62,10 +62,10 @@ describe('TextField', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual(['myComponent'])
-        expect(component.collection).toBeUndefined()
+        expect(field.keys).toEqual(['myComponent'])
+        expect(field.collection).toBeUndefined()
 
-        for (const key of component.keys) {
+        for (const key of field.keys) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -137,8 +137,8 @@ describe('TextField', () => {
         const state1 = getFormState('Text field')
         const state2 = getFormState(null)
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe('Text field')
         expect(text2).toBe('')
@@ -148,8 +148,8 @@ describe('TextField', () => {
         const state1 = getFormState('Text field')
         const state2 = getFormState(null)
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData('Text field'))
         expect(payload2).toEqual(getFormData())
@@ -159,8 +159,8 @@ describe('TextField', () => {
         const state1 = getFormState('Text field')
         const state2 = getFormState(null)
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toBe('Text field')
         expect(value2).toBeUndefined()
@@ -170,8 +170,8 @@ describe('TextField', () => {
         const payload1 = getFormData('Text field')
         const payload2 = getFormData()
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState('Text field'))
         expect(value2).toEqual(getFormState(null))
@@ -180,7 +180,7 @@ describe('TextField', () => {
 
     describe('View model', () => {
       it('sets Nunjucks component defaults', () => {
-        const viewModel = component.getViewModel(getFormData('Text field'))
+        const viewModel = field.getViewModel(getFormData('Text field'))
 
         expect(viewModel).toEqual(
           expect.objectContaining({

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -40,7 +40,7 @@ describe('TextField', () => {
       } satisfies TextFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.questions[0]
+      component = collection.fields[0]
     })
 
     describe('Schema', () => {

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -17,10 +17,10 @@ describe('TextField', () => {
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
   })
@@ -39,8 +39,8 @@ describe('TextField', () => {
         schema: {}
       } satisfies TextFieldComponent
 
-      collection = new ComponentCollection([def], { model: formModel })
-      component = collection.formItems[0]
+      collection = new ComponentCollection([def], { model })
+      component = collection.questions[0]
     })
 
     describe('Schema', () => {
@@ -63,7 +63,7 @@ describe('TextField', () => {
         const { keys } = formSchema.describe()
 
         expect(component.keys).toEqual(['myComponent'])
-        expect(component.children).toBeUndefined()
+        expect(component.collection).toBeUndefined()
 
         for (const key of component.keys) {
           expect(keys).toHaveProperty(key)
@@ -87,7 +87,7 @@ describe('TextField', () => {
       it('is optional when configured', () => {
         const collectionOptional = new ComponentCollection(
           [{ ...def, options: { required: false } }],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -470,7 +470,7 @@ describe('TextField', () => {
       let collection: ComponentCollection
 
       beforeEach(() => {
-        collection = new ComponentCollection([def], { model: formModel })
+        collection = new ComponentCollection([def], { model })
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -8,7 +8,6 @@ import {
   FormComponent,
   isFormValue
 } from '~/src/server/plugins/engine/components/FormComponent.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormState,
   type FormStateValue,
@@ -27,9 +26,9 @@ export class TextField extends FormComponent {
 
   constructor(
     def: TextFieldComponent | EmailAddressFieldComponent,
-    model: FormModel
+    props: ConstructorParameters<typeof FormComponent>[1]
   ) {
-    super(def, model)
+    super(def, props)
 
     const { options, title } = def
     const schema = 'schema' in def ? def.schema : {}

--- a/src/server/plugins/engine/components/UkAddressField.test.ts
+++ b/src/server/plugins/engine/components/UkAddressField.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@defra/forms-model'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { type ViewModel } from '~/src/server/plugins/engine/components/types.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
@@ -32,7 +32,7 @@ describe('UkAddressField', () => {
   describe('Defaults', () => {
     let def: UkAddressFieldComponent
     let collection: ComponentCollection
-    let component: FormComponentFieldClass
+    let field: Field
 
     beforeEach(() => {
       def = {
@@ -43,7 +43,7 @@ describe('UkAddressField', () => {
       } satisfies UkAddressFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.fields[0]
+      field = collection.fields[0]
     })
 
     describe('Schema', () => {
@@ -84,7 +84,7 @@ describe('UkAddressField', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
-        expect(component.keys).toEqual([
+        expect(field.keys).toEqual([
           'myComponent',
           'myComponent__addressLine1',
           'myComponent__addressLine2',
@@ -92,9 +92,9 @@ describe('UkAddressField', () => {
           'myComponent__postcode'
         ])
 
-        expect(component.collection?.keys).not.toHaveProperty('myComponent')
+        expect(field.collection?.keys).not.toHaveProperty('myComponent')
 
-        for (const key of component.collection?.keys ?? []) {
+        for (const key of field.collection?.keys ?? []) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -266,8 +266,8 @@ describe('UkAddressField', () => {
         const state1 = getFormState(address)
         const state2 = getFormState({})
 
-        const text1 = component.getDisplayStringFromState(state1)
-        const text2 = component.getDisplayStringFromState(state2)
+        const text1 = field.getDisplayStringFromState(state1)
+        const text2 = field.getDisplayStringFromState(state2)
 
         expect(text1).toBe(
           'Richard Fairclough House, Knutsford Road, Warrington, WA4 1HT'
@@ -280,8 +280,8 @@ describe('UkAddressField', () => {
         const state1 = getFormState(address)
         const state2 = getFormState({})
 
-        const payload1 = component.getFormDataFromState(state1)
-        const payload2 = component.getFormDataFromState(state2)
+        const payload1 = field.getFormDataFromState(state1)
+        const payload2 = field.getFormDataFromState(state2)
 
         expect(payload1).toEqual(getFormData(address))
         expect(payload2).toEqual(getFormData({}))
@@ -291,8 +291,8 @@ describe('UkAddressField', () => {
         const state1 = getFormState(address)
         const state2 = getFormState({})
 
-        const value1 = component.getFormValueFromState(state1)
-        const value2 = component.getFormValueFromState(state2)
+        const value1 = field.getFormValueFromState(state1)
+        const value2 = field.getFormValueFromState(state2)
 
         expect(value1).toEqual(address)
         expect(value2).toBeUndefined()
@@ -302,8 +302,8 @@ describe('UkAddressField', () => {
         const payload1 = getFormData(address)
         const payload2 = getFormData({})
 
-        const value1 = component.getStateFromValidForm(payload1)
-        const value2 = component.getStateFromValidForm(payload2)
+        const value1 = field.getStateFromValidForm(payload1)
+        const value2 = field.getStateFromValidForm(payload2)
 
         expect(value1).toEqual(getFormState(address))
         expect(value2).toEqual(getFormState({}))
@@ -320,7 +320,7 @@ describe('UkAddressField', () => {
 
       it('sets Nunjucks component defaults', () => {
         const payload = getFormData(address)
-        const viewModel = component.getViewModel(payload)
+        const viewModel = field.getViewModel(payload)
 
         expect(viewModel).toEqual(
           expect.objectContaining({
@@ -368,7 +368,7 @@ describe('UkAddressField', () => {
 
       it('sets Nunjucks component fieldset', () => {
         const payload = getFormData(address)
-        const viewModel = component.getViewModel(payload)
+        const viewModel = field.getViewModel(payload)
 
         expect(viewModel.fieldset).toEqual({
           legend: {

--- a/src/server/plugins/engine/components/UkAddressField.test.ts
+++ b/src/server/plugins/engine/components/UkAddressField.test.ts
@@ -21,10 +21,10 @@ describe('UkAddressField', () => {
     conditions: []
   } satisfies FormDefinition
 
-  let formModel: FormModel
+  let model: FormModel
 
   beforeEach(() => {
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
   })
@@ -42,8 +42,8 @@ describe('UkAddressField', () => {
         options: {}
       } satisfies UkAddressFieldComponent
 
-      collection = new ComponentCollection([def], { model: formModel })
-      component = collection.formItems[0]
+      collection = new ComponentCollection([def], { model })
+      component = collection.questions[0]
     })
 
     describe('Schema', () => {
@@ -92,9 +92,9 @@ describe('UkAddressField', () => {
           'myComponent__postcode'
         ])
 
-        expect(component.children?.keys).not.toHaveProperty('myComponent')
+        expect(component.collection?.keys).not.toHaveProperty('myComponent')
 
-        for (const key of component.children?.keys ?? []) {
+        for (const key of component.collection?.keys ?? []) {
           expect(keys).toHaveProperty(key)
         }
       })
@@ -143,7 +143,7 @@ describe('UkAddressField', () => {
               options: { required: false }
             }
           ],
-          { model: formModel }
+          { model }
         )
 
         const { formSchema } = collectionOptional
@@ -328,7 +328,7 @@ describe('UkAddressField', () => {
             name: 'myComponent',
             id: 'myComponent',
             value: undefined,
-            children: expect.arrayContaining([
+            components: expect.arrayContaining([
               expect.objectContaining({
                 model: getViewModel(address, 'addressLine1', {
                   label: { text: 'Address line 1' },
@@ -543,7 +543,7 @@ describe('UkAddressField', () => {
       let collection: ComponentCollection
 
       beforeEach(() => {
-        collection = new ComponentCollection([def], { model: formModel })
+        collection = new ComponentCollection([def], { model })
       })
 
       it.each([...assertions])(

--- a/src/server/plugins/engine/components/UkAddressField.test.ts
+++ b/src/server/plugins/engine/components/UkAddressField.test.ts
@@ -43,7 +43,7 @@ describe('UkAddressField', () => {
       } satisfies UkAddressFieldComponent
 
       collection = new ComponentCollection([def], { model })
-      component = collection.questions[0]
+      component = collection.fields[0]
     })
 
     describe('Schema', () => {

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -7,7 +7,6 @@ import {
   isFormState
 } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { TextField } from '~/src/server/plugins/engine/components/TextField.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { type PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 import {
   type FormPayload,
@@ -19,13 +18,15 @@ import {
 
 export class UkAddressField extends FormComponent {
   declare options: UkAddressFieldComponent['options']
-  children: ComponentCollection
-
   declare formSchema: ObjectSchema<FormPayload>
   declare stateSchema: ObjectSchema<FormState>
+  declare collection: ComponentCollection
 
-  constructor(def: UkAddressFieldComponent, model: FormModel) {
-    super(def, model)
+  constructor(
+    def: UkAddressFieldComponent,
+    props: ConstructorParameters<typeof FormComponent>[1]
+  ) {
+    super(def, props)
 
     const { name, options } = def
 
@@ -33,7 +34,7 @@ export class UkAddressField extends FormComponent {
     const hideOptional = !!options.optionalText
     const hideTitle = !!options.hideTitle
 
-    this.children = new ComponentCollection(
+    this.collection = new ComponentCollection(
       [
         {
           type: ComponentType.TextField,
@@ -84,12 +85,12 @@ export class UkAddressField extends FormComponent {
           }
         }
       ],
-      { model, parent: this }
+      { ...props, parent: this }
     )
 
     this.options = options
-    this.formSchema = this.children.formSchema
-    this.stateSchema = this.children.stateSchema
+    this.formSchema = this.collection.formSchema
+    this.stateSchema = this.collection.stateSchema
   }
 
   getFormValueFromState(state: FormSubmissionState) {
@@ -104,10 +105,10 @@ export class UkAddressField extends FormComponent {
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionError[]) {
-    const { children: formChildren, name, options } = this
+    const { collection, name, options } = this
 
     const viewModel = super.getViewModel(payload, errors)
-    let { children, fieldset, hint, label } = viewModel
+    let { components, fieldset, hint, label } = viewModel
 
     fieldset ??= {
       legend: {
@@ -130,12 +131,12 @@ export class UkAddressField extends FormComponent {
       }
     }
 
-    children = formChildren.getViewModel(payload, errors)
+    components = collection.getViewModel(payload, errors)
 
     return {
       ...viewModel,
       fieldset,
-      children
+      components
     }
   }
 

--- a/src/server/plugins/engine/components/YesNoField.test.ts
+++ b/src/server/plugins/engine/components/YesNoField.test.ts
@@ -19,7 +19,7 @@ describe('YesNoField', () => {
   } satisfies FormDefinition
 
   let def: YesNoFieldComponent
-  let formModel: FormModel
+  let model: FormModel
   let collection: ComponentCollection
   let component: FormComponentFieldClass
 
@@ -31,12 +31,12 @@ describe('YesNoField', () => {
       options: {}
     } satisfies YesNoFieldComponent
 
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
 
-    collection = new ComponentCollection([def], { model: formModel })
-    component = collection.formItems[0]
+    collection = new ComponentCollection([def], { model })
+    component = collection.questions[0]
   })
 
   describe('Schema', () => {
@@ -59,7 +59,7 @@ describe('YesNoField', () => {
       const { keys } = formSchema.describe()
 
       expect(component.keys).toEqual(['myComponent'])
-      expect(component.children).toBeUndefined()
+      expect(component.collection).toBeUndefined()
 
       for (const key of component.keys) {
         expect(keys).toHaveProperty(key)
@@ -83,7 +83,7 @@ describe('YesNoField', () => {
     it('is optional when configured', () => {
       const collectionOptional = new ComponentCollection(
         [{ ...def, options: { required: false } }],
-        { model: formModel }
+        { model }
       )
 
       const { formSchema } = collectionOptional

--- a/src/server/plugins/engine/components/YesNoField.test.ts
+++ b/src/server/plugins/engine/components/YesNoField.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@defra/forms-model'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { listYesNoExamples } from '~/test/fixtures/list.js'
 import { getFormData, getFormState } from '~/test/helpers/component-helpers.js'
@@ -21,7 +21,7 @@ describe('YesNoField', () => {
   let def: YesNoFieldComponent
   let model: FormModel
   let collection: ComponentCollection
-  let component: FormComponentFieldClass
+  let field: Field
 
   beforeEach(() => {
     def = {
@@ -36,7 +36,7 @@ describe('YesNoField', () => {
     })
 
     collection = new ComponentCollection([def], { model })
-    component = collection.fields[0]
+    field = collection.fields[0]
   })
 
   describe('Schema', () => {
@@ -58,10 +58,10 @@ describe('YesNoField', () => {
       const { formSchema } = collection
       const { keys } = formSchema.describe()
 
-      expect(component.keys).toEqual(['myComponent'])
-      expect(component.collection).toBeUndefined()
+      expect(field.keys).toEqual(['myComponent'])
+      expect(field.collection).toBeUndefined()
 
-      for (const key of component.keys) {
+      for (const key of field.keys) {
         expect(keys).toHaveProperty(key)
       }
     })
@@ -150,9 +150,9 @@ describe('YesNoField', () => {
       const state2 = getFormState(false)
       const state3 = getFormState(null)
 
-      const text1 = component.getDisplayStringFromState(state1)
-      const text2 = component.getDisplayStringFromState(state2)
-      const text3 = component.getDisplayStringFromState(state3)
+      const text1 = field.getDisplayStringFromState(state1)
+      const text2 = field.getDisplayStringFromState(state2)
+      const text3 = field.getDisplayStringFromState(state3)
 
       expect(text1).toBe('Yes')
       expect(text2).toBe('No')
@@ -164,9 +164,9 @@ describe('YesNoField', () => {
       const state2 = getFormState(false)
       const state3 = getFormState(null)
 
-      const payload1 = component.getFormDataFromState(state1)
-      const payload2 = component.getFormDataFromState(state2)
-      const payload3 = component.getFormDataFromState(state3)
+      const payload1 = field.getFormDataFromState(state1)
+      const payload2 = field.getFormDataFromState(state2)
+      const payload3 = field.getFormDataFromState(state3)
 
       expect(payload1).toEqual(getFormData(true))
       expect(payload2).toEqual(getFormData(false))
@@ -178,9 +178,9 @@ describe('YesNoField', () => {
       const state2 = getFormState(false)
       const state3 = getFormState(null)
 
-      const value1 = component.getFormValueFromState(state1)
-      const value2 = component.getFormValueFromState(state2)
-      const value3 = component.getFormValueFromState(state3)
+      const value1 = field.getFormValueFromState(state1)
+      const value2 = field.getFormValueFromState(state2)
+      const value3 = field.getFormValueFromState(state3)
 
       expect(value1).toBe(true)
       expect(value2).toBe(false)
@@ -192,9 +192,9 @@ describe('YesNoField', () => {
       const payload2 = getFormData(false)
       const payload3 = getFormData()
 
-      const value1 = component.getStateFromValidForm(payload1)
-      const value2 = component.getStateFromValidForm(payload2)
-      const value3 = component.getStateFromValidForm(payload3)
+      const value1 = field.getStateFromValidForm(payload1)
+      const value2 = field.getStateFromValidForm(payload2)
+      const value3 = field.getStateFromValidForm(payload3)
 
       expect(value1).toEqual(getFormState(true))
       expect(value2).toEqual(getFormState(false))
@@ -208,7 +208,7 @@ describe('YesNoField', () => {
     it('sets Nunjucks component defaults', () => {
       const item = items[0]
 
-      const viewModel = component.getViewModel(getFormData(item.value))
+      const viewModel = field.getViewModel(getFormData(item.value))
 
       expect(viewModel).toEqual(
         expect.objectContaining({
@@ -221,7 +221,7 @@ describe('YesNoField', () => {
     })
 
     it.each([...items])('sets Nunjucks component radio items', (item) => {
-      const viewModel = component.getViewModel(getFormData(item.value))
+      const viewModel = field.getViewModel(getFormData(item.value))
 
       expect(viewModel.items?.[0]).not.toMatchObject({
         value: '' // First item is never empty

--- a/src/server/plugins/engine/components/YesNoField.test.ts
+++ b/src/server/plugins/engine/components/YesNoField.test.ts
@@ -36,7 +36,7 @@ describe('YesNoField', () => {
     })
 
     collection = new ComponentCollection([def], { model })
-    component = collection.questions[0]
+    component = collection.fields[0]
   })
 
   describe('Schema', () => {

--- a/src/server/plugins/engine/components/YesNoField.ts
+++ b/src/server/plugins/engine/components/YesNoField.ts
@@ -2,7 +2,6 @@ import { type YesNoFieldComponent } from '@defra/forms-model'
 
 import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
 import { addClassOptionIfNone } from '~/src/server/plugins/engine/components/helpers.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 
 /**
  * @description
@@ -11,8 +10,11 @@ import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 export class YesNoField extends SelectionControlField {
   declare options: YesNoFieldComponent['options']
 
-  constructor(def: YesNoFieldComponent, model: FormModel) {
-    super({ ...def, list: '__yesNo' }, model)
+  constructor(
+    def: YesNoFieldComponent,
+    props: ConstructorParameters<typeof SelectionControlField>[1]
+  ) {
+    super({ ...def, list: '__yesNo' }, props)
 
     const { options } = def
     let { formSchema } = this

--- a/src/server/plugins/engine/components/helpers.ts
+++ b/src/server/plugins/engine/components/helpers.ts
@@ -3,11 +3,13 @@ import { ComponentType, type ComponentDef } from '@defra/forms-model'
 import { type ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import * as Components from '~/src/server/plugins/engine/components/index.js'
 
-export type ComponentFieldClass = InstanceType<ComponentFieldType>
-export type ComponentFieldType = (typeof Components)[keyof typeof Components]
+// All component instances
+export type Component = InstanceType<
+  (typeof Components)[keyof typeof Components]
+>
 
-export type FormComponentFieldClass = InstanceType<FormComponentFieldType>
-export type FormComponentFieldType =
+// Field component instances only
+export type Field = InstanceType<
   | typeof Components.AutocompleteField
   | typeof Components.CheckboxesField
   | typeof Components.DatePartsField
@@ -20,15 +22,16 @@ export type FormComponentFieldType =
   | typeof Components.TextField
   | typeof Components.UkAddressField
   | typeof Components.FileUploadField
+>
 
 /**
  * Create field instance for each {@link ComponentDef} type
  */
-export function createComponentField(
+export function createComponent(
   def: ComponentDef,
   options: ConstructorParameters<typeof ComponentBase>[1]
-): ComponentFieldClass {
-  let component: ComponentFieldClass | undefined
+): Component {
+  let component: Component | undefined
 
   switch (def.type) {
     case ComponentType.AutocompleteField:

--- a/src/server/plugins/engine/components/helpers.ts
+++ b/src/server/plugins/engine/components/helpers.ts
@@ -1,7 +1,7 @@
 import { ComponentType, type ComponentDef } from '@defra/forms-model'
 
+import { type ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import * as Components from '~/src/server/plugins/engine/components/index.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 
 export type ComponentFieldClass = InstanceType<ComponentFieldType>
 export type ComponentFieldType = (typeof Components)[keyof typeof Components]
@@ -26,82 +26,86 @@ export type FormComponentFieldType =
  */
 export function createComponentField(
   def: ComponentDef,
-  model: FormModel
-): ComponentFieldClass | undefined {
+  options: ConstructorParameters<typeof ComponentBase>[1]
+): ComponentFieldClass {
   let component: ComponentFieldClass | undefined
 
   switch (def.type) {
     case ComponentType.AutocompleteField:
-      component = new Components.AutocompleteField(def, model)
+      component = new Components.AutocompleteField(def, options)
       break
 
     case ComponentType.CheckboxesField:
-      component = new Components.CheckboxesField(def, model)
+      component = new Components.CheckboxesField(def, options)
       break
 
     case ComponentType.DatePartsField:
-      component = new Components.DatePartsField(def, model)
+      component = new Components.DatePartsField(def, options)
       break
 
     case ComponentType.Details:
-      component = new Components.Details(def, model)
+      component = new Components.Details(def, options)
       break
 
     case ComponentType.EmailAddressField:
-      component = new Components.EmailAddressField(def, model)
+      component = new Components.EmailAddressField(def, options)
       break
 
     case ComponentType.Html:
-      component = new Components.Html(def, model)
+      component = new Components.Html(def, options)
       break
 
     case ComponentType.InsetText:
-      component = new Components.InsetText(def, model)
+      component = new Components.InsetText(def, options)
       break
 
     case ComponentType.List:
-      component = new Components.List(def, model)
+      component = new Components.List(def, options)
       break
 
     case ComponentType.MultilineTextField:
-      component = new Components.MultilineTextField(def, model)
+      component = new Components.MultilineTextField(def, options)
       break
 
     case ComponentType.NumberField:
-      component = new Components.NumberField(def, model)
+      component = new Components.NumberField(def, options)
       break
 
     case ComponentType.RadiosField:
-      component = new Components.RadiosField(def, model)
+      component = new Components.RadiosField(def, options)
       break
 
     case ComponentType.SelectField:
-      component = new Components.SelectField(def, model)
+      component = new Components.SelectField(def, options)
       break
 
     case ComponentType.TelephoneNumberField:
-      component = new Components.TelephoneNumberField(def, model)
+      component = new Components.TelephoneNumberField(def, options)
       break
 
     case ComponentType.TextField:
-      component = new Components.TextField(def, model)
+      component = new Components.TextField(def, options)
       break
 
     case ComponentType.UkAddressField:
-      component = new Components.UkAddressField(def, model)
+      component = new Components.UkAddressField(def, options)
       break
 
     case ComponentType.YesNoField:
-      component = new Components.YesNoField(def, model)
+      component = new Components.YesNoField(def, options)
       break
 
     case ComponentType.MonthYearField:
-      component = new Components.MonthYearField(def, model)
+      component = new Components.MonthYearField(def, options)
       break
 
     case ComponentType.FileUploadField:
-      component = new Components.FileUploadField(def, model)
+      component = new Components.FileUploadField(def, options)
       break
+  }
+
+  if (typeof component === 'undefined') {
+    throw new Error(`Component type ${def.type} does not exist`)
   }
 
   return component

--- a/src/server/plugins/engine/components/types.ts
+++ b/src/server/plugins/engine/components/types.ts
@@ -88,7 +88,7 @@ export interface ViewModel extends Record<string, unknown> {
     classes?: string
     attributes?: string | Record<string, string>
   }
-  children?: ComponentViewModel[]
+  components?: ComponentViewModel[]
   upload?: {
     count: number
     pendingCount: number

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -119,7 +119,7 @@ export class FormModel {
     let schema = joi.object<FormSubmissionState>().required()
 
     relevantPages.forEach((page) => {
-      schema = schema.concat(page.components.stateSchema)
+      schema = schema.concat(page.collection.stateSchema)
     })
 
     return schema

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -126,7 +126,7 @@ export class SummaryViewModel {
         if (page instanceof RepeatPageController) {
           addRepeaterItem(page, request, model, state, items)
         } else {
-          for (const component of page.components.formItems) {
+          for (const component of page.collection.questions) {
             const item = Item(component, state, page, model)
             if (items.find((cbItem) => cbItem.name === item.name)) return
             items.push(item)
@@ -152,7 +152,7 @@ export class SummaryViewModel {
     const relevantPages: PageControllerClass[] = []
 
     while (nextPage != null) {
-      if (nextPage.hasFormComponents) {
+      if (nextPage.collection.questions.length) {
         relevantPages.push(nextPage)
       }
 
@@ -185,7 +185,7 @@ function addRepeaterItem(
 
   rawValue.forEach((itemState) => {
     const sub: DetailItem[] = []
-    for (const component of page.components.formItems) {
+    for (const component of page.collection.questions) {
       const item = Item(component, itemState, page, model)
       if (sub.find((cbItem) => cbItem.name === item.name)) return
       sub.push(item)

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -1,6 +1,6 @@
 import { type ValidationResult } from 'joi'
 
-import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { getError, redirectUrl } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
@@ -209,7 +209,7 @@ function addRepeaterItem(
  * Creates an Item object for Details
  */
 function Item(
-  component: FormComponentFieldClass,
+  component: Field,
   state: FormState,
   page: PageControllerClass,
   model: FormModel,

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -126,7 +126,7 @@ export class SummaryViewModel {
         if (page instanceof RepeatPageController) {
           addRepeaterItem(page, request, model, state, items)
         } else {
-          for (const component of page.collection.questions) {
+          for (const component of page.collection.fields) {
             const item = Item(component, state, page, model)
             if (items.find((cbItem) => cbItem.name === item.name)) return
             items.push(item)
@@ -152,7 +152,7 @@ export class SummaryViewModel {
     const relevantPages: PageControllerClass[] = []
 
     while (nextPage != null) {
-      if (nextPage.collection.questions.length) {
+      if (nextPage.collection.fields.length) {
         relevantPages.push(nextPage)
       }
 
@@ -185,7 +185,7 @@ function addRepeaterItem(
 
   rawValue.forEach((itemState) => {
     const sub: DetailItem[] = []
-    for (const component of page.collection.questions) {
+    for (const component of page.collection.fields) {
       const item = Item(component, itemState, page, model)
       if (sub.find((cbItem) => cbItem.name === item.name)) return
       sub.push(item)

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
@@ -30,7 +30,7 @@ describe('FileUploadPageController', () => {
 
   let page: Page
   let definition: FormDefinition
-  let formModel: FormModel
+  let model: FormModel
   let controller: FileUploadPageController
 
   beforeEach(() => {
@@ -48,17 +48,17 @@ describe('FileUploadPageController', () => {
       conditions: []
     }
 
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
 
-    controller = new FileUploadPageController(formModel, page)
+    controller = new FileUploadPageController(model, page)
   })
 
   describe('Constructor', () => {
     it('throws unless there is exactly 1 file upload component', () => {
       expect(() => {
-        const fileUploadController = new FileUploadPageController(formModel, {
+        const fileUploadController = new FileUploadPageController(model, {
           path: '/first-page',
           title: 'Upload files',
           components: [component1],
@@ -81,7 +81,7 @@ describe('FileUploadPageController', () => {
       }
 
       expect(() => {
-        const fileUploadController = new FileUploadPageController(formModel, {
+        const fileUploadController = new FileUploadPageController(model, {
           path: '/first-page',
           title: 'Upload files',
           components: [textComponent, component2],
@@ -97,7 +97,7 @@ describe('FileUploadPageController', () => {
 
   describe('Form validation', () => {
     it('includes title text and error', () => {
-      const result = controller.components.validate()
+      const result = controller.collection.validate()
 
       expect(result.errors).toEqual([
         {
@@ -115,7 +115,7 @@ describe('FileUploadPageController', () => {
     })
 
     it('includes all field errors', () => {
-      const result = controller.components.validate()
+      const result = controller.collection.validate()
       expect(result.errors).toHaveLength(1)
     })
   })

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -81,7 +81,7 @@ export class FileUploadPageController extends PageController {
     const fileUploadComponent = fileUploadComponents[0]
 
     // Assert the file upload component is the first form component
-    if (this.collection.questions[0].name !== fileUploadComponent.name) {
+    if (this.collection.fields[0].name !== fileUploadComponent.name) {
       throw Boom.badImplementation(
         `Expected '${fileUploadComponent.name}' to be the first form component in FileUploadPageController '${pageDef.path}'`
       )

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -81,7 +81,7 @@ export class FileUploadPageController extends PageController {
     const fileUploadComponent = fileUploadComponents[0]
 
     // Assert the file upload component is the first form component
-    if (this.components.formItems[0].name !== fileUploadComponent.name) {
+    if (this.collection.questions[0].name !== fileUploadComponent.name) {
       throw Boom.badImplementation(
         `Expected '${fileUploadComponent.name}' to be the first form component in FileUploadPageController '${pageDef.path}'`
       )

--- a/src/server/plugins/engine/pageControllers/PageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.test.ts
@@ -8,13 +8,13 @@ import { type FormSubmissionState } from '~/src/server/plugins/engine/types.js'
 
 describe('Condition Evaluation Context', () => {
   it('correctly includes/filters state values', () => {
-    const formModel = new FormModel(formJson as FormDefinition, {
+    const model = new FormModel(formJson as FormDefinition, {
       basePath: 'test'
     })
 
     // Selected page appears after convergence and contains a conditional field
     // This is the page we're theoretically browsing to
-    const testConditionsPage = formModel.pages.find(
+    const testConditionsPage = model.pages.find(
       (page) => page.path === '/testconditions'
     )
 
@@ -22,7 +22,7 @@ describe('Condition Evaluation Context', () => {
       throw new Error('Test conditions page not found')
     }
 
-    const page = new PageController(formModel, testConditionsPage.pageDef)
+    const page = new PageController(model, testConditionsPage.pageDef)
 
     // The state below shows we said we had a UKPassport and entered details for an applicant
     const completeState: FormSubmissionState = {
@@ -52,10 +52,7 @@ describe('Condition Evaluation Context', () => {
     }
 
     // Calculate our relevantState based on the page we're attempting to load and the above state we provide
-    let relevantState = page.getConditionEvaluationContext(
-      formModel,
-      completeState
-    )
+    let relevantState = page.getConditionEvaluationContext(model, completeState)
 
     // Our relevantState should know our first applicant
     expect(relevantState).toEqual(
@@ -75,7 +72,7 @@ describe('Condition Evaluation Context', () => {
     completeState.ukPassport = false
 
     // And recalculate our relevantState
-    relevantState = page.getConditionEvaluationContext(formModel, completeState)
+    relevantState = page.getConditionEvaluationContext(model, completeState)
 
     // Our relevantState should no longer know anything about our applicant
     expect(relevantState.applicantOneFirstName).toBeUndefined()
@@ -90,11 +87,11 @@ describe('Condition Evaluation Context', () => {
 
   describe('DatePartsField', () => {
     it('correctly transforms DateTimeParts components', () => {
-      const formModel = new FormModel(dateFormConditionJson as FormDefinition, {
+      const model = new FormModel(dateFormConditionJson as FormDefinition, {
         basePath: 'test'
       })
 
-      const testConditionsPage = formModel.pages.find(
+      const testConditionsPage = model.pages.find(
         (page) => page.path === '/page-one'
       )
 
@@ -102,7 +99,7 @@ describe('Condition Evaluation Context', () => {
         throw new Error('Test conditions page not found')
       }
 
-      const page = new PageController(formModel, testConditionsPage.pageDef)
+      const page = new PageController(model, testConditionsPage.pageDef)
 
       const completeState: FormSubmissionState = {
         progress: [],
@@ -113,7 +110,7 @@ describe('Condition Evaluation Context', () => {
 
       // get the state including our DatePartsField
       const relevantState = page.getConditionEvaluationContext(
-        formModel,
+        model,
         completeState
       )
 

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
@@ -23,16 +23,24 @@ describe('PageControllerBase', () => {
     options: {}
   }
 
+  const component3: ComponentDef = {
+    name: 'detailsField',
+    title: 'Find out more',
+    type: ComponentType.Details,
+    content: 'Some content goes here',
+    options: {}
+  }
+
   let page: Page
   let definition: FormDefinition
-  let formModel: FormModel
+  let model: FormModel
   let controller: PageControllerBase
 
   beforeEach(() => {
     page = {
       path: '/first-page',
       title: 'When will you get married?',
-      components: [component1, component2],
+      components: [component1, component2, component3],
       next: []
     }
 
@@ -43,16 +51,35 @@ describe('PageControllerBase', () => {
       conditions: []
     }
 
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
 
-    controller = new PageControllerBase(formModel, page)
+    controller = new PageControllerBase(model, page)
+  })
+
+  describe('Component collection', () => {
+    it('returns the components for the page', () => {
+      const { components } = controller.collection
+
+      expect(components).toHaveLength(3)
+      expect(components[0].name).toBe('dateField')
+      expect(components[1].name).toBe('yesNoField')
+      expect(components[2].name).toBe('detailsField')
+    })
+
+    it('returns the questions for the page', () => {
+      const { questions } = controller.collection
+
+      expect(questions).toHaveLength(2)
+      expect(questions[0].name).toBe('dateField')
+      expect(questions[1].name).toBe('yesNoField')
+    })
   })
 
   describe('Form validation', () => {
     it('includes all field errors', () => {
-      const result = controller.components.validate()
+      const result = controller.collection.validate()
       expect(result.errors).toHaveLength(4)
     })
   })

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
@@ -68,12 +68,12 @@ describe('PageControllerBase', () => {
       expect(components[2].name).toBe('detailsField')
     })
 
-    it('returns the questions for the page', () => {
-      const { questions } = controller.collection
+    it('returns the fields for the page', () => {
+      const { fields } = controller.collection
 
-      expect(questions).toHaveLength(2)
-      expect(questions[0].name).toBe('dateField')
-      expect(questions[1].name).toBe('yesNoField')
+      expect(fields).toHaveLength(2)
+      expect(fields[0].name).toBe('dateField')
+      expect(fields[1].name).toBe('yesNoField')
     })
   })
 

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -141,7 +141,7 @@ export class PageControllerBase {
 
           // Check for optional in label
           const isOptional =
-            this.collection.questions.at(0)?.options.required === false
+            this.collection.fields.at(0)?.options.required === false
 
           if (pageTitle) {
             labelOrLegend.text = isOptional
@@ -265,7 +265,7 @@ export class PageControllerBase {
 
       if (!hasRepeater(nextPage.pageDef)) {
         // Iterate all components on this page and pull out the saved values from the state
-        for (const component of nextPage.collection.questions) {
+        for (const component of nextPage.collection.fields) {
           const { name, options } = component
 
           const value = component.getFormValueFromState(state)

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -63,8 +63,8 @@ export class PageControllerBase {
   title: string
   condition?: string
   section?: Section
-  components: ComponentCollection
-  hasFormComponents: boolean
+  collection: ComponentCollection
+  errorSummaryTitle = 'There is a problem'
   viewName = 'index'
 
   constructor(model: FormModel, pageDef: Page) {
@@ -83,16 +83,14 @@ export class PageControllerBase {
     )
 
     // Components collection
-    this.components = new ComponentCollection(
+    this.collection = new ComponentCollection(
       hasComponents(pageDef) ? pageDef.components : [],
       { model, page: this }
     )
 
-    this.components.formSchema = this.components.formSchema.keys({
+    this.collection.formSchema = this.collection.formSchema.keys({
       crumb: joi.string().optional().allow('')
     })
-
-    this.hasFormComponents = !!this.components.formItems.length
   }
 
   /**
@@ -113,7 +111,7 @@ export class PageControllerBase {
 
     const serviceUrl = `/${this.model.basePath}`
 
-    const components = this.components.getViewModel(payload, errors)
+    const components = this.collection.getViewModel(payload, errors)
     const formComponents = components.filter(
       ({ isFormComponent }) => isFormComponent
     )
@@ -143,7 +141,7 @@ export class PageControllerBase {
 
           // Check for optional in label
           const isOptional =
-            this.components.formItems.at(0)?.options.required === false
+            this.collection.questions.at(0)?.options.required === false
 
           if (pageTitle) {
             labelOrLegend.text = isOptional
@@ -237,7 +235,7 @@ export class PageControllerBase {
    */
   getFormDataFromState(state: FormSubmissionState): FormPayload {
     return {
-      ...this.components.getFormDataFromState(state)
+      ...this.collection.getFormDataFromState(state)
     }
   }
 
@@ -245,7 +243,7 @@ export class PageControllerBase {
     request: FormRequestPayload,
     payload: FormRequestPayload['payload']
   ) {
-    return this.components.getStateFromValidForm(payload)
+    return this.collection.getStateFromValidForm(payload)
   }
 
   getErrors(details?: ValidationErrorItem[]) {
@@ -267,7 +265,7 @@ export class PageControllerBase {
 
       if (!hasRepeater(nextPage.pageDef)) {
         // Iterate all components on this page and pull out the saved values from the state
-        for (const component of nextPage.components.formItems) {
+        for (const component of nextPage.collection.questions) {
           const { name, options } = component
 
           const value = component.getFormValueFromState(state)
@@ -483,7 +481,7 @@ export class PageControllerBase {
   ) => Promise<ResponseObject | Boom> {
     return async (request, h) => {
       const formPayload = this.getPayload(request)
-      const formResult = this.components.validate(formPayload)
+      const formResult = this.collection.validate(formPayload)
 
       let state = await this.getState(request)
       const progress = state.progress ?? []
@@ -505,7 +503,7 @@ export class PageControllerBase {
         )
       }
 
-      const stateResult = this.components.validate(
+      const stateResult = this.collection.validate(
         this.getStateFromValidForm(request, payload),
         'stateSchema'
       )
@@ -617,7 +615,7 @@ export class PageControllerBase {
   ) {
     const viewModel = this.getViewModel(request, payload, errors)
 
-    viewModel.errors = this.components.getErrors(viewModel.errors)
+    viewModel.errors = this.collection.getErrors(viewModel.errors)
     viewModel.backLink = progress[progress.length - 2]
 
     return h.view(this.viewName, viewModel)

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
@@ -29,7 +29,7 @@ describe('RepeatPageController', () => {
 
   let page: PageRepeat
   let definition: FormDefinition
-  let formModel: FormModel
+  let model: FormModel
   let controller: RepeatPageController
 
   beforeEach(() => {
@@ -52,17 +52,17 @@ describe('RepeatPageController', () => {
       conditions: []
     }
 
-    formModel = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
 
-    controller = new RepeatPageController(formModel, page)
+    controller = new RepeatPageController(model, page)
   })
 
   describe('Constructor', () => {
     it('throws if page controller is not ControllerType.Repeat', () => {
       expect(() => {
-        const repeatController = new RepeatPageController(formModel, {
+        const repeatController = new RepeatPageController(model, {
           path: '/first-page',
           title: 'Pizza',
           components: [component1],
@@ -76,7 +76,7 @@ describe('RepeatPageController', () => {
 
   describe('Form validation', () => {
     it('includes title text and errors', () => {
-      const result = controller.components.validate()
+      const result = controller.collection.validate()
 
       expect(result.errors).toEqual<FormSubmissionError[]>([
         {
@@ -115,7 +115,7 @@ describe('RepeatPageController', () => {
     })
 
     it('includes all field errors', () => {
-      const result = controller.components.validate()
+      const result = controller.collection.validate()
       expect(result.errors).toHaveLength(3)
     })
   })

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -53,10 +53,10 @@ export class RepeatPageController extends PageController {
     const { options, schema } = this.repeat
     const itemId = Joi.string().uuid().required()
 
-    this.components.formSchema = this.components.formSchema.append({ itemId })
-    this.components.stateSchema = Joi.object<RepeatState>().keys({
+    this.collection.formSchema = this.collection.formSchema.append({ itemId })
+    this.collection.stateSchema = Joi.object<RepeatState>().keys({
       [options.name]: Joi.array()
-        .items(this.components.stateSchema.append({ itemId }))
+        .items(this.collection.stateSchema.append({ itemId }))
         .min(schema.min)
         .max(schema.max)
         .label(`${options.title} list`)
@@ -363,7 +363,7 @@ export class RepeatPageController extends PageController {
     const { title } = this.repeat.options
     const sectionTitle = section?.hideTitle !== true ? section?.title : ''
     const serviceUrl = `/${model.basePath}`
-    const firstQuestion = this.components.formItems.at(0)
+    const firstQuestion = this.collection.questions.at(0)
     const rows: Row[] = []
     let count = 0
 

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -359,11 +359,11 @@ export class RepeatPageController extends PageController {
     repeatTitle: string
     backLink?: string
   } {
-    const { section, model } = this
-    const { title } = this.repeat.options
+    const { collection, model, repeat, section } = this
+
+    const { title } = repeat.options
     const sectionTitle = section?.hideTitle !== true ? section?.title : ''
     const serviceUrl = `/${model.basePath}`
-    const firstQuestion = this.collection.questions.at(0)
     const rows: Row[] = []
     let count = 0
 
@@ -389,8 +389,8 @@ export class RepeatPageController extends PageController {
           })
         }
 
-        const itemDisplayText: string = firstQuestion
-          ? firstQuestion.getDisplayStringFromState(item)
+        const itemDisplayText = collection.fields.length
+          ? collection.fields[0].getDisplayStringFromState(item)
           : ''
 
         rows.push({

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -119,8 +119,8 @@ export class SummaryPageController extends PageController {
             let conditionMatches = true
             if (property) {
               propertyMatches =
-                page.components.formItems.filter(
-                  (item) => item.name === property
+                page.collection.questions.filter(
+                  (component) => component.name === property
                 ).length > 0
             }
             if (
@@ -244,7 +244,7 @@ async function extendFileRetention(
   // For each file upload component with files in
   // state, add the files to the batch getting persisted
   model.pages.forEach((page) => {
-    const fileUploadComponents = page.components.formItems.filter(
+    const fileUploadComponents = page.collection.questions.filter(
       (component) => component instanceof FileUploadField
     )
 

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -119,7 +119,7 @@ export class SummaryPageController extends PageController {
             let conditionMatches = true
             if (property) {
               propertyMatches =
-                page.collection.questions.filter(
+                page.collection.fields.filter(
                   (component) => component.name === property
                 ).length > 0
             }
@@ -244,7 +244,7 @@ async function extendFileRetention(
   // For each file upload component with files in
   // state, add the files to the batch getting persisted
   model.pages.forEach((page) => {
-    const fileUploadComponents = page.collection.questions.filter(
+    const fileUploadComponents = page.collection.fields.filter(
       (component) => component instanceof FileUploadField
     )
 

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -43,7 +43,7 @@ import {
   type FormRequestPayloadRefs,
   type FormRequestRefs
 } from '~/src/server/routes/types.js'
-import { type Field } from '~/src/server/schemas/types.js'
+import { type FieldSummary } from '~/src/server/schemas/types.js'
 import { sendNotification } from '~/src/server/utils/notify.js'
 
 const designerUrl = config.get('designerUrl')
@@ -52,7 +52,7 @@ const templateId = config.get('notifyTemplateId')
 interface QuestionRecord {
   title: string
   value: string
-  field: Field
+  field: FieldSummary
 }
 
 export class SummaryPageController extends PageController {
@@ -482,7 +482,7 @@ function getFormSubmissionData(
     )
 
     const fields = itemsForPage.flatMap((item) => {
-      return [detailItemToField(item)]
+      return [toFieldSummary(item)]
     })
 
     return {
@@ -540,7 +540,7 @@ export function answerFromDetailItem(item: DetailItem) {
   return value
 }
 
-function detailItemToField(item: DetailItem): Field {
+function toFieldSummary(item: DetailItem): FieldSummary {
   return {
     key: item.name,
     title: item.title,

--- a/src/server/plugins/engine/views/components/ukaddressfield.html
+++ b/src/server/plugins/engine/views/components/ukaddressfield.html
@@ -4,7 +4,7 @@
 
 {% macro UkAddressField(component) %}
   {% set fieldset = component.model.fieldset %}
-  {% set addressFieldHtml = componentList(component.model.children) %}
+  {% set addressFieldHtml = componentList(component.model.components) %}
 
   {% if component.model.hint %}
     {% set addressHintHtml %}

--- a/src/server/schemas/types.ts
+++ b/src/server/schemas/types.ts
@@ -1,6 +1,6 @@
 import { type DetailItem } from '~/src/server/plugins/engine/models/types.js'
 
-export interface Field {
+export interface FieldSummary {
   key: string
   type: DetailItem['dataType']
   title: DetailItem['title']


### PR DESCRIPTION
This is a tidy up PR to align collection fields with component fields to avoid confusion

All fields now have `this.parent` to determine if they're part of a collection

## Single fields

* Added `this.parent` to match collection fields
* Renamed view model `children` to `components`
* Updated constructor to `new FormComponent(def, { parent, model }})`

## Collection fields

* Renamed `items` to `components`
* Renamed `formitems` to `fields`
* Added `this.parent` in [#509](https://github.com/DEFRA/forms-runner/pull/509)
* Updated constructor in [#509](https://github.com/DEFRA/forms-runner/pull/509) to `new ComponentCollection(def, { parent, model }, schema})`