### PR TITLE
Fix nested or section fields error handling on summary page

### DIFF
--- a/src/server/plugins/engine/models/types.ts
+++ b/src/server/plugins/engine/models/types.ts
@@ -14,12 +14,14 @@ import {
 import { type Expression } from 'expr-eval'
 
 import { type ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
+import { type Field } from '~/src/server/plugins/engine/components/helpers.js'
 import { type DataType } from '~/src/server/plugins/engine/components/types.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import {
   type FileState,
   type FormState,
   type FormStateValue,
+  type FormSubmissionError,
   type FormSubmissionState,
   type RepeatState
 } from '~/src/server/plugins/engine/types.js'
@@ -55,14 +57,20 @@ export interface DetailItemBase {
   value: string
 
   /**
-   * Flag to indicate if field is in error and should be changed
+   * Field submission state error, used to flag unanswered questions
+   * Shown as 'Complete all unanswered questions before submitting the form'
    */
-  inError?: boolean
+  error?: FormSubmissionError
 
   /**
    * Raw value of a field. For example, a Date will be displayed as 2022-12-25
    */
   rawValue: FormState | FormStateValue
+
+  /**
+   * Field component instance
+   */
+  field?: Field
 
   url: string
   type?: FormComponentsDef['type']

--- a/src/server/views/partials/summary-row.html
+++ b/src/server/views/partials/summary-row.html
@@ -4,14 +4,14 @@
       {{item.label}}
     </dt>
     <dd class="govuk-summary-list__value">
-      {% if item.inError %}
+      {% if item.error %}
         <a class="govuk-link" href="{{item.url}}">Enter {{item.label | lower}}</a>
       {% else %}
         {{ item.value | default("Not supplied", true) }}
       {% endif %}
     </dd>
     <dd class="govuk-summary-list__actions">
-      {% if not item.inError %}
+      {% if not item.error %}
         <a class="govuk-link" href="{{item.url}}">
           Change<span class="govuk-visually-hidden"> {{item.label}}</span>
         </a>

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -400,16 +400,20 @@ describe('Form journey', () => {
       expect($heading2).toBeInTheDocument()
     })
 
-    it("should render fields as 'Not supplied' (after submit)", () => {
+    it("should render fields as 'Enter XXXX' (after submit)", () => {
       for (const { fields = [] } of journey) {
         for (const detail of fields) {
           const index = $titles.findIndex(
             ({ textContent }) => textContent?.trim() === detail.title
           )
 
+          const label = detail.title.toLowerCase()
+
           expect($titles[index]).toHaveTextContent(detail.title)
-          expect($values[index]).toHaveTextContent('Not supplied')
-          expect($actions[index]).toHaveTextContent(`Change ${detail.title}`)
+          expect($values[index]).toHaveTextContent(`Enter ${label}`)
+          expect($actions[index]).not.toHaveTextContent(
+            `Change ${detail.title}`
+          )
         }
       }
     })


### PR DESCRIPTION
This PR fixes a regression as part of [bug #478145](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/478145)

Missed field values via the "Jenny bug" were incorrectly shown as "Not supplied" with the default change link

## Initial scope
The bug originally affected missed Month/Year fields with keys such as:

```
field__month
field__year
```

This is because the summary page looked for errors with `section.field` or `field` keys

## Wider scope

Recent state changes widened the bug scope:

1. Work to [flatten section state in **`a17ef98`**](https://github.com/DEFRA/forms-runner/pull/430/commits/a17ef98cd145ed2a96c2e97b962a583a222d34ca) affected all missed fields within a section
2. Work to [flatten nested field state in **#470**](https://github.com/DEFRA/forms-runner/pull/470) affected missed address and date fields

## The fix

This PR uses `field.getError()` powered by `field.keys` to always check for the correct keys

Our workaround for [**Showing missing information**](https://design-system.service.gov.uk/components/summary-list/#showing-missing-information) now works correctly again for nested and section fields:

<img width="706" alt="Missing field workaround" src="https://github.com/user-attachments/assets/09cbcd7f-10c4-4530-812c-349888289a37">
