### PR TITLE
Remove optional text from fields when shown in legend

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -8,7 +8,6 @@ import {
   isFormState
 } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { NumberField } from '~/src/server/plugins/engine/components/NumberField.js'
-import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
 import {
   DataType,
   type DateInputItem
@@ -36,7 +35,6 @@ export class DatePartsField extends FormComponent {
     const { name, options, title } = def
 
     const isRequired = options.required !== false
-    const hideOptional = options.optionalText
 
     this.children = new ComponentCollection(
       [
@@ -47,7 +45,7 @@ export class DatePartsField extends FormComponent {
           schema: { min: 1, max: 31, precision: 0 },
           options: {
             required: isRequired,
-            optionalText: !isRequired && hideOptional,
+            optionalText: true,
             classes: 'govuk-input--width-2',
             customValidationMessage: `${title} must include a {{#label}}`
           }
@@ -59,7 +57,7 @@ export class DatePartsField extends FormComponent {
           schema: { min: 1, max: 12, precision: 0 },
           options: {
             required: isRequired,
-            optionalText: !isRequired && hideOptional,
+            optionalText: true,
             classes: 'govuk-input--width-2',
             customValidationMessage: `${title} must include a {{#label}}`
           }
@@ -71,7 +69,7 @@ export class DatePartsField extends FormComponent {
           schema: { min: 1000, max: 3000, precision: 0 },
           options: {
             required: isRequired,
-            optionalText: !isRequired && hideOptional,
+            optionalText: true,
             classes: 'govuk-input--width-4',
             customValidationMessage: `${title} must include a {{#label}}`
           }
@@ -147,7 +145,6 @@ export class DatePartsField extends FormComponent {
         let { label, type, value, classes, errorMessage } = model
 
         if (label) {
-          label.text = label.text.replace(optionalText, '')
           label.toString = () => label.text // Date component uses string labels
         }
 

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -7,7 +7,6 @@ import {
   isFormState
 } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { NumberField } from '~/src/server/plugins/engine/components/NumberField.js'
-import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
 import {
   DataType,
   type DateInputItem
@@ -35,7 +34,6 @@ export class MonthYearField extends FormComponent {
     const { name, options, title } = def
 
     const isRequired = options.required !== false
-    const hideOptional = options.optionalText
 
     this.children = new ComponentCollection(
       [
@@ -46,7 +44,7 @@ export class MonthYearField extends FormComponent {
           schema: { min: 1, max: 12, precision: 0 },
           options: {
             required: isRequired,
-            optionalText: !isRequired && hideOptional,
+            optionalText: true,
             classes: 'govuk-input--width-2',
             customValidationMessage: `${title} must include a {{#label}}`
           }
@@ -58,7 +56,7 @@ export class MonthYearField extends FormComponent {
           schema: { min: 1000, max: 3000, precision: 0 },
           options: {
             required: isRequired,
-            optionalText: !isRequired && hideOptional,
+            optionalText: true,
             classes: 'govuk-input--width-4',
             customValidationMessage: `${title} must include a {{#label}}`
           }
@@ -123,7 +121,6 @@ export class MonthYearField extends FormComponent {
         let { label, type, value, classes, errorMessage } = model
 
         if (label) {
-          label.text = label.text.replace(optionalText, '')
           label.toString = () => label.text // Date component uses string labels
         }
 

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -30,7 +30,8 @@ export class UkAddressField extends FormComponent {
     const { name, options, title } = def
 
     const isRequired = options.required !== false
-    const hideOptional = options.optionalText
+    const hideOptional = !!options.optionalText
+    const hideTitle = !!options.hideTitle
 
     this.children = new ComponentCollection(
       [
@@ -42,7 +43,7 @@ export class UkAddressField extends FormComponent {
           options: {
             autocomplete: 'address-line1',
             required: isRequired,
-            optionalText: !isRequired && hideOptional
+            optionalText: !isRequired && (hideOptional || !hideTitle)
           }
         },
         {
@@ -53,7 +54,7 @@ export class UkAddressField extends FormComponent {
           options: {
             autocomplete: 'address-line2',
             required: false,
-            optionalText: !isRequired && hideOptional
+            optionalText: !isRequired && (hideOptional || !hideTitle)
           }
         },
         {
@@ -65,7 +66,7 @@ export class UkAddressField extends FormComponent {
             autocomplete: 'address-level2',
             classes: 'govuk-!-width-two-thirds',
             required: isRequired,
-            optionalText: !isRequired && hideOptional
+            optionalText: !isRequired && (hideOptional || !hideTitle)
           }
         },
         {
@@ -79,7 +80,7 @@ export class UkAddressField extends FormComponent {
             autocomplete: 'postal-code',
             classes: 'govuk-input--width-10',
             required: isRequired,
-            optionalText: !isRequired && hideOptional
+            optionalText: !isRequired && (hideOptional || !hideTitle)
           }
         }
       ],


### PR DESCRIPTION
This PR closes [bug #468636](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/468636)

It partially reverts a previous change to add "**(optional)**" to form fields with legends

## Before
The optional text is shown in the legend and child fields

<img width="684" alt="Optional before" src="https://github.com/user-attachments/assets/42c3defa-4ff0-40a4-a039-db528e70a1ac">

## After
The optional text is shown only in the legend unless the component title is hidden

<img width="654" alt="Optional after" src="https://github.com/user-attachments/assets/d5a9c787-f04a-4673-ac56-ec473a4c25de">
