### PR TITLE
Allow non-numbers in Number field payload on error etc

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -319,6 +319,34 @@ describe('DatePartsField', () => {
         )
       })
 
+      it('sets Nunjucks component value when invalid', () => {
+        const payload = getFormData({
+          day: 'DD',
+          month: 'MM',
+          year: 'YYYY'
+        })
+
+        const viewModel = component.getViewModel(payload)
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            items: [
+              expect.objectContaining(
+                getViewModel(date, 'day', { value: 'DD' })
+              ),
+
+              expect.objectContaining(
+                getViewModel(date, 'month', { value: 'MM' })
+              ),
+
+              expect.objectContaining(
+                getViewModel(date, 'year', { value: 'YYYY' })
+              )
+            ]
+          })
+        )
+      })
+
       it('sets Nunjucks component fieldset', () => {
         const payload = getFormData(date)
         const viewModel = component.getViewModel(payload)
@@ -663,7 +691,9 @@ function getViewModel(
   overrides?: Partial<DateInputItem>
 ): DateInputItem {
   const payload = getFormData(date)
+
   const fieldName = `myComponent__${name}`
+  const fieldValue = overrides?.value ?? payload[fieldName]
   const fieldClasses = overrides?.classes ?? expect.any(String)
 
   return {
@@ -674,7 +704,7 @@ function getViewModel(
     ),
     name: fieldName,
     id: fieldName,
-    value: payload[fieldName] as number,
+    value: fieldValue as DateInputItem['value'],
     classes: fieldClasses,
     type: 'number'
   }

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -5,7 +5,8 @@ import { type CustomValidator, type ObjectSchema } from 'joi'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import {
   FormComponent,
-  isFormState
+  isFormState,
+  isFormValue
 } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { NumberField } from '~/src/server/plugins/engine/components/NumberField.js'
 import {
@@ -149,7 +150,9 @@ export class DatePartsField extends FormComponent {
           classes = `${classes} govuk-input--error`.trim()
         }
 
-        if (!NumberField.isNumber(value)) {
+        // Allow any `toString()`-able value so non-numeric
+        // values are shown alongside their error messages
+        if (!isFormValue(value)) {
           value = undefined
         }
 

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -35,6 +35,7 @@ export class ListFormComponent extends FormComponent {
     | ArraySchema<number>
     | BooleanSchema<string>
     | NumberSchema<string>
+    | NumberSchema
     | StringSchema
 
   declare stateSchema:
@@ -42,6 +43,7 @@ export class ListFormComponent extends FormComponent {
     | ArraySchema<number>
     | BooleanSchema<string>
     | NumberSchema<string>
+    | NumberSchema
     | StringSchema
 
   list?: List

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -275,6 +275,29 @@ describe('MonthYearField', () => {
         )
       })
 
+      it('sets Nunjucks component value when invalid', () => {
+        const payload = getFormData({
+          month: 'MM',
+          year: 'YYYY'
+        })
+
+        const viewModel = component.getViewModel(payload)
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            items: [
+              expect.objectContaining(
+                getViewModel(date, 'month', { value: 'MM' })
+              ),
+
+              expect.objectContaining(
+                getViewModel(date, 'year', { value: 'YYYY' })
+              )
+            ]
+          })
+        )
+      })
+
       it('sets Nunjucks component fieldset', () => {
         const payload = getFormData(date)
         const viewModel = component.getViewModel(payload)
@@ -451,7 +474,9 @@ function getViewModel(
   overrides?: Partial<DateInputItem>
 ): DateInputItem {
   const payload = getFormData(date)
+
   const fieldName = `myComponent__${name}`
+  const fieldValue = overrides?.value ?? payload[fieldName]
   const fieldClasses = overrides?.classes ?? expect.any(String)
 
   return {
@@ -462,7 +487,7 @@ function getViewModel(
     ),
     name: fieldName,
     id: fieldName,
-    value: payload[fieldName] as number,
+    value: fieldValue as DateInputItem['value'],
     classes: fieldClasses,
     type: 'number'
   }

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -4,7 +4,8 @@ import { type CustomValidator, type ObjectSchema } from 'joi'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import {
   FormComponent,
-  isFormState
+  isFormState,
+  isFormValue
 } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { NumberField } from '~/src/server/plugins/engine/components/NumberField.js'
 import {
@@ -128,7 +129,9 @@ export class MonthYearField extends FormComponent {
           classes = `${classes} govuk-input--error`.trim()
         }
 
-        if (!NumberField.isNumber(value)) {
+        // Allow any `toString()`-able value so non-numeric
+        // values are shown alongside their error messages
+        if (!isFormValue(value)) {
           value = undefined
         }
 

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -205,6 +205,11 @@ describe('NumberField', () => {
         )
       })
     })
+
+    it('sets Nunjucks component value when invalid', () => {
+      const viewModel = component.getViewModel(getFormData('AA'))
+      expect(viewModel).toEqual(expect.objectContaining({ value: 'AA' }))
+    })
   })
 
   describe('Validation', () => {

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -1,7 +1,10 @@
 import { type NumberFieldComponent } from '@defra/forms-model'
 import joi, { type CustomValidator, type NumberSchema } from 'joi'
 
-import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
+import {
+  FormComponent,
+  isFormValue
+} from '~/src/server/plugins/engine/components/FormComponent.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { messageTemplate } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 import {
@@ -95,7 +98,9 @@ export class NumberField extends FormComponent {
       }
     }
 
-    if (!this.isValue(value)) {
+    // Allow any `toString()`-able value so non-numeric
+    // values are shown alongside their error messages
+    if (!isFormValue(value)) {
       value = undefined
     }
 

--- a/src/server/plugins/engine/components/types.ts
+++ b/src/server/plugins/engine/components/types.ts
@@ -35,7 +35,7 @@ export interface DateInputItem {
   type?: string
   id?: string
   name?: string
-  value?: number
+  value?: Item['value']
   classes?: string
   condition?: undefined
 }


### PR DESCRIPTION
This PR adjusts `FormData` checks for [bug #414012](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/414012) to allow invalid values to be rendered alongside their errors

It loosens type checks from [PR #470](https://github.com/DEFRA/forms-runner/pull/470) for `FormData` as the Number field can use any `toString()`-able value

## Before

<img width="327" alt="Before, text values like AA are removed" src="https://github.com/user-attachments/assets/615a77b0-668f-421e-8dec-7d13e161b064">

## After

<img width="314" alt="After, text values like AA are preserved" src="https://github.com/user-attachments/assets/41b7ebae-4898-4d77-964f-2400217d229b">
