### PR TITLE
Fix the "Jenny bug"

### DIFF
--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -23,7 +23,6 @@ import {
   type FormSubmissionState,
   type SummaryListRow
 } from '~/src/server/plugins/engine/types.js'
-import { render } from '~/src/server/plugins/nunjucks/index.js'
 import {
   type FormRequest,
   type FormRequestPayload
@@ -45,7 +44,6 @@ export class SummaryViewModel {
   phaseTag?: string
   errors?: FormSubmissionError[]
   serviceUrl: string
-  showErrorSummary?: boolean
   notificationEmailWarning?: {
     slug: string
     designerUrl: string
@@ -78,31 +76,15 @@ export class SummaryViewModel {
       const { items, title } = detail
 
       const rows = items.map((item): SummaryListRow => {
-        const value = render.macro(
-          'summaryValue',
-          'partials/summary-value.html',
-          {
-            params: {
-              href: item.href,
-              label: item.label,
-              value: item.value,
-              error: item.error
-            }
-          }
-        )
-
-        const row: SummaryListRow = {
+        return {
           key: {
             text: item.title
           },
           value: {
             classes: 'app-prose-scope',
-            html: value
-          }
-        }
-
-        if (!item.error) {
-          row.actions = {
+            html: item.value || 'Not supplied'
+          },
+          actions: {
             items: [
               {
                 href: item.href,
@@ -113,8 +95,6 @@ export class SummaryViewModel {
             ]
           }
         }
-
-        return row
       })
 
       return {

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -126,14 +126,6 @@ export class SummaryPageController extends PageController {
       const state = await this.getState(request)
       const summaryViewModel = this.getSummaryViewModel(state, request)
 
-      // Display error summary on the summary
-      // page if there are incomplete form errors
-      if (summaryViewModel.errors) {
-        summaryViewModel.showErrorSummary = true
-
-        return h.view('summary', summaryViewModel)
-      }
-
       const { params } = request
 
       // Get the form metadata using the `slug` param

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -18,8 +18,7 @@ import {
 } from '~/src/server/plugins/engine/components/helpers.js'
 import {
   checkEmailAddressForLiveFormSubmission,
-  checkFormStatus,
-  redirectUrl
+  checkFormStatus
 } from '~/src/server/plugins/engine/helpers.js'
 import {
   SummaryViewModel,
@@ -82,49 +81,19 @@ export class SummaryPageController extends PageController {
     h: ResponseToolkit<FormRequestRefs>
   ) => Promise<ResponseObject | Boom> {
     return async (request, h) => {
-      const { model } = this
-
       const state = await this.getState(request)
       const viewModel = this.getSummaryViewModel(state, request)
 
       /**
-       * iterates through the errors. If there are errors, a user will be redirected to the page
-       * with the error with returnUrl=`/${model.basePath}/summary` in the URL query parameter.
+       * Redirect back to pages with field errors
        */
       if (viewModel.errors) {
-        const errorToFix = viewModel.errors[0]
-        const { path: parts } = errorToFix
-        const section = parts[0]
-        const property = parts.length > 1 ? parts[parts.length - 1] : null
-        const pageWithError = model.pages.find((page) => {
-          if (page.section && page.section.name === section) {
-            let propertyMatches = true
-            let conditionMatches = true
-            if (property) {
-              propertyMatches =
-                page.collection.fields.filter(
-                  (component) => component.name === property
-                ).length > 0
-            }
-            if (
-              propertyMatches &&
-              page.condition &&
-              model.conditions[page.condition]
-            ) {
-              conditionMatches =
-                model.conditions[page.condition]?.fn(state) ?? false
-            }
-            return propertyMatches && conditionMatches
-          }
-          return false
-        })
+        const errorField = viewModel.details
+          .flatMap(({ items }) => items.find(({ error }) => error) ?? [])
+          .at(0)
 
-        if (pageWithError) {
-          return h.redirect(
-            redirectUrl(pageWithError.href, {
-              returnUrl: redirectUrl(pageWithError.getSummaryPath())
-            })
-          )
+        if (errorField) {
+          return h.redirect(errorField.href)
         }
       }
 

--- a/src/server/plugins/engine/views/partials/summary-value.html
+++ b/src/server/plugins/engine/views/partials/summary-value.html
@@ -1,7 +1,0 @@
-{% macro summaryValue(params) -%}
-  {% if params.error -%}
-    <a class="govuk-link" href="{{ params.href }}">Enter {{ params.label | lower }}</a>
-  {%- else %}
-    {{- params.value | default("Not supplied", true) | safe -}}
-  {% endif %}
-{%- endmacro %}

--- a/src/server/views/summary.html
+++ b/src/server/views/summary.html
@@ -10,13 +10,6 @@
         {% include "partials/preview-banner.html" %}
       {% endif %}
 
-      {% if showErrorSummary %}
-        {{ govukErrorSummary({
-          titleText: "There is a problem",
-          errorList: [{ text: "Complete all unanswered questions before submitting the form." }]
-        }) }}
-      {% endif %}
-
       {% if notificationEmailWarning %}
         {% include "partials/warn-missing-notification-email.html" %}
       {% endif %}

--- a/test/form/definitions/minimal.js
+++ b/test/form/definitions/minimal.js
@@ -1,0 +1,39 @@
+import {
+  ComponentType,
+  ControllerPath,
+  ControllerType
+} from '@defra/forms-model'
+
+export default /** @satisfies {FormDefinition} */ ({
+  name: 'Minimal',
+  startPage: '/start',
+  pages: [
+    {
+      title: 'Optional field',
+      path: '/start',
+      components: [
+        {
+          type: ComponentType.TextField,
+          name: 'field',
+          title: 'Optional field',
+          options: {},
+          schema: {}
+        }
+      ],
+      next: [{ path: '/summary' }]
+    },
+    {
+      path: ControllerPath.Summary,
+      controller: ControllerType.Summary,
+      title: 'Summary'
+    }
+  ],
+  sections: [],
+  conditions: [],
+  lists: [],
+  outputEmail: 'enrique.chase@defra.gov.uk'
+})
+
+/**
+ * @import { FormDefinition } from '@defra/forms-model'
+ */

--- a/test/form/definitions/titles.json
+++ b/test/form/definitions/titles.json
@@ -16,7 +16,7 @@
         },
         {
           "type": "TextField",
-          "name": "firstName",
+          "name": "firstName1",
           "title": "First name",
           "options": {
             "required": true
@@ -29,14 +29,14 @@
             "optionalText": false
           },
           "type": "TextField",
-          "name": "middleName",
+          "name": "middleName1",
           "title": "Middle name",
           "hint": "If you have a middle name on your passport you must include it here",
           "schema": {}
         },
         {
           "type": "TextField",
-          "name": "lastName",
+          "name": "lastName1",
           "title": "Surname",
           "options": {
             "required": true
@@ -56,60 +56,8 @@
       "components": [
         {
           "type": "UkAddressField",
-          "name": "address",
+          "name": "address1",
           "title": "Address",
-          "options": {
-            "required": true
-          },
-          "schema": {}
-        }
-      ],
-      "next": [
-        {
-          "path": "/contact-details"
-        }
-      ],
-      "title": "Address"
-    },
-    {
-      "path": "/applicant-one-address-optional",
-      "section": "applicantOneDetails",
-      "components": [
-        {
-          "type": "UkAddressField",
-          "name": "address",
-          "title": "Address",
-          "options": {
-            "required": false
-          },
-          "schema": {}
-        }
-      ],
-      "next": [
-        {
-          "path": "/contact-details"
-        }
-      ],
-      "title": "Address"
-    },
-    {
-      "path": "/contact-details",
-      "section": "applicantDetails",
-      "components": [
-        {
-          "type": "TelephoneNumberField",
-          "name": "phoneNumber",
-          "title": "Phone number",
-          "hint": "If you haven't got a UK phone number, include country code",
-          "options": {
-            "required": true
-          },
-          "schema": {}
-        },
-        {
-          "type": "EmailAddressField",
-          "name": "emailAddress",
-          "title": "Your email address",
           "options": {
             "required": true
           },
@@ -121,7 +69,7 @@
           "path": "/applicant-two"
         }
       ],
-      "title": "Applicant contact details"
+      "title": "Address"
     },
     {
       "path": "/applicant-two",
@@ -138,7 +86,7 @@
         },
         {
           "type": "TextField",
-          "name": "firstName",
+          "name": "firstName2",
           "title": "First name",
           "options": {
             "required": true
@@ -151,14 +99,14 @@
             "optionalText": false
           },
           "type": "TextField",
-          "name": "middleName",
+          "name": "middleName2",
           "title": "Middle name",
           "hint": "If you have a middle name on your passport you must include it here",
           "schema": {}
         },
         {
           "type": "TextField",
-          "name": "lastName",
+          "name": "lastName2",
           "title": "Surname",
           "options": {
             "required": true
@@ -168,9 +116,30 @@
       ],
       "next": [
         {
-          "path": "/summary"
+          "path": "/applicant-two-address-optional"
         }
       ]
+    },
+    {
+      "path": "/applicant-two-address-optional",
+      "section": "applicantOneDetails",
+      "components": [
+        {
+          "type": "UkAddressField",
+          "name": "address2",
+          "title": "Address",
+          "options": {
+            "required": false
+          },
+          "schema": {}
+        }
+      ],
+      "next": [
+        {
+          "path": "/summary"
+        }
+      ],
+      "title": "Address"
     },
     {
       "path": "/summary",

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -246,18 +246,18 @@ describe('Form journey', () => {
         headers
       }))
 
-      $titles = container.getAllByRole('term')
+      $titles = container.queryAllByRole('term')
 
       // Field values
       $values = container
-        .getAllByRole('definition')
+        .queryAllByRole('definition')
         .filter(({ classList }) =>
           classList.contains('govuk-summary-list__value')
         )
 
       // Change links
       $actions = container
-        .getAllByRole('definition')
+        .queryAllByRole('definition')
         .filter(({ classList }) =>
           classList.contains('govuk-summary-list__actions')
         )
@@ -423,20 +423,17 @@ describe('Form journey', () => {
       expect($heading2).toBeInTheDocument()
     })
 
-    it("should render fields as 'Enter XXXX' (after submit)", () => {
-      for (const { fields = [] } of journey) {
-        for (const detail of fields) {
-          const index = $titles.findIndex(
-            ({ textContent }) => textContent?.trim() === detail.title
-          )
+    it('should redirect back to start (after submit)', async () => {
+      const response = await server.inject({
+        url: `${basePath}/summary`,
+        headers
+      })
 
-          const label = detail.title.toLowerCase()
-
-          expect($titles[index]).toHaveTextContent(detail.title)
-          expect($values[index]).toHaveTextContent(`Enter ${label}`)
-          expect($actions[index]).toBeUndefined()
-        }
-      }
+      // Redirect back to start
+      expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+      expect(response.headers.location).toBe(
+        `${basePath}/start?returnUrl=%2Fbasic%2Fsummary`
+      )
     })
   })
 })


### PR DESCRIPTION
This PR fixes the "Jenny bug" and removes the "Enter XXX" missing field workaround

We add both `item.href` and `item.error` on **detail items** so can easily redirect back to pages with errors:

```js
if (errorField) {
  return h.redirect(errorField.href)
}
```

**Note:** Invalid state from missed pages is only checked when reaching the `/summary` page

Since exit pages are reached with valid state the summary page can still be accessed and submitted

---

This is part of a series of PRs where 2) and 3) below both fix and improve the ["exit page bug" #482470](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/482470)

1. **“Jenny bug” fix** in [#557](https://github.com/DEFRA/forms-runner/pull/557) (this PR)
Validating state at the end and redirecting to pages with errors

2. **Fast walking with direct page access** in [#568](https://github.com/DEFRA/forms-runner/pull/568)
Given a landing path, check it's in the list of relevant paths

3. **Slow walking with redirects to correct page** in [#570](https://github.com/DEFRA/forms-runner/pull/570)
Same as 2) but validate state is correct before running conditions on it