### PR TITLE
Test all fields using component collections

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -51,28 +51,52 @@ describe('DatePartsField', () => {
     describe('Schema', () => {
       it('uses collection titles as labels', () => {
         const { formSchema } = collection
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().keys).toEqual(
+        expect(keys).toHaveProperty(
+          'myComponent__day',
           expect.objectContaining({
-            myComponent__day: expect.objectContaining({
-              flags: expect.objectContaining({ label: 'day' })
-            }),
-            myComponent__month: expect.objectContaining({
-              flags: expect.objectContaining({ label: 'month' })
-            }),
-            myComponent__year: expect.objectContaining({
-              flags: expect.objectContaining({ label: 'year' })
-            })
+            flags: expect.objectContaining({ label: 'day' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__month',
+          expect.objectContaining({
+            flags: expect.objectContaining({ label: 'month' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__year',
+          expect.objectContaining({
+            flags: expect.objectContaining({ label: 'year' })
           })
         )
       })
 
       it('is required by default', () => {
         const { formSchema } = collection
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().flags).toEqual(
+        expect(keys).toHaveProperty(
+          'myComponent__day',
           expect.objectContaining({
-            presence: 'required'
+            flags: expect.objectContaining({ presence: 'required' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__month',
+          expect.objectContaining({
+            flags: expect.objectContaining({ presence: 'required' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__year',
+          expect.objectContaining({
+            flags: expect.objectContaining({ presence: 'required' })
           })
         )
       })
@@ -91,19 +115,21 @@ describe('DatePartsField', () => {
         )
 
         const { formSchema } = collectionOptional
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().keys).toEqual(
-          expect.objectContaining({
-            myComponent__day: expect.objectContaining({
-              allow: ['']
-            }),
-            myComponent__month: expect.objectContaining({
-              allow: ['']
-            }),
-            myComponent__year: expect.objectContaining({
-              allow: ['']
-            })
-          })
+        expect(keys).toHaveProperty(
+          'myComponent__day',
+          expect.objectContaining({ allow: [''] })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__month',
+          expect.objectContaining({ allow: [''] })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__year',
+          expect.objectContaining({ allow: [''] })
         )
 
         // Empty optional payload (valid)
@@ -119,7 +145,7 @@ describe('DatePartsField', () => {
         // Partial optional payload (invalid)
         const result2 = formSchema.validate(
           getFormData({
-            day: 31,
+            day: '31',
             month: '',
             year: ''
           }),
@@ -196,8 +222,20 @@ describe('DatePartsField', () => {
       it('adds errors for invalid values', () => {
         const { formSchema } = collection
 
-        const result1 = formSchema.validate(['invalid'], opts)
-        const result2 = formSchema.validate({ unknown: 'invalid' }, opts)
+        const result1 = formSchema.validate(
+          getFormData({ unknown: 'invalid' }),
+          opts
+        )
+
+        const result2 = formSchema.validate(
+          getFormData({
+            day: ['invalid'],
+            month: ['invalid'],
+            year: ['invalid']
+          }),
+          opts
+        )
+
         const result3 = formSchema.validate(
           getFormData({
             day: 'invalid',

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -106,7 +106,7 @@ export class FileUploadField extends FormComponent {
       .required()
 
     if (options.required === false) {
-      formSchema = formSchema.optional().allow(null)
+      formSchema = formSchema.optional()
     }
 
     if (typeof schema.length !== 'number') {
@@ -121,8 +121,12 @@ export class FileUploadField extends FormComponent {
       formSchema = formSchema.length(schema.length)
     }
 
-    this.formSchema = formSchema.items(formItemSchema).empty(null)
-    this.stateSchema = formSchema.items(formItemSchema)
+    this.formSchema = formSchema.items(formItemSchema)
+    this.stateSchema = formSchema
+      .items(formItemSchema)
+      .default(null)
+      .allow(null)
+
     this.options = options
     this.schema = schema
   }

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -51,8 +51,9 @@ describe('MonthYearField', () => {
     describe('Schema', () => {
       it('uses collection titles as labels', () => {
         const { formSchema } = collection
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().keys).toEqual(
+        expect(keys).toEqual(
           expect.objectContaining({
             myComponent__month: expect.objectContaining({
               flags: expect.objectContaining({ label: 'month' })
@@ -66,10 +67,16 @@ describe('MonthYearField', () => {
 
       it('is required by default', () => {
         const { formSchema } = collection
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().flags).toEqual(
+        expect(keys).toEqual(
           expect.objectContaining({
-            presence: 'required'
+            myComponent__month: expect.objectContaining({
+              flags: expect.objectContaining({ presence: 'required' })
+            }),
+            myComponent__year: expect.objectContaining({
+              flags: expect.objectContaining({ presence: 'required' })
+            })
           })
         )
       })
@@ -88,8 +95,9 @@ describe('MonthYearField', () => {
         )
 
         const { formSchema } = collectionOptional
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().keys).toEqual(
+        expect(keys).toEqual(
           expect.objectContaining({
             myComponent__month: expect.objectContaining({
               allow: ['']
@@ -112,7 +120,7 @@ describe('MonthYearField', () => {
         // Partial optional payload (invalid)
         const result2 = formSchema.validate(
           getFormData({
-            month: 12,
+            month: '12',
             year: ''
           }),
           opts

--- a/src/server/plugins/engine/components/RadiosField.test.ts
+++ b/src/server/plugins/engine/components/RadiosField.test.ts
@@ -4,7 +4,9 @@ import {
   type RadiosFieldComponent
 } from '@defra/forms-model'
 
+import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { RadiosField } from '~/src/server/plugins/engine/components/RadiosField.js'
+import { type FormComponentFieldClass } from '~/src/server/plugins/engine/components/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { validationOptions as opts } from '~/src/server/plugins/engine/pageControllers/validationOptions.js'
 import {
@@ -55,60 +57,76 @@ describe.each([
   } satisfies FormDefinition
 
   let formModel: FormModel
-  let component: RadiosField
-  let label: string
+  let collection: ComponentCollection
+  let component: FormComponentFieldClass
 
   beforeEach(() => {
     formModel = new FormModel(definition, {
       basePath: 'test'
     })
 
-    component = new RadiosField(def, formModel)
-    label = def.title.toLowerCase()
+    collection = new ComponentCollection([def], { model: formModel })
+    component = collection.formItems[0]
   })
 
   describe('Defaults', () => {
     describe('Schema', () => {
       it('uses component title as label', () => {
-        const { formSchema } = component
+        const { formSchema } = collection
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().flags).toEqual(
-          expect.objectContaining({ label })
+        expect(keys).toHaveProperty(
+          'myComponent',
+          expect.objectContaining({
+            flags: expect.objectContaining({
+              label: def.title.toLowerCase()
+            })
+          })
         )
       })
 
       it('is required by default', () => {
-        const { formSchema } = component
+        const { formSchema } = collection
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().flags).toEqual(
+        expect(keys).toHaveProperty(
+          'myComponent',
           expect.objectContaining({
-            presence: 'required'
+            flags: expect.objectContaining({
+              presence: 'required'
+            })
           })
         )
       })
 
       it('is optional when configured', () => {
-        const componentOptional = new RadiosField(
-          { ...def, options: { required: false } },
-          formModel
+        const collectionOptional = new ComponentCollection(
+          [{ ...def, options: { required: false } }],
+          { model: formModel }
         )
 
-        const { formSchema } = componentOptional
+        const { formSchema } = collectionOptional
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().flags).toEqual(
+        expect(keys).toHaveProperty(
+          'myComponent',
           expect.objectContaining({
-            presence: 'optional'
+            flags: expect.objectContaining({
+              presence: 'optional'
+            })
           })
         )
 
-        const result = formSchema.validate(undefined, opts)
+        const result = formSchema.validate(getFormData(), opts)
         expect(result.error).toBeUndefined()
       })
 
       it('is configured with radio items', () => {
-        const { formSchema } = component
+        const { formSchema } = collection
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe()).toEqual(
+        expect(keys).toHaveProperty(
+          'myComponent',
           expect.objectContaining({
             allow: options.allow,
             type: options.list.type
@@ -117,29 +135,33 @@ describe.each([
       })
 
       it.each([...options.allow])('accepts valid radio item', (value) => {
-        const { formSchema } = component
+        const { formSchema } = collection
 
-        const result = formSchema.validate(value, opts)
+        const result = formSchema.validate(getFormData(value), opts)
         expect(result.error).toBeUndefined()
       })
 
       it('adds errors for empty value', () => {
-        const { formSchema } = component
+        const { formSchema } = collection
 
-        const result = formSchema.validate(undefined, opts)
+        const result = formSchema.validate(getFormData(), opts)
 
         expect(result.error).toEqual(
           expect.objectContaining({
-            message: `Select ${label}`
+            message: `Select ${def.title.toLowerCase()}`
           })
         )
       })
 
       it('adds errors for invalid values', () => {
-        const { formSchema } = component
+        const { formSchema } = collection
 
-        const result1 = formSchema.validate('invalid', opts)
-        const result2 = formSchema.validate({ unknown: 'invalid' }, opts)
+        const result1 = formSchema.validate(getFormData('invalid'), opts)
+        const result2 = formSchema.validate(
+          // @ts-expect-error - Allow invalid param for test
+          getFormData({ unknown: 'invalid' }),
+          opts
+        )
 
         expect(result1.error).toBeTruthy()
         expect(result2.error).toBeTruthy()
@@ -201,8 +223,8 @@ describe.each([
         expect(viewModel).toEqual(
           expect.objectContaining({
             label: { text: def.title },
-            name: def.name,
-            id: def.name,
+            name: 'myComponent',
+            id: 'myComponent',
             value: item.value
           })
         )
@@ -213,7 +235,7 @@ describe.each([
         (item) => {
           const viewModel = component.getViewModel(getFormData(item.value))
 
-          expect(viewModel.items[0]).not.toMatchObject({
+          expect(viewModel.items?.[0]).not.toMatchObject({
             value: '' // First item is never empty
           })
 
@@ -232,13 +254,11 @@ describe.each([
 
     describe('Radio items', () => {
       it('returns radio items', () => {
-        const { items } = component
-        expect(items).toEqual(options.list.items)
+        expect(component).toHaveProperty('items', options.list.items)
       })
 
       it('returns radio items matching type', () => {
-        const { values } = component
-        expect(values).toEqual(expect.arrayContaining([]))
+        expect(component).toHaveProperty('values', expect.arrayContaining([]))
       })
 
       it('returns empty items when missing', () => {

--- a/src/server/plugins/engine/components/UkAddressField.test.ts
+++ b/src/server/plugins/engine/components/UkAddressField.test.ts
@@ -50,31 +50,67 @@ describe('UkAddressField', () => {
     describe('Schema', () => {
       it('uses collection titles as labels', () => {
         const { formSchema } = collection
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().keys).toEqual(
+        expect(keys).toHaveProperty(
+          'myComponent__addressLine1',
           expect.objectContaining({
-            myComponent__addressLine1: expect.objectContaining({
-              flags: expect.objectContaining({ label: 'address line 1' })
-            }),
-            myComponent__addressLine2: expect.objectContaining({
-              flags: expect.objectContaining({ label: 'address line 2' })
-            }),
-            myComponent__town: expect.objectContaining({
-              flags: expect.objectContaining({ label: 'town or city' })
-            }),
-            myComponent__postcode: expect.objectContaining({
-              flags: expect.objectContaining({ label: 'postcode' })
-            })
+            flags: expect.objectContaining({ label: 'address line 1' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__addressLine2',
+          expect.objectContaining({
+            flags: expect.objectContaining({ label: 'address line 2' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__town',
+          expect.objectContaining({
+            flags: expect.objectContaining({ label: 'town or city' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          `myComponent__postcode`,
+          expect.objectContaining({
+            flags: expect.objectContaining({ label: 'postcode' })
           })
         )
       })
 
       it('is required by default', () => {
         const { formSchema } = collection
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().flags).toEqual(
+        expect(keys).toHaveProperty(
+          'myComponent__addressLine1',
           expect.objectContaining({
-            presence: 'required'
+            flags: expect.objectContaining({ presence: 'required' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__addressLine2',
+          expect.objectContaining({
+            allow: [''], // Required but empty string is allowed
+            flags: expect.objectContaining({ presence: 'required' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__town',
+          expect.objectContaining({
+            flags: expect.objectContaining({ presence: 'required' })
+          })
+        )
+
+        expect(keys).toHaveProperty(
+          `myComponent__postcode`,
+          expect.objectContaining({
+            flags: expect.objectContaining({ presence: 'required' })
           })
         )
       })
@@ -93,22 +129,26 @@ describe('UkAddressField', () => {
         )
 
         const { formSchema } = collectionOptional
+        const { keys } = formSchema.describe()
 
-        expect(formSchema.describe().keys).toEqual(
-          expect.objectContaining({
-            myComponent__addressLine1: expect.objectContaining({
-              allow: ['']
-            }),
-            myComponent__addressLine2: expect.objectContaining({
-              allow: ['']
-            }),
-            myComponent__town: expect.objectContaining({
-              allow: ['']
-            }),
-            myComponent__postcode: expect.objectContaining({
-              allow: ['']
-            })
-          })
+        expect(keys).toHaveProperty(
+          'myComponent__addressLine1',
+          expect.objectContaining({ allow: [''] })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__addressLine2',
+          expect.objectContaining({ allow: [''] })
+        )
+
+        expect(keys).toHaveProperty(
+          'myComponent__town',
+          expect.objectContaining({ allow: [''] })
+        )
+
+        expect(keys).toHaveProperty(
+          `myComponent__postcode`,
+          expect.objectContaining({ allow: [''] })
         )
 
         const result = formSchema.validate(
@@ -178,11 +218,34 @@ describe('UkAddressField', () => {
       it('adds errors for invalid values', () => {
         const { formSchema } = collection
 
-        const result1 = formSchema.validate(['invalid'], opts)
-        const result2 = formSchema.validate({ unknown: 'invalid' }, opts)
+        const result1 = formSchema.validate(
+          getFormData({ unknown: 'invalid' }),
+          opts
+        )
+
+        const result2 = formSchema.validate(
+          getFormData({
+            addressLine1: ['invalid'],
+            addressLine2: ['invalid'],
+            town: ['invalid'],
+            postcode: ['invalid']
+          }),
+          opts
+        )
+
+        const result3 = formSchema.validate(
+          getFormData({
+            addressLine1: 'invalid',
+            addressLine2: 'invalid',
+            town: 'invalid',
+            postcode: 'invalid'
+          }),
+          opts
+        )
 
         expect(result1.error).toBeTruthy()
         expect(result2.error).toBeTruthy()
+        expect(result3.error).toBeTruthy()
       })
     })
 


### PR DESCRIPTION
This PR follows on from https://github.com/DEFRA/forms-runner/pull/470 and tests all components via `new ComponentCollection()`

This helps unblock collection-level changes such as looping fields to filter allowed errors