### PR TITLE
Add service status banner

### DIFF
--- a/src/client/stylesheets/_service-banner.scss
+++ b/src/client/stylesheets/_service-banner.scss
@@ -1,0 +1,24 @@
+@use "govuk-frontend" as *;
+
+.app-service-banner {
+  display: block;
+  background: govuk-colour("yellow");
+  color: govuk-colour("black");
+
+  @include govuk-responsive-padding(2, "top");
+  @include govuk-responsive-padding(2, "bottom");
+
+  &__content {
+    margin: 0;
+  }
+
+  .govuk-warning-text__text {
+    font-weight: $govuk-font-weight-regular;
+  }
+
+  .govuk-skip-link:active + &,
+  .govuk-skip-link:focus + & {
+    // Ofset service banner from skip link
+    margin-top: $govuk-border-width + $govuk-focus-width;
+  }
+}

--- a/src/client/stylesheets/application.scss
+++ b/src/client/stylesheets/application.scss
@@ -9,3 +9,13 @@
 .autocomplete__option {
   @include govuk-typography-common;
 }
+
+.dxt-announcement-bar {
+  background: #ffcc00;
+  text-align: center;
+  padding: 0.5rem;
+
+  p {
+    margin: 0;
+  }
+}

--- a/src/client/stylesheets/application.scss
+++ b/src/client/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @use "govuk-frontend" as *;
 @use "pkg:accessible-autocomplete";
+@use "service-banner";
 @use "summary-list";
 @use "prose";
 
@@ -8,14 +9,4 @@
 .autocomplete__input,
 .autocomplete__option {
   @include govuk-typography-common;
-}
-
-.dxt-announcement-bar {
-  background: #ffcc00;
-  text-align: center;
-  padding: 0.5rem;
-
-  p {
-    margin: 0;
-  }
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -195,11 +195,11 @@ export const config = convict({
     env: 'STAGING_PREFIX'
   },
 
-  announcementContent: {
-    doc: 'A user-visible global announcement to inform the the user. Set no empty to hide.',
+  serviceBannerText: {
+    doc: 'Service banner text used to show a maintenance message on all pages when set',
     format: String,
     default: '',
-    env: 'ANNOUNCEMENT_CONTENT'
+    env: 'SERVICE_BANNER_TEXT'
   }
 })
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -193,6 +193,13 @@ export const config = convict({
     format: String,
     default: 'staging',
     env: 'STAGING_PREFIX'
+  },
+
+  announcementContent: {
+    doc: 'A user-visible global announcement to inform the the user. Set no empty to hide.',
+    format: String,
+    default: '',
+    env: 'ANNOUNCEMENT_CONTENT'
   }
 })
 

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,6 +1,5 @@
 import { type Server } from '@hapi/hapi'
 
-import { config } from '~/src/config/index.js'
 import { createServer } from '~/src/server/index.js'
 import {
   getFormDefinition,
@@ -8,7 +7,6 @@ import {
 } from '~/src/server/plugins/engine/services/formsService.js'
 import { FormStatus } from '~/src/server/routes/types.js'
 import * as fixtures from '~/test/fixtures/index.js'
-import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
@@ -469,52 +467,5 @@ describe('Model cache', () => {
 
       expect(res.statusCode).toBe(okStatusCode)
     })
-  })
-})
-
-describe('Base pages', () => {
-  let server: Server
-
-  beforeAll(async () => {
-    server = await createServer()
-    await server.initialize()
-  })
-
-  afterAll(async () => {
-    await server.stop()
-  })
-
-  test('The announcement bar is shown', async () => {
-    config.set('announcementContent', 'Hello world')
-
-    const options = {
-      method: 'GET',
-      url: '/'
-    }
-
-    const { container } = await renderResponse(server, options)
-
-    const $announcement = container.getByRole('region', {
-      name: 'Announcement'
-    })
-
-    expect($announcement).toHaveTextContent('Hello world')
-  })
-
-  test('The announcement bar is not shown', async () => {
-    config.set('announcementContent', '')
-
-    const options = {
-      method: 'GET',
-      url: '/'
-    }
-
-    const { container } = await renderResponse(server, options)
-
-    const $announcement = container.queryByRole('region', {
-      name: 'Announcement'
-    })
-
-    expect($announcement).toBeNull()
   })
 })

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,5 +1,6 @@
 import { type Server } from '@hapi/hapi'
 
+import { config } from '~/src/config/index.js'
 import { createServer } from '~/src/server/index.js'
 import {
   getFormDefinition,
@@ -7,6 +8,7 @@ import {
 } from '~/src/server/plugins/engine/services/formsService.js'
 import { FormStatus } from '~/src/server/routes/types.js'
 import * as fixtures from '~/test/fixtures/index.js'
+import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
@@ -467,5 +469,52 @@ describe('Model cache', () => {
 
       expect(res.statusCode).toBe(okStatusCode)
     })
+  })
+})
+
+describe('Base pages', () => {
+  let server: Server
+
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  test('The announcement bar is shown', async () => {
+    config.set('announcementContent', 'Hello world')
+
+    const options = {
+      method: 'GET',
+      url: '/'
+    }
+
+    const { container } = await renderResponse(server, options)
+
+    const $announcement = container.getByRole('region', {
+      name: 'Announcement'
+    })
+
+    expect($announcement).toHaveTextContent('Hello world')
+  })
+
+  test('The announcement bar is not shown', async () => {
+    config.set('announcementContent', '')
+
+    const options = {
+      method: 'GET',
+      url: '/'
+    }
+
+    const { container } = await renderResponse(server, options)
+
+    const $announcement = container.queryByRole('region', {
+      name: 'Announcement'
+    })
+
+    expect($announcement).toBeNull()
   })
 })

--- a/src/server/plugins/views.ts
+++ b/src/server/plugins/views.ts
@@ -67,6 +67,7 @@ function nunjucksContext(request: FormRequest | FormRequestPayload | null) {
     phaseTag: config.get('phaseTag'),
     previewMode: isPreviewMode ? params?.state : undefined,
     slug: params?.slug,
+    announcementContent: config.get('announcementContent'),
 
     getAssetPath(asset: string) {
       const webpackAssetPath = webpackManifest?.[asset] ?? asset

--- a/src/server/plugins/views.ts
+++ b/src/server/plugins/views.ts
@@ -63,11 +63,11 @@ function nunjucksContext(request: FormRequest | FormRequestPayload | null) {
     appVersion: pkg.version,
     assetPath: '/assets',
     serviceName: capitalize(config.get('serviceName')),
+    serviceBannerText: config.get('serviceBannerText'),
     feedbackLink: encodeUrl(config.get('feedbackLink')),
     phaseTag: config.get('phaseTag'),
     previewMode: isPreviewMode ? params?.state : undefined,
     slug: params?.slug,
-    announcementContent: config.get('announcementContent'),
 
     getAssetPath(asset: string) {
       const webpackAssetPath = webpackManifest?.[asset] ?? asset

--- a/src/server/routes/index.test.ts
+++ b/src/server/routes/index.test.ts
@@ -1,5 +1,6 @@
 import { type Server } from '@hapi/hapi'
 
+import { config } from '~/src/config/index.js'
 import { createServer } from '~/src/server/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
@@ -58,5 +59,48 @@ describe('Routes', () => {
     const res = await server.inject(options)
 
     expect(res.statusCode).toBe(200)
+  })
+
+  test('Service banner is not shown by default', async () => {
+    const { container } = await renderResponse(server, {
+      method: 'GET',
+      url: '/'
+    })
+
+    const $banner = container.queryByRole('complementary', {
+      name: 'Service status'
+    })
+
+    expect($banner).not.toBeInTheDocument()
+  })
+
+  test('Service banner is not shown when empty', async () => {
+    config.set('serviceBannerText', '')
+
+    const { container } = await renderResponse(server, {
+      method: 'GET',
+      url: '/'
+    })
+
+    const $banner = container.queryByRole('complementary', {
+      name: 'Service status'
+    })
+
+    expect($banner).not.toBeInTheDocument()
+  })
+
+  test('Service banner is shown when configured', async () => {
+    config.set('serviceBannerText', 'Hello world')
+
+    const { container } = await renderResponse(server, {
+      method: 'GET',
+      url: '/'
+    })
+
+    const $banner = container.getByRole('complementary', {
+      name: 'Service status'
+    })
+
+    expect($banner).toHaveTextContent('Hello world')
   })
 })

--- a/src/server/views/components/service-banner/macro.njk
+++ b/src/server/views/components/service-banner/macro.njk
@@ -1,0 +1,3 @@
+{% macro appServiceBanner(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/server/views/components/service-banner/template.njk
+++ b/src/server/views/components/service-banner/template.njk
@@ -1,0 +1,20 @@
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText -%}
+
+{%- macro _message(params) %}
+  <span class="govuk-!-font-weight-bold" aria-hidden="true">{{ params.title }}:</span>
+  <span class="app-service-banner__text">{{ params.text if params.text else params.html | safe }}</span>
+{% endmacro -%}
+
+{%- macro _iconFallback(params) %}
+  <span id="app-service-banner-description">{{ params.title }}</span>
+{% endmacro -%}
+
+<aside class="app-service-banner" aria-labelledby="app-service-banner-description" aria-live="polite">
+  <div class="govuk-width-container">
+    {{ govukWarningText({
+      html: _message(params) | trim | indent(2, true),
+      iconFallbackText: _iconFallback(params) | safe | trim,
+      classes: "app-service-banner__content"
+    }) | trim | indent(4) }}
+  </div>
+</aside>

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -26,9 +26,9 @@
 
 {% block header %}
   {% if announcementContent %}
-    <div class="dxt-announcement-bar" role="region" aria-live="polite" aria-label="Announcement">
+    <section class="dxt-announcement-bar" aria-live="polite" aria-label="Announcement">
       <p class="govuk-body">{{ announcementContent | safe }}</p>
-    </div>
+    </section>
   {% endif %}
 
   {{ govukHeader({

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -26,10 +26,10 @@
 
 
 {% block header %}
-  {% if announcementContent %}
+  {% if serviceBannerText | length %}
     {{ appServiceBanner({
       title: "Service status",
-      text: announcementContent
+      text: serviceBannerText
     }) }}
   {% endif %}
 

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -5,6 +5,7 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink -%}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "components/service-banner/macro.njk" import appServiceBanner -%}
 
 {% block head %}
   <link rel="preload" as="font" href="{{ assetPath }}/fonts/bold-b542beb274-v2.woff2" type="font/woff2" crossorigin="anonymous">
@@ -26,9 +27,10 @@
 
 {% block header %}
   {% if announcementContent %}
-    <section class="dxt-announcement-bar" aria-live="polite" aria-label="Announcement">
-      <p class="govuk-body">{{ announcementContent | safe }}</p>
-    </section>
+    {{ appServiceBanner({
+      title: "Service status",
+      text: announcementContent
+    }) }}
   {% endif %}
 
   {{ govukHeader({
@@ -37,7 +39,6 @@
     serviceName: name if name else serviceName,
     serviceUrl: serviceUrl
   }) }}
-
 {% endblock %}
 
 {% block beforeContent %}

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -25,12 +25,18 @@
 
 
 {% block header %}
+  {% if announcementContent %}
+    <div class="dxt-announcement-bar" role="region" aria-live="polite" aria-label="Announcement">
+      <p class="govuk-body">{{ announcementContent | safe }}</p>
+    </div>
+  {% endif %}
+
   {{ govukHeader({
     homepageUrl: "https://www.gov.uk",
     containerClasses: "govuk-width-container",
     serviceName: name if name else serviceName,
     serviceUrl: serviceUrl
-}) }}
+  }) }}
 
 {% endblock %}
 


### PR DESCRIPTION
Adds an announcement bar that can be toggled on/off with the `SERVICE_BANNER_TEXT` environment variable

Styling provided by design team:

<img width="1129" alt="Status message" src="https://github.com/user-attachments/assets/6690e6a3-c998-4c40-b49b-281397608335">
