### PR TITLE
Always use double new lines in email output

### DIFF
--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -420,14 +420,16 @@ export function getPersonalisation(
   const lines: string[] = []
 
   lines.push(
-    `^ For security reasons, the links in this email expire at ${formattedExpiryDate}\n`
+    `^ For security reasons, the links in this email expire at ${formattedExpiryDate}\n\n`
   )
 
   if (formStatus.isPreview) {
-    lines.push(`This is a test of the ${model.name} ${formStatus.state} form.`)
+    lines.push(
+      `This is a test of the ${model.name} ${formStatus.state} form.\n\n`
+    )
   }
 
-  lines.push(`Form received at ${formattedNow}.\n`)
+  lines.push(`Form received at ${formattedNow}.\n\n`)
 
   questions.forEach((question) => {
     const { title, value, field } = question
@@ -445,9 +447,9 @@ export function getPersonalisation(
         )
         .join('\n')
 
-      line = `${files.length} file${files.length !== 1 ? 's' : ''} uploaded (links expire ${formattedExpiryDate}):\n\n${bullets}`
+      line = `${files.length} file${files.length !== 1 ? 's' : ''} uploaded (links expire ${formattedExpiryDate}):\n\n${bullets}\n`
     } else if (Array.isArray(item.subItems)) {
-      line = `[Download ${item.title} (CSV)](${designerUrl}/file-download/${submitResponse.result.files.repeaters[item.name]})`
+      line = `[Download ${item.title} (CSV)](${designerUrl}/file-download/${submitResponse.result.files.repeaters[item.name]})\n`
     } else {
       line = literal(value)
     }
@@ -468,7 +470,7 @@ export function getPersonalisation(
 }
 
 function literal(str: string) {
-  return `\`\`\`\n${str}\n\`\`\``
+  return `\`\`\`\n${str}\n\`\`\`\n`
 }
 
 function getFormSubmissionData(

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -138,12 +138,15 @@ describe('Submission journey test', () => {
         body: expect.stringContaining(outdent`
           ^ For security reasons, the links in this email expire at ${formattedExpiryDate}
 
+
           Form received at ${dateNowFormatted}.
+
 
           ## Text field
           \`\`\`
           Text field
           \`\`\`
+
 
 
           ## Multiline text field
@@ -152,10 +155,12 @@ describe('Submission journey test', () => {
           \`\`\`
 
 
+
           ## Number field
           \`\`\`
           1
           \`\`\`
+
 
 
           ## Date parts field
@@ -164,10 +169,12 @@ describe('Submission journey test', () => {
           \`\`\`
 
 
+
           ## Month year field
           \`\`\`
           2012-12
           \`\`\`
+
 
 
           ## Yes/No field
@@ -176,10 +183,12 @@ describe('Submission journey test', () => {
           \`\`\`
 
 
+
           ## Email address field
           \`\`\`
           user@email.com
           \`\`\`
+
 
 
           ## Telephone number field
@@ -188,10 +197,12 @@ describe('Submission journey test', () => {
           \`\`\`
 
 
+
           ## Address field
           \`\`\`
           Address line 1, Address line 2, Town or city, CW1 1AB
           \`\`\`
+
 
 
           ## Radios field
@@ -200,10 +211,12 @@ describe('Submission journey test', () => {
           \`\`\`
 
 
+
           ## Select field
           \`\`\`
           910400000
           \`\`\`
+
 
 
           ## Autocomplete field
@@ -212,10 +225,12 @@ describe('Submission journey test', () => {
           \`\`\`
 
 
+
           ## Checkboxes field 1
           \`\`\`
           Shetland
           \`\`\`
+
 
 
           ## Checkboxes field 2
@@ -224,10 +239,12 @@ describe('Submission journey test', () => {
           \`\`\`
 
 
+
           ## Checkboxes field 3 (number)
           \`\`\`
           1
           \`\`\`
+
 
 
           ## Checkboxes field 4 (number)
@@ -236,13 +253,16 @@ describe('Submission journey test', () => {
           \`\`\`
 
 
+
           ## Upload your methodology statement
           1 file uploaded (links expire ${formattedExpiryDate}):
 
           * [test.pdf](https://test-designer.cdp-int.defra.cloud/file-download/5a76a1a3-bc8a-4bc0-859a-116d775c7f15)
 
 
+
           [Download main form (CSV)](https://test-designer.cdp-int.defra.cloud/file-download/00000000-0000-0000-0000-000000000000)
+
           `)
       }
     })


### PR DESCRIPTION
Looks like GOV.UK Notify needs `\n\n` for a visual paragraph break

This PR replaces a couple of single `\n` line breaks for the security warning and preview intro

<br>

![image](https://github.com/user-attachments/assets/745ecba0-0fce-4cce-a634-9faa4b94bee5)