### PR TITLE
Improve date validation messages

### DIFF
--- a/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.ts
@@ -18,9 +18,11 @@ export class AutocompleteField extends SelectField {
     let { formSchema } = this
 
     if (options.required !== false) {
+      const messages = options.customValidationMessages
+
       formSchema = formSchema.messages({
-        'any.only': messageTemplate.required,
-        'any.required': messageTemplate.required
+        'any.only': messages?.['any.only'] ?? messageTemplate.required,
+        'any.required': messages?.['any.required'] ?? messageTemplate.required
       })
     }
 

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -2,6 +2,7 @@ import { type ComponentDef } from '@defra/forms-model'
 import joi, {
   type CustomValidator,
   type ErrorReportCollection,
+  type LanguageMessages,
   type ObjectSchema
 } from 'joi'
 
@@ -54,6 +55,11 @@ export class ComponentCollection {
        * Defines a custom validation rule for the object schema
        */
       custom?: CustomValidator
+
+      /**
+       * Defines custom validation messages for the object schema
+       */
+      messages?: LanguageMessages
     }
   ) {
     const items = componentDefs.map((def) => {
@@ -84,6 +90,10 @@ export class ComponentCollection {
       stateSchema = children
         ? stateSchema.concat(children.stateSchema)
         : stateSchema.keys({ [name]: field.stateSchema })
+    }
+
+    if (schema?.messages) {
+      formSchema = formSchema.messages(schema.messages)
     }
 
     // Add parent field title to collection field errors

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -170,7 +170,7 @@ describe('DatePartsField', () => {
         expect(result1.errors).toBeUndefined()
         expect(result2.errors).toEqual([
           expect.objectContaining({
-            text: 'Example date parts field must include a month, year'
+            text: 'Example date parts field must include a month'
           })
         ])
       })
@@ -475,13 +475,13 @@ describe('DatePartsField', () => {
               }),
               errors: [
                 expect.objectContaining({
-                  text: 'Example date parts field must include a day'
+                  text: 'Example date parts field must be a real date'
                 }),
                 expect.objectContaining({
-                  text: 'Example date parts field must include a month'
+                  text: 'Example date parts field must be a real date'
                 }),
                 expect.objectContaining({
-                  text: 'Example date parts field must include a year'
+                  text: 'Example date parts field must be a real date'
                 })
               ]
             }
@@ -557,7 +557,7 @@ describe('DatePartsField', () => {
               }),
               errors: [
                 expect.objectContaining({
-                  text: 'Example date parts field must include a day'
+                  text: 'Example date parts field must be a real date'
                 })
               ]
             }
@@ -576,7 +576,7 @@ describe('DatePartsField', () => {
               }),
               errors: [
                 expect.objectContaining({
-                  text: 'Example date parts field must include a month'
+                  text: 'Example date parts field must be a real date'
                 })
               ]
             }
@@ -595,7 +595,7 @@ describe('DatePartsField', () => {
               }),
               errors: [
                 expect.objectContaining({
-                  text: 'Example date parts field must include a year'
+                  text: 'Example date parts field must be a real date'
                 })
               ]
             }

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -1,6 +1,11 @@
 import { ComponentType, type DatePartsFieldComponent } from '@defra/forms-model'
 import { add, format, isValid, parse, startOfToday, sub } from 'date-fns'
-import { type Context, type CustomValidator, type ObjectSchema } from 'joi'
+import {
+  type Context,
+  type CustomValidator,
+  type LanguageMessages,
+  type ObjectSchema
+} from 'joi'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import {
@@ -34,9 +39,19 @@ export class DatePartsField extends FormComponent {
   constructor(def: DatePartsFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { name, options, title } = def
+    const { name, options } = def
 
     const isRequired = options.required !== false
+
+    const customValidationMessages: LanguageMessages = {
+      'any.required': messageTemplate.objectMissing,
+      'number.base': messageTemplate.objectMissing,
+      'number.precision': messageTemplate.dateFormat,
+      'number.integer': messageTemplate.dateFormat,
+      'number.unsafe': messageTemplate.dateFormat,
+      'number.min': messageTemplate.dateFormat,
+      'number.max': messageTemplate.dateFormat
+    }
 
     this.children = new ComponentCollection(
       [
@@ -49,9 +64,7 @@ export class DatePartsField extends FormComponent {
             required: isRequired,
             optionalText: true,
             classes: 'govuk-input--width-2',
-            customValidationMessage: messageTemplate.objectMissing
-              .replace('{{#title}}', title)
-              .replace('{{#missingWithLabels}}', 'day')
+            customValidationMessages
           }
         },
         {
@@ -63,9 +76,7 @@ export class DatePartsField extends FormComponent {
             required: isRequired,
             optionalText: true,
             classes: 'govuk-input--width-2',
-            customValidationMessage: messageTemplate.objectMissing
-              .replace('{{#title}}', title)
-              .replace('{{#missingWithLabels}}', 'month')
+            customValidationMessages
           }
         },
         {
@@ -77,16 +88,15 @@ export class DatePartsField extends FormComponent {
             required: isRequired,
             optionalText: true,
             classes: 'govuk-input--width-4',
-            customValidationMessage: messageTemplate.objectMissing
-              .replace('{{#title}}', title)
-              .replace('{{#missingWithLabels}}', 'year')
+            customValidationMessages
           }
         }
       ],
       { model, parent: this },
       {
-        peers: [`${name}__day`, `${name}__month`, `${name}__year`],
-        custom: getValidatorDate(this)
+        custom: getValidatorDate(this),
+        messages: customValidationMessages,
+        peers: [`${name}__day`, `${name}__month`, `${name}__year`]
       }
     )
 

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -263,16 +263,32 @@ describe('EmailAddressField', () => {
         ]
       },
       {
-        description: 'Custom validation',
+        description: 'Custom validation message',
         component: {
           title: 'Example email address field',
           name: 'myComponent',
           type: ComponentType.EmailAddressField,
           options: {
-            customValidationMessage: 'This is a custom error'
+            customValidationMessage: 'This is a custom error',
+            customValidationMessages: {
+              'any.required': 'This is not used',
+              'string.empty': 'This is not used',
+              'string.email': 'This is not used'
+            }
           }
         } satisfies EmailAddressFieldComponent,
         assertions: [
+          {
+            input: getFormData(''),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          },
           {
             input: getFormData('invalid'),
             output: {
@@ -280,6 +296,56 @@ describe('EmailAddressField', () => {
               errors: [
                 expect.objectContaining({
                   text: 'This is a custom error'
+                })
+              ]
+            }
+          }
+        ]
+      },
+      {
+        description: 'Custom validation messages (multiple)',
+        component: {
+          title: 'Example email address field',
+          name: 'myComponent',
+          type: ComponentType.EmailAddressField,
+          options: {
+            customValidationMessages: {
+              'any.required': 'This is a custom required error',
+              'string.empty': 'This is a custom empty string error',
+              'string.email': 'This is a custom invalid email error'
+            }
+          }
+        } satisfies EmailAddressFieldComponent,
+        assertions: [
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom required error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(''),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom empty string error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('invalid'),
+            output: {
+              value: getFormData('invalid'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom invalid email error'
                 })
               ]
             }

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -35,6 +35,8 @@ export class EmailAddressField extends FormComponent {
         'string.empty': message,
         'string.email': message
       })
+    } else if (options.customValidationMessages) {
+      formSchema = formSchema.messages(options.customValidationMessages)
     }
 
     this.formSchema = formSchema.default('')

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -73,10 +73,14 @@ export class ListFormComponent extends FormComponent {
       this.listType = this.list?.type ?? 'string'
     }
 
-    const formSchema = joi[this.listType]()
+    let formSchema = joi[this.listType]()
       .valid(...this.values)
       .label(title.toLowerCase())
       .required()
+
+    if (options.customValidationMessages) {
+      formSchema = formSchema.messages(options.customValidationMessages)
+    }
 
     this.formSchema = formSchema
     this.stateSchema = formSchema.default(null).allow(null)

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -394,10 +394,10 @@ describe('MonthYearField', () => {
               }),
               errors: [
                 expect.objectContaining({
-                  text: 'Example month/year field must include a month'
+                  text: 'Example month/year field must be a real date'
                 }),
                 expect.objectContaining({
-                  text: 'Example month/year field must include a year'
+                  text: 'Example month/year field must be a real date'
                 })
               ]
             }
@@ -425,7 +425,7 @@ describe('MonthYearField', () => {
               }),
               errors: [
                 expect.objectContaining({
-                  text: 'Example month/year field must include a month'
+                  text: 'Example month/year field must be a real date'
                 })
               ]
             }
@@ -442,7 +442,7 @@ describe('MonthYearField', () => {
               }),
               errors: [
                 expect.objectContaining({
-                  text: 'Example month/year field must include a year'
+                  text: 'Example month/year field must be a real date'
                 })
               ]
             }

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -1,5 +1,10 @@
 import { ComponentType, type MonthYearFieldComponent } from '@defra/forms-model'
-import { type Context, type CustomValidator, type ObjectSchema } from 'joi'
+import {
+  type Context,
+  type CustomValidator,
+  type LanguageMessages,
+  type ObjectSchema
+} from 'joi'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import {
@@ -33,9 +38,19 @@ export class MonthYearField extends FormComponent {
   constructor(def: MonthYearFieldComponent, model: FormModel) {
     super(def, model)
 
-    const { name, options, title } = def
+    const { name, options } = def
 
     const isRequired = options.required !== false
+
+    const customValidationMessages: LanguageMessages = {
+      'any.required': messageTemplate.objectMissing,
+      'number.base': messageTemplate.objectMissing,
+      'number.precision': messageTemplate.dateFormat,
+      'number.integer': messageTemplate.dateFormat,
+      'number.unsafe': messageTemplate.dateFormat,
+      'number.min': messageTemplate.dateFormat,
+      'number.max': messageTemplate.dateFormat
+    }
 
     this.children = new ComponentCollection(
       [
@@ -48,9 +63,7 @@ export class MonthYearField extends FormComponent {
             required: isRequired,
             optionalText: true,
             classes: 'govuk-input--width-2',
-            customValidationMessage: messageTemplate.objectMissing
-              .replace('{{#title}}', title)
-              .replace('{{#missingWithLabels}}', 'month')
+            customValidationMessages
           }
         },
         {
@@ -62,16 +75,15 @@ export class MonthYearField extends FormComponent {
             required: isRequired,
             optionalText: true,
             classes: 'govuk-input--width-4',
-            customValidationMessage: messageTemplate.objectMissing
-              .replace('{{#title}}', title)
-              .replace('{{#missingWithLabels}}', 'year')
+            customValidationMessages
           }
         }
       ],
       { model, parent: this },
       {
-        peers: [`${name}__month`, `${name}__year`],
-        custom: getValidatorMonthYear(this)
+        custom: getValidatorMonthYear(this),
+        messages: customValidationMessages,
+        peers: [`${name}__month`, `${name}__year`]
       }
     )
 

--- a/src/server/plugins/engine/components/MultilineTextField.test.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.test.ts
@@ -382,17 +382,37 @@ describe('MultilineTextField', () => {
         ]
       },
       {
-        description: 'Custom validation',
+        description: 'Custom validation message',
         component: {
           title: 'Example textarea',
           name: 'myComponent',
           type: ComponentType.MultilineTextField,
           options: {
-            customValidationMessage: 'This is a custom error'
+            customValidationMessage: 'This is a custom error',
+            customValidationMessages: {
+              'any.required': 'This is not used',
+              'string.empty': 'This is not used',
+              'string.max': 'This is not used',
+              'string.min': 'This is not used'
+            }
           },
-          schema: {}
+          schema: {
+            min: 5,
+            max: 8
+          }
         } satisfies MultilineTextFieldComponent,
         assertions: [
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          },
           {
             input: getFormData(''),
             output: {
@@ -400,6 +420,94 @@ describe('MultilineTextField', () => {
               errors: [
                 expect.objectContaining({
                   text: 'This is a custom error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('Text'),
+            output: {
+              value: getFormData('Text'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('Textarea too long'),
+            output: {
+              value: getFormData('Textarea too long'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          }
+        ]
+      },
+      {
+        description: 'Custom validation messages (multiple)',
+        component: {
+          title: 'Example textarea',
+          name: 'myComponent',
+          type: ComponentType.MultilineTextField,
+          options: {
+            customValidationMessages: {
+              'any.required': 'This is a custom required error',
+              'string.empty': 'This is a custom empty string error',
+              'string.max': 'This is a custom max length error',
+              'string.min': 'This is a custom min length error'
+            }
+          },
+          schema: {
+            min: 5,
+            max: 8
+          }
+        } satisfies MultilineTextFieldComponent,
+        assertions: [
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom required error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(''),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom empty string error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('Text'),
+            output: {
+              value: getFormData('Text'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom min length error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('Textarea too long'),
+            output: {
+              value: getFormData('Textarea too long'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom max length error'
                 })
               ]
             }

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -66,6 +66,8 @@ export class MultilineTextField extends FormComponent {
         'string.pattern.base': message,
         'string.maxWords': message
       })
+    } else if (options.customValidationMessages) {
+      formSchema = formSchema.messages(options.customValidationMessages)
     }
 
     this.formSchema = formSchema.default('')

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -515,23 +515,119 @@ describe('NumberField', () => {
         ]
       },
       {
-        description: 'Custom validation',
+        description: 'Custom validation message',
         component: {
           title: 'Example number field',
           name: 'myComponent',
           type: ComponentType.NumberField,
           options: {
-            customValidationMessage: 'This is a custom error'
+            customValidationMessage: 'This is a custom error',
+            customValidationMessages: {
+              'any.required': 'This is not used',
+              'number.base': 'This is not used',
+              'number.min': 'This is not used',
+              'number.max': 'This is not used'
+            }
           },
           schema: {}
         } satisfies NumberFieldComponent,
         assertions: [
           {
+            input: getFormData(''),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('AA'),
+            output: {
+              value: getFormData('AA'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          },
+          {
             input: getFormData('invalid'),
             output: {
               value: getFormData('invalid'),
               errors: [
-                expect.objectContaining({ text: 'This is a custom error' })
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          }
+        ]
+      },
+      {
+        description: 'Custom validation messages (multiple)',
+        component: {
+          title: 'Example number field',
+          name: 'myComponent',
+          type: ComponentType.NumberField,
+          options: {
+            customValidationMessages: {
+              'any.required': 'This is a custom required error',
+              'number.base': 'This is a custom number error',
+              'number.max': 'This is a custom max number error',
+              'number.min': 'This is a custom min number error'
+            }
+          },
+          schema: {
+            min: 5,
+            max: 8
+          }
+        } satisfies NumberFieldComponent,
+        assertions: [
+          {
+            input: getFormData(''),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom required error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('AA'),
+            output: {
+              value: getFormData('AA'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom number error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('4'),
+            output: {
+              value: getFormData(4),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom min number error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('10'),
+            output: {
+              value: getFormData(10),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom max number error'
+                })
               ]
             }
           }
@@ -556,7 +652,9 @@ describe('NumberField', () => {
             output: {
               value: getFormData(3.14159),
               errors: [
-                expect.objectContaining({ text: 'This is a custom error' })
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
               ]
             }
           }

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -35,8 +35,10 @@ export class NumberField extends FormComponent {
     if (options.required === false) {
       formSchema = formSchema.allow('')
     } else {
+      const messages = options.customValidationMessages
+
       formSchema = formSchema.empty('').messages({
-        'any.required': messageTemplate.required
+        'any.required': messages?.['any.required'] ?? messageTemplate.required
       })
     }
 

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -63,6 +63,8 @@ export class NumberField extends FormComponent {
         'number.min': message,
         'number.max': message
       })
+    } else if (options.customValidationMessages) {
+      formSchema = formSchema.messages(options.customValidationMessages)
     }
 
     this.formSchema = formSchema.default('')

--- a/src/server/plugins/engine/components/TelephoneNumberField.test.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.test.ts
@@ -213,16 +213,32 @@ describe('TelephoneNumberField', () => {
   describe('Validation', () => {
     describe.each([
       {
-        description: 'Custom validation',
+        description: 'Custom validation message',
         component: {
           title: 'Example telephone number field',
           name: 'myComponent',
           type: ComponentType.TelephoneNumberField,
           options: {
-            customValidationMessage: 'This is a custom error'
+            customValidationMessage: 'This is a custom error',
+            customValidationMessages: {
+              'any.required': 'This is not used',
+              'string.empty': 'This is not used',
+              'string.pattern.base': 'This is not used'
+            }
           }
         } satisfies TelephoneNumberFieldComponent,
         assertions: [
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          },
           {
             input: getFormData(''),
             output: {
@@ -230,6 +246,67 @@ describe('TelephoneNumberField', () => {
               errors: [
                 expect.objectContaining({
                   text: 'This is a custom error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('AA'),
+            output: {
+              value: getFormData('AA'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          }
+        ]
+      },
+      {
+        description: 'Custom validation messages (multiple)',
+        component: {
+          title: 'Example telephone number field',
+          name: 'myComponent',
+          type: ComponentType.TelephoneNumberField,
+          options: {
+            customValidationMessages: {
+              'any.required': 'This is a custom required error',
+              'string.empty': 'This is a custom empty string error',
+              'string.pattern.base': 'This is a custom pattern error'
+            }
+          }
+        } satisfies TelephoneNumberFieldComponent,
+        assertions: [
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom required error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(''),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom empty string error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('AA'),
+            output: {
+              value: getFormData('AA'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom pattern error'
                 })
               ]
             }

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -40,6 +40,8 @@ export class TelephoneNumberField extends FormComponent {
         'string.empty': message,
         'string.pattern.base': message
       })
+    } else if (options.customValidationMessages) {
+      formSchema = formSchema.messages(options.customValidationMessages)
     }
 
     addClassOptionIfNone(options, 'govuk-input--width-20')

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -316,17 +316,37 @@ describe('TextField', () => {
         ]
       },
       {
-        description: 'Custom validation',
+        description: 'Custom validation message',
         component: {
           title: 'Example text field',
           name: 'myComponent',
           type: ComponentType.TextField,
           options: {
-            customValidationMessage: 'This is a custom error'
+            customValidationMessage: 'This is a custom error',
+            customValidationMessages: {
+              'any.required': 'This is not used',
+              'string.empty': 'This is not used',
+              'string.max': 'This is not used',
+              'string.min': 'This is not used'
+            }
           },
-          schema: {}
+          schema: {
+            min: 5,
+            max: 8
+          }
         } satisfies TextFieldComponent,
         assertions: [
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          },
           {
             input: getFormData(''),
             output: {
@@ -334,6 +354,94 @@ describe('TextField', () => {
               errors: [
                 expect.objectContaining({
                   text: 'This is a custom error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('Text'),
+            output: {
+              value: getFormData('Text'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('Text field'),
+            output: {
+              value: getFormData('Text field'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom error'
+                })
+              ]
+            }
+          }
+        ]
+      },
+      {
+        description: 'Custom validation messages (multiple)',
+        component: {
+          title: 'Example text field',
+          name: 'myComponent',
+          type: ComponentType.TextField,
+          options: {
+            customValidationMessages: {
+              'any.required': 'This is a custom required error',
+              'string.empty': 'This is a custom empty string error',
+              'string.max': 'This is a custom max length error',
+              'string.min': 'This is a custom min length error'
+            }
+          },
+          schema: {
+            min: 5,
+            max: 8
+          }
+        } satisfies TextFieldComponent,
+        assertions: [
+          {
+            input: getFormData(),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom required error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData(''),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom empty string error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('Text'),
+            output: {
+              value: getFormData('Text'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom min length error'
+                })
+              ]
+            }
+          },
+          {
+            input: getFormData('Text field'),
+            output: {
+              value: getFormData('Text field'),
+              errors: [
+                expect.objectContaining({
+                  text: 'This is a custom max length error'
                 })
               ]
             }

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -68,6 +68,8 @@ export class TextField extends FormComponent {
         'string.length': message,
         'string.pattern.base': message
       })
+    } else if (options.customValidationMessages) {
+      formSchema = formSchema.messages(options.customValidationMessages)
     }
 
     this.formSchema = formSchema.default('')

--- a/src/server/plugins/engine/pageControllers/validationOptions.ts
+++ b/src/server/plugins/engine/pageControllers/validationOptions.ts
@@ -18,8 +18,8 @@ export const messageTemplate = {
   maxWords: '{{#label}} must be {{#limit}} words or fewer',
 
   // Nested fields use component title
-  objectRequired: 'Enter {{#title}}',
-  objectMissing: '{{#title}} must include a {{#missingWithLabels}}',
+  objectRequired: 'Enter {{#label}}',
+  objectMissing: '{{#title}} must include a {{#label}}',
   dateFormat: '{{#title}} must be a real date',
   dateMin: '{{#title}} must be the same as or after {{#limit}}',
   dateMax: '{{#title}} must be the same as or before {{#limit}}'


### PR DESCRIPTION
This PR improves date error messages now [bug #458983](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/458983) has unblocked us

For example, these error messages incorrectly show up multiple times for decimals and whole number errors:

> * Example date parts field must include a day
> * Example date parts field must include a month
> * Example date parts field must include a year

But with this PR we can show a single error message from the [**Date input** error messages guidance](https://design-system.service.gov.uk/components/date-input/#error-messages):

> * Example date parts field must be a real date