### PR TITLE
Add summary page controller test coverage for repeaters

### DIFF
--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -52,7 +52,7 @@ export class SummaryViewModel {
     pageTitle: string,
     model: FormModel,
     state: FormSubmissionState,
-    relevantState: FormSubmissionState,
+    relevantState: FormState,
     request: FormRequest | FormRequestPayload
   ) {
     this.pageTitle = pageTitle

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -246,7 +246,10 @@ export class PageControllerBase {
   /**
    * Returns an async function. This is called in plugin.ts when there is a GET request at `/{id}/{path*}`
    */
-  getConditionEvaluationContext(model: FormModel, state: FormSubmissionState) {
+  getConditionEvaluationContext(
+    model: FormModel,
+    state: FormSubmissionState
+  ): FormState {
     let relevantState: FormState = {}
     // Start at our startPage
     let nextPage = model.startPage

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -49,7 +49,7 @@ import { sendNotification } from '~/src/server/utils/notify.js'
 const designerUrl = config.get('designerUrl')
 const templateId = config.get('notifyTemplateId')
 
-interface QuestionRecord {
+export interface QuestionRecord {
   title: string
   value: string
   field: FieldSummary

--- a/test/form/definitions/repeat-mixed.js
+++ b/test/form/definitions/repeat-mixed.js
@@ -1,0 +1,54 @@
+import { ComponentType } from '@defra/forms-model'
+
+import definition from '~/test/form/definitions/repeat.js'
+
+export default /** @satisfies {FormDefinition} */ ({
+  ...definition,
+
+  name: 'Repeat form mixed',
+  startPage: '/delivery-or-collection',
+  pages: [
+    {
+      title: 'Delivery or collection',
+      path: '/delivery-or-collection',
+      components: [
+        {
+          name: 'orderType',
+          title: 'How would you like to receive your pizza?',
+          type: ComponentType.RadiosField,
+          list: 'orderTypeOption',
+          options: {}
+        }
+      ],
+      next: [
+        {
+          path: '/pizza-order'
+        }
+      ]
+    },
+
+    // Combine with repeat form pages
+    ...definition.pages
+  ],
+  lists: [
+    {
+      name: 'orderTypeOption',
+      title: 'Order type',
+      type: 'string',
+      items: [
+        {
+          text: 'Delivery',
+          value: 'delivery'
+        },
+        {
+          text: 'Collection',
+          value: 'collection'
+        }
+      ]
+    }
+  ]
+})
+
+/**
+ * @import { FormDefinition, Page } from '@defra/forms-model'
+ */

--- a/test/form/definitions/repeat.js
+++ b/test/form/definitions/repeat.js
@@ -55,8 +55,8 @@ export default /** @satisfies {FormDefinition} */ ({
   ],
   sections: [
     {
-      name: 'section',
-      title: 'Section title',
+      name: 'food',
+      title: 'Food',
       hideTitle: false
     }
   ],

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -164,7 +164,7 @@ describe('Repeat GET tests', () => {
     })
 
     const $heading2 = container.getByRole('heading', {
-      name: 'Pizza 1',
+      name: 'Food: Pizza 1',
       level: 2
     })
 
@@ -208,7 +208,7 @@ describe('Repeat GET tests', () => {
     })
 
     const $heading2 = container.getByRole('heading', {
-      name: 'Pizza 1',
+      name: 'Food: Pizza 1',
       level: 2
     })
 


### PR DESCRIPTION
This PR adds a non-repeater "How would you like to receive your pizza?" question to the repeater form definition

Which then gives us a mixed form to test some **SummaryPageController** coverage gaps

---

Part of [story #458979](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/458979) and addresses code review feedback in:

* https://github.com/DEFRA/forms-runner/pull/488#pullrequestreview-2392306238