### PR TITLE
Add check answers + submission service `submit()` test coverage

### DIFF
--- a/src/server/plugins/engine/models/SummaryViewModel.test.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.test.ts
@@ -1,0 +1,127 @@
+import {
+  FormModel,
+  SummaryViewModel
+} from '~/src/server/plugins/engine/models/index.js'
+import { type FormRequest } from '~/src/server/routes/types.js'
+import definition from '~/test/form/definitions/repeat-mixed.js'
+
+describe('SummaryViewModel', () => {
+  const itemId1 = 'abc-123'
+  const itemId2 = 'xyz-987'
+
+  let summaryViewModel: SummaryViewModel
+
+  beforeEach(() => {
+    const model = new FormModel(definition, {
+      basePath: 'test'
+    })
+
+    const relevantState = {
+      orderType: 'delivery',
+      pizza: [
+        {
+          toppings: 'Ham',
+          quantity: 2,
+          itemId: itemId1
+        },
+        {
+          toppings: 'Pepperoni',
+          quantity: 1,
+          itemId: itemId2
+        }
+      ]
+    }
+
+    const submissionState = {
+      progress: [
+        'repeat/delivery-or-collection',
+        `repeat/pizza-order/${itemId1}`,
+        `repeat/pizza-order/${itemId2}`,
+        'repeat/summary'
+      ],
+      ...relevantState
+    }
+
+    const request = {
+      url: new URL('http://example.com/repeat/pizza-order/summary'),
+      params: {
+        path: 'pizza-order',
+        slug: 'repeat'
+      },
+      query: {}
+    } as FormRequest
+
+    summaryViewModel = new SummaryViewModel(
+      'Summary',
+      model,
+      submissionState,
+      relevantState,
+      request
+    )
+  })
+
+  describe('Check answers', () => {
+    it('should add title for each section', () => {
+      const [checkAnswers1, checkAnswers2] = summaryViewModel.checkAnswers
+
+      // 1st summary list has no title
+      expect(checkAnswers1).toHaveProperty('title', undefined)
+
+      // 2nd summary list has section title
+      expect(checkAnswers2).toHaveProperty('title', {
+        text: 'Food'
+      })
+    })
+
+    it('should add summary list for each section', () => {
+      expect(summaryViewModel.checkAnswers).toHaveLength(2)
+
+      const [checkAnswers1, checkAnswers2] = summaryViewModel.checkAnswers
+
+      const { summaryList: summaryList1 } = checkAnswers1
+      const { summaryList: summaryList2 } = checkAnswers2
+
+      expect(summaryList1).toHaveProperty('rows', [
+        {
+          key: {
+            text: 'How would you like to receive your pizza?'
+          },
+          value: {
+            html: 'Delivery'
+          },
+          actions: {
+            items: [
+              {
+                classes: 'govuk-link--no-visited-state',
+                href: '/test/delivery-or-collection?returnUrl=%2Ftest%2Fsummary',
+                text: 'Change',
+                visuallyHiddenText: 'How would you like to receive your pizza?'
+              }
+            ]
+          }
+        }
+      ])
+
+      expect(summaryList2).toHaveProperty('rows', [
+        {
+          key: {
+            text: 'Pizzas added'
+          },
+          value: {
+            html: 'You added 2 Pizzas'
+          },
+          actions: {
+            items: [
+              {
+                classes: 'govuk-link--no-visited-state',
+                href: '/test/pizza-order/summary?returnUrl=%2Ftest%2Fsummary',
+                text: 'Change',
+                visuallyHiddenText: 'Pizza'
+              }
+            ]
+          }
+        }
+      ])
+    })
+  })
+})

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -100,7 +100,7 @@ export class SummaryViewModel {
 
         const row: SummaryListRow = {
           key: {
-            text: item.label
+            text: item.title
           },
           value: {
             html: value
@@ -205,16 +205,15 @@ function addRepeaterItem(
   const { name, title } = options
   const repeatSummaryPath = page.getSummaryPath(request)
   const path = `/${model.basePath}${page.path}`
-  const rawValue = page.getListFromState(state)
-  const hasItems = rawValue.length > 0
-  const value = hasItems ? rawValue.length.toString() : '0'
-  const url = redirectUrl(hasItems ? repeatSummaryPath : path, {
+  const values = page.getListFromState(state)
+  const unit = values.length === 1 ? title : `${title}s`
+  const url = redirectUrl(values.length ? repeatSummaryPath : path, {
     returnUrl: redirectUrl(`/${model.basePath}/summary`)
   })
 
   const subItems: DetailItem[][] = []
 
-  rawValue.forEach((itemState) => {
+  values.forEach((itemState) => {
     const sub: DetailItem[] = []
     for (const component of page.collection.fields) {
       const item = Item(component, itemState, page, model)
@@ -227,11 +226,11 @@ function addRepeaterItem(
   items.push({
     name,
     path: page.path,
-    label: hasItems ? `${title}s added` : title,
-    value: `You added ${value} ${title}${value === '1' ? '' : 's'}`,
-    rawValue,
+    label: title,
+    title: values.length ? `${unit} added` : unit,
+    value: `You added ${values.length} ${unit}`,
+    rawValue: values,
     url,
-    title,
     subItems
   })
 }

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -290,7 +290,7 @@ function submitData(
       value: (record.field.item.subItems ?? []).map((detailItem) =>
         detailItem.map((item) => ({
           name: item.name,
-          title: item.title,
+          title: item.label,
           value: item.value
         }))
       )
@@ -449,7 +449,7 @@ export function getPersonalisation(
 
       line = `${files.length} file${files.length !== 1 ? 's' : ''} uploaded (links expire ${formattedExpiryDate}):\n\n${bullets}\n`
     } else if (Array.isArray(item.subItems)) {
-      line = `[Download ${item.title} (CSV)](${designerUrl}/file-download/${submitResponse.result.files.repeaters[item.name]})\n`
+      line = `[Download ${item.label} (CSV)](${designerUrl}/file-download/${submitResponse.result.files.repeaters[item.name]})\n`
     } else {
       line = literal(value)
     }
@@ -545,7 +545,7 @@ export function answerFromDetailItem(item: DetailItem) {
 function toFieldSummary(item: DetailItem): FieldSummary {
   return {
     key: item.name,
-    title: item.title,
+    title: item.label,
     type: item.dataType,
     answer: answerFromDetailItem(item),
     item

--- a/src/server/plugins/engine/views/partials/summary-value.html
+++ b/src/server/plugins/engine/views/partials/summary-value.html
@@ -1,7 +1,7 @@
-{% macro summaryValue(params) %}
-  {% if params.error %}
+{% macro summaryValue(params) -%}
+  {% if params.error -%}
     <a class="govuk-link" href="{{ params.href }}">Enter {{ params.label | lower }}</a>
-  {% else %}
-    {{ params.value | default("Not supplied", true) }}
+  {%- else %}
+    {{- params.value | default("Not supplied", true) -}}
   {% endif %}
-{% endmacro %}
+{%- endmacro %}

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -267,6 +267,99 @@ describe('Submission journey test', () => {
       }
     })
 
+    expect(submit).toHaveBeenCalledWith({
+      main: [
+        {
+          name: 'textField',
+          title: 'Text field',
+          value: 'Text field'
+        },
+        {
+          name: 'multilineTextField',
+          title: 'Multiline text field',
+          value: 'Multiline text field'
+        },
+        {
+          name: 'numberField',
+          title: 'Number field',
+          value: '1'
+        },
+        {
+          name: 'datePartsField',
+          title: 'Date parts field',
+          value: '2012-12-12'
+        },
+        {
+          name: 'monthYearField',
+          title: 'Month year field',
+          value: '2012-12'
+        },
+        {
+          name: 'yesNoField',
+          title: 'Yes/No field',
+          value: 'yes'
+        },
+        {
+          name: 'emailAddressField',
+          title: 'Email address field',
+          value: 'user@email.com'
+        },
+        {
+          name: 'telephoneNumberField',
+          title: 'Telephone number field',
+          value: '+447900000000'
+        },
+        {
+          name: 'addressField',
+          title: 'Address field',
+          value: 'Address line 1, Address line 2, Town or city, CW1 1AB'
+        },
+        {
+          name: 'radiosField',
+          title: 'Radios field',
+          value: 'privateLimitedCompany'
+        },
+        {
+          name: 'selectField',
+          title: 'Select field',
+          value: '910400000'
+        },
+        {
+          name: 'autocompleteField',
+          title: 'Autocomplete field',
+          value: '910400044'
+        },
+        {
+          name: 'checkboxesSingle',
+          title: 'Checkboxes field 1',
+          value: 'Shetland'
+        },
+        {
+          name: 'checkboxesMultiple',
+          title: 'Checkboxes field 2',
+          value: 'Arabian,Shire,Race'
+        },
+        {
+          name: 'checkboxesSingleNumber',
+          title: 'Checkboxes field 3 (number)',
+          value: '1'
+        },
+        {
+          name: 'checkboxesMultipleNumber',
+          title: 'Checkboxes field 4 (number)',
+          value: '0,1'
+        },
+        {
+          name: 'fileUpload',
+          title: 'Upload your methodology statement',
+          value: '5a76a1a3-bc8a-4bc0-859a-116d775c7f15'
+        }
+      ],
+      repeaters: [],
+      retrievalKey: 'enrique.chase@defra.gov.uk',
+      sessionId: expect.any(String)
+    })
+
     // Status page
     await statusPage(headers)
   })

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -378,6 +378,24 @@ describe('Form journey', () => {
         payload: { crumb: csrfToken }
       })
 
+      expect(submit).toHaveBeenCalledWith({
+        main: [
+          {
+            name: 'licenceLength',
+            title: 'Which fishing licence do you want to get?',
+            value: '1'
+          },
+          {
+            name: 'fullName',
+            title: "What's your name?",
+            value: 'Firstname Lastname'
+          }
+        ],
+        repeaters: [],
+        retrievalKey: 'enrique.chase@defra.gov.uk',
+        sessionId: expect.any(String)
+      })
+
       expect(response.statusCode).toBe(302)
       expect(response.headers.location).toBe('/basic/status')
 

--- a/test/form/persist-files.test.js
+++ b/test/form/persist-files.test.js
@@ -15,10 +15,10 @@ import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
 
-jest.mock('~/src/server/plugins/engine/services/formSubmissionService.js')
-jest.mock('~/src/server/plugins/engine/services/uploadService.js')
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
+jest.mock('~/src/server/plugins/engine/services/formSubmissionService.js')
+jest.mock('~/src/server/plugins/engine/services/uploadService.js')
 
 const okStatusCode = 200
 const redirectStatusCode = 302
@@ -180,7 +180,22 @@ describe('Submission journey test', () => {
     })
 
     expect(persistFiles).toHaveBeenCalledTimes(1)
-    expect(submit).toHaveBeenCalledTimes(1)
+    expect(submit).toHaveBeenCalledWith({
+      main: [
+        {
+          name: 'fileUpload',
+          title: 'Upload something',
+          value: [
+            'a9e7470b-86a5-4826-a908-360a36aac71d',
+            'a9e7470b-86a5-4826-a908-360a36aac72a'
+          ].join(',')
+        }
+      ],
+      repeaters: [],
+      retrievalKey: 'enrique.chase@defra.gov.uk',
+      sessionId: expect.any(String)
+    })
+
     expect(submitRes.statusCode).toBe(redirectStatusCode)
     expect(submitRes.headers.location).toBe('/file-upload-basic/status')
 


### PR DESCRIPTION
Quick PR to add test coverage before merging https://github.com/DEFRA/forms-runner/pull/476

Mainly adds `expect(submit).toHaveBeenCalledWith()` to cover repeater + file upload submission output

Included a fix to use label “**Pizza**” not title “**Pizzas added**” in change links etc