### PR TITLE
Prefer page path methods for start/summary

### DIFF
--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,4 +1,5 @@
 import { type Server } from '@hapi/hapi'
+import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/server/index.js'
 import {
@@ -51,7 +52,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(302)
+      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
       expect(res.headers.location).toBe('/slug/page-one')
       expect(getCacheSize()).toBe(1)
     })
@@ -71,7 +72,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(302)
+      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
       expect(res.headers.location).toBe('/preview/live/slug/page-one')
       expect(getCacheSize()).toBe(1)
     })
@@ -91,7 +92,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(302)
+      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
       expect(res.headers.location).toBe('/preview/draft/slug/page-one')
       expect(getCacheSize()).toBe(1)
     })
@@ -111,7 +112,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(StatusCodes.OK)
       expect(getCacheSize()).toBe(1)
     })
 
@@ -130,7 +131,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(StatusCodes.OK)
       expect(getCacheSize()).toBe(1)
     })
 
@@ -149,7 +150,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(StatusCodes.OK)
       expect(getCacheSize()).toBe(1)
     })
 
@@ -168,7 +169,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(StatusCodes.OK)
       expect(getCacheSize()).toBe(1)
     })
 
@@ -189,7 +190,7 @@ describe('Model cache', () => {
 
       const res1 = await server.inject(options1)
 
-      expect(res1.statusCode).toBe(200)
+      expect(res1.statusCode).toBe(StatusCodes.OK)
       expect(getCacheSize()).toBe(1)
 
       // Populate live/preview cache item
@@ -200,7 +201,7 @@ describe('Model cache', () => {
 
       const res2 = await server.inject(options2)
 
-      expect(res2.statusCode).toBe(200)
+      expect(res2.statusCode).toBe(StatusCodes.OK)
       expect(getCacheSize()).toBe(2)
 
       // Populate draft/preview cache item
@@ -211,7 +212,7 @@ describe('Model cache', () => {
 
       const res3 = await server.inject(options3)
 
-      expect(res3.statusCode).toBe(200)
+      expect(res3.statusCode).toBe(StatusCodes.OK)
       expect(getCacheSize()).toBe(3)
 
       // Execute each request again and
@@ -263,7 +264,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -277,7 +278,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -291,7 +292,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -309,7 +310,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -327,7 +328,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -345,7 +346,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -359,7 +360,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -373,7 +374,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -387,7 +388,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -405,7 +406,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -423,7 +424,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -441,7 +442,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(404)
+      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
       expect(getCacheSize()).toBe(0)
     })
   })
@@ -461,7 +462,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(200)
+      expect(res.statusCode).toBe(StatusCodes.OK)
     })
   })
 })

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -10,10 +10,6 @@ import * as fixtures from '~/test/fixtures/index.js'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
-const okStatusCode = 200
-const redirectStatusCode = 302
-const notFoundStatusCode = 404
-
 describe('Model cache', () => {
   let server: Server
 
@@ -55,7 +51,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(redirectStatusCode)
+      expect(res.statusCode).toBe(302)
       expect(res.headers.location).toBe('/slug/page-one')
       expect(getCacheSize()).toBe(1)
     })
@@ -75,7 +71,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(redirectStatusCode)
+      expect(res.statusCode).toBe(302)
       expect(res.headers.location).toBe('/preview/live/slug/page-one')
       expect(getCacheSize()).toBe(1)
     })
@@ -95,7 +91,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(redirectStatusCode)
+      expect(res.statusCode).toBe(302)
       expect(res.headers.location).toBe('/preview/draft/slug/page-one')
       expect(getCacheSize()).toBe(1)
     })
@@ -115,7 +111,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(okStatusCode)
+      expect(res.statusCode).toBe(200)
       expect(getCacheSize()).toBe(1)
     })
 
@@ -134,7 +130,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(okStatusCode)
+      expect(res.statusCode).toBe(200)
       expect(getCacheSize()).toBe(1)
     })
 
@@ -153,7 +149,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(okStatusCode)
+      expect(res.statusCode).toBe(200)
       expect(getCacheSize()).toBe(1)
     })
 
@@ -172,7 +168,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(okStatusCode)
+      expect(res.statusCode).toBe(200)
       expect(getCacheSize()).toBe(1)
     })
 
@@ -193,7 +189,7 @@ describe('Model cache', () => {
 
       const res1 = await server.inject(options1)
 
-      expect(res1.statusCode).toBe(okStatusCode)
+      expect(res1.statusCode).toBe(200)
       expect(getCacheSize()).toBe(1)
 
       // Populate live/preview cache item
@@ -204,7 +200,7 @@ describe('Model cache', () => {
 
       const res2 = await server.inject(options2)
 
-      expect(res2.statusCode).toBe(okStatusCode)
+      expect(res2.statusCode).toBe(200)
       expect(getCacheSize()).toBe(2)
 
       // Populate draft/preview cache item
@@ -215,7 +211,7 @@ describe('Model cache', () => {
 
       const res3 = await server.inject(options3)
 
-      expect(res3.statusCode).toBe(okStatusCode)
+      expect(res3.statusCode).toBe(200)
       expect(getCacheSize()).toBe(3)
 
       // Execute each request again and
@@ -267,7 +263,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -281,7 +277,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -295,7 +291,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -313,7 +309,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -331,7 +327,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -349,7 +345,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -363,7 +359,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -377,7 +373,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -391,7 +387,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -409,7 +405,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -427,7 +423,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
 
@@ -445,7 +441,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(notFoundStatusCode)
+      expect(res.statusCode).toBe(404)
       expect(getCacheSize()).toBe(0)
     })
   })
@@ -465,7 +461,7 @@ describe('Model cache', () => {
 
       const res = await server.inject(options)
 
-      expect(res.statusCode).toBe(okStatusCode)
+      expect(res.statusCode).toBe(200)
     })
   })
 })

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -9,7 +9,6 @@ import {
   encodeUrl,
   getErrors,
   proceed,
-  redirectTo,
   redirectUrl
 } from '~/src/server/plugins/engine/helpers.js'
 import { FormStatus } from '~/src/server/routes/types.js'
@@ -54,27 +53,6 @@ describe('Helpers', () => {
 
       const nextUrl = 'badgers/monkeys'
       proceed(request, h, nextUrl)
-
-      expect(h.redirect).toHaveBeenCalledTimes(1)
-      expect(h.redirect).toHaveBeenCalledWith(nextUrl)
-    })
-  })
-
-  describe('redirectTo', () => {
-    it('should redirect to next url when no query params in the request', () => {
-      const nextUrl = 'badgers/monkeys'
-      redirectTo(h, nextUrl)
-
-      expect(h.redirect).toHaveBeenCalledTimes(1)
-      expect(h.redirect).toHaveBeenCalledWith(nextUrl)
-    })
-
-    it('should redirect to next url ignoring most params from original request', () => {
-      request.query.myParam = 'myValue'
-      request.query.myParam2 = 'myValue2'
-
-      const nextUrl = 'badgers/monkeys'
-      redirectTo(h, nextUrl)
 
       expect(h.redirect).toHaveBeenCalledTimes(1)
       expect(h.redirect).toHaveBeenCalledWith(nextUrl)

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -1,3 +1,4 @@
+import { ControllerPath } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { type ResponseToolkit } from '@hapi/hapi'
 import { format, parseISO } from 'date-fns'
@@ -7,9 +8,10 @@ import upperFirst from 'lodash/upperFirst.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
 import { RelativeUrl } from '~/src/server/plugins/engine/feedback/index.js'
+import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { type FormSubmissionError } from '~/src/server/plugins/engine/types.js'
-import { FormStatus } from '~/src/server/routes/types.js'
 import {
+  FormStatus,
   type FormQuery,
   type FormRequest,
   type FormRequestPayload
@@ -56,6 +58,27 @@ export function redirectUrl(targetUrl: string, params?: FormQuery) {
   })
 
   return relativeUrl.toString()
+}
+
+export function normalisePath(path: string) {
+  return path.replace(/^\//, '').replace(/\/$/, '')
+}
+
+export function getPage(request: FormRequest | FormRequestPayload) {
+  const { model } = request.app
+  const { path } = request.params
+
+  return model?.pages.find(
+    (page) => normalisePath(page.path) === normalisePath(path)
+  )
+}
+
+export function getStartPath(model?: FormModel) {
+  const startPage = normalisePath(model?.def.startPage ?? ControllerPath.Start)
+
+  return !startPage.startsWith('http') && model?.basePath
+    ? `/${model.basePath}/${startPage}`
+    : startPage
 }
 
 export const filesize = (bytes: number) => {

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -60,8 +60,11 @@ export function redirectUrl(targetUrl: string, params?: FormQuery) {
   return relativeUrl.toString()
 }
 
-export function normalisePath(path: string) {
-  return path.replace(/^\//, '').replace(/\/$/, '')
+export function normalisePath(path = '') {
+  return path
+    .trim() // Trim empty spaces
+    .replace(/^\//, '') // Remove leading slash
+    .replace(/\/$/, '') // Remove trailing slash
 }
 
 export function getPage(request: FormRequest | FormRequestPayload) {
@@ -74,11 +77,15 @@ export function getPage(request: FormRequest | FormRequestPayload) {
 }
 
 export function getStartPath(model?: FormModel) {
-  const startPage = normalisePath(model?.def.startPage ?? ControllerPath.Start)
+  const basePath = model?.basePath ?? ''
+  const startPage = model?.def.startPage
 
-  return !startPage.startsWith('http') && model?.basePath
-    ? `/${model.basePath}/${startPage}`
-    : startPage
+  if (startPage?.startsWith('http')) {
+    return startPage
+  }
+
+  const startPath = normalisePath(startPage)
+  return `/${basePath}/${startPath || ControllerPath.Start}`
 }
 
 export const filesize = (bytes: number) => {

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -30,7 +30,7 @@ export function proceed(
   if (returnUrl?.startsWith('/')) {
     return h.redirect(returnUrl)
   } else {
-    return redirectTo(h, nextUrl)
+    return h.redirect(nextUrl)
   }
 }
 
@@ -56,19 +56,6 @@ export function redirectUrl(targetUrl: string, params?: FormQuery) {
   })
 
   return relativeUrl.toString()
-}
-
-export function redirectTo(
-  h: Pick<ResponseToolkit, 'redirect'>,
-  targetUrl: string,
-  params?: FormQuery
-) {
-  if (targetUrl.startsWith('http')) {
-    return h.redirect(targetUrl)
-  }
-
-  const url = redirectUrl(targetUrl, params)
-  return h.redirect(url)
 }
 
 export const filesize = (bytes: number) => {

--- a/src/server/plugins/engine/index.ts
+++ b/src/server/plugins/engine/index.ts
@@ -1,2 +1,2 @@
-export { redirectTo, redirectUrl } from '~/src/server/plugins/engine/helpers.js'
+export { redirectUrl } from '~/src/server/plugins/engine/helpers.js'
 export { configureEnginePlugin } from '~/src/server/plugins/engine/configureEnginePlugin.js'

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -15,12 +15,12 @@ import { add } from 'date-fns'
 import { Parser, type Value } from 'expr-eval'
 import joi from 'joi'
 
+import { getPage } from '~/src/server/plugins/engine/helpers.js'
 import { type ExecutableCondition } from '~/src/server/plugins/engine/models/types.js'
 import {
   getPageController,
   type PageControllerClass
 } from '~/src/server/plugins/engine/pageControllers/helpers.js'
-import { getPage } from '~/src/server/plugins/engine/plugin.js'
 import {
   type FormContext,
   type FormState,

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -15,7 +15,7 @@ import { add } from 'date-fns'
 import { Parser, type Value } from 'expr-eval'
 import joi from 'joi'
 
-import { getPage } from '~/src/server/plugins/engine/helpers.js'
+import { getPage, normalisePath } from '~/src/server/plugins/engine/helpers.js'
 import { type ExecutableCondition } from '~/src/server/plugins/engine/models/types.js'
 import {
   getPageController,
@@ -41,15 +41,13 @@ export class FormModel {
 
   lists: FormDefinition['lists']
   sections: FormDefinition['sections'] = []
-  options: { basePath: string }
   name: string
   values: FormDefinition
   basePath: string
   conditions: Partial<Record<string, ExecutableCondition>>
   pages: PageControllerClass[]
-  startPage?: PageControllerClass
 
-  constructor(def: typeof this.def, options: typeof this.options) {
+  constructor(def: typeof this.def, options: { basePath: string }) {
     const result = formDefinitionSchema.validate(def, { abortEarly: false })
 
     if (result.error) {
@@ -80,10 +78,9 @@ export class FormModel {
     this.def = def
     this.lists = def.lists
     this.sections = def.sections
-    this.options = options
     this.name = def.name ?? ''
     this.values = result.value
-    this.basePath = options.basePath
+    this.basePath = normalisePath(options.basePath)
     this.conditions = {}
 
     def.conditions.forEach((conditionDef) => {
@@ -108,8 +105,6 @@ export class FormModel {
         })
       )
     }
-
-    this.startPage = this.pages.find((page) => page.path === def.startPage)
   }
 
   /**
@@ -211,10 +206,15 @@ export class FormModel {
     state: FormSubmissionState,
     request: FormRequest | FormRequestPayload
   ) {
-    let { basePath, startPage: nextPage } = this
+    const { pages } = this
 
-    const currentPath = getPage(request)?.path
-    const summaryPath = nextPage?.getSummaryPath()
+    // Current page
+    const page = getPage(request)
+
+    // Determine form paths
+    const currentPath = page?.href
+    const startPath = page?.getStartPath()
+    const summaryPath = page?.getSummaryPath()
 
     const context: FormContext = {
       evaluationState: {},
@@ -223,16 +223,18 @@ export class FormModel {
       paths: []
     }
 
+    // Find start page
+    let nextPage = pages.find(({ href }) => href === startPath)
+
     // Walk form pages from start
     while (nextPage) {
       const { collection, pageDef } = nextPage
-      const isRepeater = hasRepeater(pageDef)
 
       // Add page to context
       context.relevantPages.push(nextPage)
 
       // Skip evaluation state for repeater pages
-      if (!isRepeater) {
+      if (!hasRepeater(pageDef)) {
         Object.assign(
           context.evaluationState,
           collection.getContextValueFromState(state)
@@ -247,7 +249,7 @@ export class FormModel {
       }
 
       // Stop at current or summary page
-      if (nextPage.path === currentPath || nextPage.path === summaryPath) {
+      if (nextPage.href === currentPath || nextPage.href === summaryPath) {
         break
       }
 
@@ -257,14 +259,12 @@ export class FormModel {
 
     // Check if current page is in context
     const isFormPath = context.relevantPages.some(
-      ({ path }) => path === currentPath
+      ({ href }) => href === currentPath
     )
 
     // Add paths for navigation
     if (isFormPath) {
-      context.paths = context.relevantPages.map(
-        ({ path }) => `${basePath}${path}`
-      )
+      context.paths = context.relevantPages.map(({ href }) => href)
     }
 
     return context

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -129,7 +129,7 @@ export class SummaryViewModel {
     state: FormSubmissionState
   ) {
     const { errors, context } = this
-    const { basePath, sections } = model
+    const { sections } = model
 
     const details: Detail[] = []
 
@@ -141,8 +141,7 @@ export class SummaryViewModel {
       )
 
       sectionPages.forEach((page) => {
-        const { collection, path } = page
-        const href = `/${basePath}${path}`
+        const { collection, href } = page
 
         if (page instanceof RepeatPageController) {
           items.push(

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.test.ts
@@ -61,10 +61,10 @@ describe('PageControllerBase', () => {
       // The state below shows we said we had a UKPassport and entered details for an applicant
       const state: FormSubmissionState = {
         progress: [
-          'test/uk-passport',
-          'test/how-many-people',
-          'test/applicant-one-name',
-          'test/applicant-one-address'
+          '/test/uk-passport',
+          '/test/how-many-people',
+          '/test/applicant-one-name',
+          '/test/applicant-one-address'
         ],
         ukPassport: true,
         numberOfApplicants: 2,
@@ -116,10 +116,10 @@ describe('PageControllerBase', () => {
 
       // Our context should know which pages are relevant
       expect(context.paths).toEqual([
-        'test/uk-passport',
-        'test/how-many-people',
-        'test/applicant-one-name',
-        'test/applicant-one-address'
+        '/test/uk-passport',
+        '/test/how-many-people',
+        '/test/applicant-one-name',
+        '/test/applicant-one-address'
       ])
 
       // Now mark that we don't have a UK Passport
@@ -142,9 +142,9 @@ describe('PageControllerBase', () => {
 
       // Our context should no longer list pages about our applicant
       expect(context.paths).toEqual([
-        'test/uk-passport',
-        'test/testconditions',
-        'test/summary'
+        '/test/uk-passport',
+        '/test/testconditions',
+        '/test/summary'
       ])
 
       // Our context should no longer know anything about our applicant

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -22,8 +22,7 @@ import { optionalText } from '~/src/server/plugins/engine/components/constants.j
 import {
   encodeUrl,
   getErrors,
-  proceed,
-  redirectTo
+  proceed
 } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
@@ -271,15 +270,11 @@ export class PageControllerBase {
 
       if (shouldRedirectToStartPage) {
         return startPage?.startsWith('http')
-          ? redirectTo(h, startPage)
-          : redirectTo(h, `/${this.model.basePath}${startPage}`)
+          ? h.redirect(startPage)
+          : h.redirect(`/${this.model.basePath}${startPage}`)
       }
 
       const viewModel = this.getViewModel(request, payload)
-
-      viewModel.startPage = startPage?.startsWith('http')
-        ? redirectTo(h, startPage)
-        : redirectTo(h, `/${this.model.basePath}${startPage}`)
 
       /**
        * Content components can be hidden based on a condition. If the condition evaluates to true, it is safe to be kept, otherwise discard it

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -1,5 +1,6 @@
 import {
   ComponentType,
+  ControllerPath,
   hasComponents,
   hasNext,
   type FormDefinition,
@@ -168,6 +169,11 @@ export class PageControllerBase {
     }
   }
 
+  get href() {
+    const { model, path } = this
+    return `/${model.basePath}${path}`
+  }
+
   get next(): Link[] {
     const { def, pageDef } = this
 
@@ -182,7 +188,8 @@ export class PageControllerBase {
   }
 
   getSummaryPath() {
-    return this.defaultNextPath
+    const { model } = this
+    return `/${model.basePath}${ControllerPath.Summary}`
   }
 
   /**
@@ -214,7 +221,7 @@ export class PageControllerBase {
     const nextPage = this.getNextPage(evaluationState)
 
     if (nextPage) {
-      return `/${this.model.basePath || ''}${nextPage.path}`
+      return nextPage.href
     }
 
     return this.getSummaryPath()
@@ -502,10 +509,6 @@ export class PageControllerBase {
     const { evaluationState } = this.model.getFormContext(state, request)
 
     return proceed(request, h, this.getNext(evaluationState))
-  }
-
-  get defaultNextPath() {
-    return `/${this.model.basePath || ''}/summary`
   }
 
   /**

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -24,6 +24,7 @@ import {
   encodeUrl,
   getErrors,
   getStartPath,
+  normalisePath,
   proceed
 } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
@@ -102,10 +103,8 @@ export class PageControllerBase {
   ): PageViewModel {
     let showTitle = true
 
-    let { title: pageTitle, section } = this
+    let { model, title: pageTitle, section } = this
     const sectionTitle = section?.hideTitle !== true ? section?.title : ''
-
-    const serviceUrl = `/${this.model.basePath}`
 
     const components = this.collection.getViewModel(payload, errors)
     const formComponents = components.filter(
@@ -161,7 +160,7 @@ export class PageControllerBase {
       components,
       errors,
       isStartPage: false,
-      serviceUrl,
+      serviceUrl: `/${model.basePath}`,
       feedbackLink: this.getFeedbackLink(),
       phaseTag: this.getPhaseTag()
     }
@@ -169,7 +168,7 @@ export class PageControllerBase {
 
   get href() {
     const { model, path } = this
-    return `/${model.basePath}${path}`
+    return `/${model.basePath}/${normalisePath(path)}`
   }
 
   get next(): Link[] {
@@ -181,7 +180,7 @@ export class PageControllerBase {
 
     // Remove stale links
     return pageDef.next.filter(({ path }) =>
-      def.pages.some((page) => path === page.path)
+      def.pages.some((page) => normalisePath(path) === normalisePath(page.path))
     )
   }
 
@@ -491,7 +490,9 @@ export class PageControllerBase {
   }
 
   findPageByPath(path?: string) {
-    return this.model.pages.find((page) => page.path === path)
+    return this.model.pages.find(
+      (page) => normalisePath(page.path) === normalisePath(path)
+    )
   }
 
   /**

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -199,12 +199,11 @@ export class RepeatPageController extends PageController {
       request: FormRequest,
       h: ResponseToolkit<FormRequestRefs>
     ) => {
-      const { cacheService } = request.services([])
       const state = await super.getState(request)
       const list = this.getListFromState(state)
       const progress = state.progress ?? []
 
-      await this.updateProgress(progress, request, cacheService)
+      await this.updateProgress(progress, request)
 
       const viewModel = this.getListSummaryViewModel(request, list)
       viewModel.backLink = this.getBackLink(progress)

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -351,7 +351,6 @@ export class RepeatPageController extends PageController {
 
     const { title } = repeat.options
     const sectionTitle = section?.hideTitle !== true ? section?.title : ''
-    const serviceUrl = `/${model.basePath}`
 
     const summaryList: SummaryList = {
       classes: 'govuk-summary-list--long-actions',
@@ -406,7 +405,7 @@ export class RepeatPageController extends PageController {
       sectionTitle,
       showTitle: true,
       errors,
-      serviceUrl,
+      serviceUrl: `/${model.basePath}`,
       checkAnswers: [{ summaryList }],
       repeatTitle: title
     }

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -218,8 +218,10 @@ export class RepeatPageController extends PageController {
       request: FormRequestPayload,
       h: ResponseToolkit<FormRequestPayloadRefs>
     ) => {
+      const { href } = this
       const { payload } = request
       const { action } = payload
+
       const state = await super.getState(request)
 
       if (action === ADD_ANOTHER) {
@@ -242,9 +244,7 @@ export class RepeatPageController extends PageController {
           return h.view(this.listSummaryViewName, viewModel)
         }
 
-        return h.redirect(
-          `/${this.model.basePath}${this.path}${request.url.search}`
-        )
+        return h.redirect(`${href}${request.url.search}`)
       } else if (action === CONTINUE) {
         return super.proceed(request, h, state)
       }
@@ -348,7 +348,7 @@ export class RepeatPageController extends PageController {
     repeatTitle: string
     backLink?: string
   } {
-    const { collection, model, repeat, section } = this
+    const { collection, href, model, repeat, section } = this
 
     const { title } = repeat.options
     const sectionTitle = section?.hideTitle !== true ? section?.title : ''
@@ -367,7 +367,7 @@ export class RepeatPageController extends PageController {
       state.forEach((item, index) => {
         const items: SummaryListAction[] = [
           {
-            href: `/${model.basePath}${this.path}/${item.itemId}${request.url.search}`,
+            href: `${href}/${item.itemId}${request.url.search}`,
             text: 'Change',
             classes: 'govuk-link--no-visited-state',
             visuallyHiddenText: `item ${index + 1}`
@@ -376,7 +376,7 @@ export class RepeatPageController extends PageController {
 
         if (count > 1) {
           items.push({
-            href: `/${model.basePath}${this.path}/${item.itemId}/confirm-delete${request.url.search}`,
+            href: `${href}/${item.itemId}/confirm-delete${request.url.search}`,
             text: 'Remove',
             classes: 'govuk-link--no-visited-state',
             visuallyHiddenText: `item ${index + 1}`
@@ -416,7 +416,7 @@ export class RepeatPageController extends PageController {
   getSummaryPath(
     request?: Pick<FormRequest | FormRequestPayload, 'url' | 'params' | 'query'>
   ) {
-    const { model, path } = this
+    const { href } = this
 
     if (!request) {
       return super.getSummaryPath()
@@ -431,6 +431,6 @@ export class RepeatPageController extends PageController {
       newUrl.searchParams.delete('itemId')
     }
 
-    return `/${model.basePath}${path}/summary${newUrl.search}`
+    return `${href}/summary${newUrl.search}`
   }
 }

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.test.ts
@@ -67,7 +67,7 @@ describe('SummaryPageController', () => {
       app: { model }
     } as FormRequest
 
-    summaryViewModel = controller.getSummaryViewModel(model, state, request)
+    summaryViewModel = controller.getSummaryViewModel(state, request)
 
     submitResponse = {
       message: 'Submit completed',

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -16,7 +16,6 @@ import { getAnswer } from '~/src/server/plugins/engine/components/helpers.js'
 import {
   checkEmailAddressForLiveFormSubmission,
   checkFormStatus,
-  redirectTo,
   redirectUrl
 } from '~/src/server/plugins/engine/helpers.js'
 import {
@@ -113,14 +112,12 @@ export class SummaryPageController extends PageController {
           }
           return false
         })
+
         if (pageWithError) {
-          const params = {
-            returnUrl: redirectUrl(`/${model.basePath}/summary`)
-          }
-          return redirectTo(
-            h,
-            `/${model.basePath}${pageWithError.path}`,
-            params
+          return h.redirect(
+            redirectUrl(`/${model.basePath}${pageWithError.path}`, {
+              returnUrl: redirectUrl(`/${model.basePath}/summary`)
+            })
           )
         }
       }
@@ -179,7 +176,7 @@ export class SummaryPageController extends PageController {
       // Clear all form data
       await cacheService.clearState(request)
 
-      return redirectTo(h, `/${model.basePath}/status`)
+      return h.redirect(`/${model.basePath}/status`)
     }
   }
 

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -53,11 +53,15 @@ export class SummaryPageController extends PageController {
    */
 
   getSummaryViewModel(
-    model: FormModel,
     state: FormSubmissionState,
     request: FormRequest | FormRequestPayload
   ): SummaryViewModel {
-    const viewModel = new SummaryViewModel(model, this.pageDef, state, request)
+    const viewModel = new SummaryViewModel(
+      this.model,
+      this.pageDef,
+      state,
+      request
+    )
 
     // We already figure these out in the base page controller. Take them and apply them to our page-specific model.
     // This is a stop-gap until we can add proper inheritance in place.
@@ -75,11 +79,10 @@ export class SummaryPageController extends PageController {
     h: ResponseToolkit<FormRequestRefs>
   ) => Promise<ResponseObject | Boom> {
     return async (request, h) => {
-      const { cacheService } = request.services([])
+      const { model } = this
 
-      const model = this.model
-      const state = await cacheService.getState(request)
-      const viewModel = this.getSummaryViewModel(model, state, request)
+      const state = await this.getState(request)
+      const viewModel = this.getSummaryViewModel(state, request)
 
       /**
        * iterates through the errors. If there are errors, a user will be redirected to the page
@@ -124,7 +127,7 @@ export class SummaryPageController extends PageController {
 
       const progress = state.progress ?? []
 
-      await this.updateProgress(progress, request, cacheService)
+      await this.updateProgress(progress, request)
 
       viewModel.backLink = this.getBackLink(progress)
 
@@ -144,10 +147,12 @@ export class SummaryPageController extends PageController {
     h: ResponseToolkit<FormRequestPayloadRefs>
   ) => Promise<ResponseObject | Boom> {
     return async (request, h) => {
+      const { model } = this
+
       const { cacheService } = request.services([])
-      const model = this.model
-      const state = await cacheService.getState(request)
-      const summaryViewModel = this.getSummaryViewModel(model, state, request)
+
+      const state = await this.getState(request)
+      const summaryViewModel = this.getSummaryViewModel(state, request)
 
       // Display error summary on the summary
       // page if there are incomplete form errors

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -118,8 +118,8 @@ export class SummaryPageController extends PageController {
 
         if (pageWithError) {
           return h.redirect(
-            redirectUrl(`/${model.basePath}${pageWithError.path}`, {
-              returnUrl: redirectUrl(`/${model.basePath}/summary`)
+            redirectUrl(pageWithError.href, {
+              returnUrl: redirectUrl(pageWithError.getSummaryPath())
             })
           )
         }
@@ -403,9 +403,9 @@ export function getPersonalisation(
 
 export function getFormSubmissionData(context: FormContext, details: Detail[]) {
   return context.relevantPages
-    .map(({ path }) =>
+    .map(({ href }) =>
       details.flatMap(({ items }) =>
-        items.filter(({ page }) => page.path === path)
+        items.filter(({ page }) => page.href === href)
       )
     )
     .flat()

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -13,8 +13,7 @@ import {
   ADD_ANOTHER,
   CONTINUE,
   checkEmailAddressForLiveFormSubmission,
-  checkFormStatus,
-  redirectTo
+  checkFormStatus
 } from '~/src/server/plugins/engine/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { RepeatPageController } from '~/src/server/plugins/engine/pageControllers/RepeatPageController.js'
@@ -50,10 +49,10 @@ function getStartPageRedirect(
   const startPage = normalisePath(model?.def.startPage ?? '')
 
   if (startPage.startsWith('http') || !model?.basePath) {
-    return redirectTo(h, startPage)
+    return h.redirect(startPage)
   }
 
-  return redirectTo(h, `/${model.basePath}/${startPage}`)
+  return h.redirect(`/${model.basePath}/${startPage}`)
 }
 
 export interface PluginOptions {

--- a/src/server/plugins/engine/services/formsService.test.js
+++ b/src/server/plugins/engine/services/formsService.test.js
@@ -1,3 +1,5 @@
+import { StatusCodes } from 'http-status-codes'
+
 import {
   getFormDefinition,
   getFormMetadata
@@ -16,7 +18,9 @@ describe('Forms service', () => {
   describe('getFormMetadata', () => {
     beforeEach(() => {
       jest.mocked(getJson).mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 200 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.OK
+        }),
         payload: metadata
       })
     })
@@ -39,7 +43,9 @@ describe('Forms service', () => {
       }
 
       jest.mocked(getJson).mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 200 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.OK
+        }),
         payload
       })
 
@@ -54,7 +60,9 @@ describe('Forms service', () => {
   describe('getFormDefinition', () => {
     beforeEach(() => {
       jest.mocked(getJson).mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 200 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.OK
+        }),
         payload: definition
       })
     })

--- a/src/server/plugins/errorPages.ts
+++ b/src/server/plugins/errorPages.ts
@@ -3,6 +3,7 @@ import {
   type ResponseToolkit,
   type ServerRegisterPluginObject
 } from '@hapi/hapi'
+import { StatusCodes } from 'http-status-codes'
 
 /*
  * Add an `onPreResponse` listener to return error pages
@@ -34,7 +35,7 @@ export default {
 
           // In the event of 404
           // return the `404` view
-          if (statusCode === 404) {
+          if (statusCode === StatusCodes.NOT_FOUND.valueOf()) {
             return h.view('404', viewModel).code(statusCode)
           }
 

--- a/src/server/routes/health.js
+++ b/src/server/routes/health.js
@@ -1,8 +1,10 @@
+import { StatusCodes } from 'http-status-codes'
+
 export default /** @type {ServerRoute} */ ({
   method: 'GET',
   path: '/health',
   handler(_, h) {
-    return h.response({ message: 'success' }).code(200)
+    return h.response({ message: 'success' }).code(StatusCodes.OK)
   }
 })
 

--- a/src/server/routes/index.test.ts
+++ b/src/server/routes/index.test.ts
@@ -1,4 +1,5 @@
 import { type Server } from '@hapi/hapi'
+import { StatusCodes } from 'http-status-codes'
 
 import { config } from '~/src/config/index.js'
 import { createServer } from '~/src/server/index.js'
@@ -58,7 +59,7 @@ describe('Routes', () => {
 
     const res = await server.inject(options)
 
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(StatusCodes.OK)
   })
 
   test('Service banner is not shown by default', async () => {

--- a/src/server/services/httpService.test.js
+++ b/src/server/services/httpService.test.js
@@ -1,5 +1,6 @@
 import Boom from '@hapi/boom'
 import Wreck from '@hapi/wreck'
+import { StatusCodes } from 'http-status-codes'
 
 import {
   get,
@@ -20,14 +21,16 @@ describe('HTTP service', () => {
   describe('GET', () => {
     beforeEach(() => {
       jest.spyOn(Wreck, 'get').mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 200 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.OK
+        }),
         payload: undefined
       })
     })
 
     it('sends request', async () => {
       await expect(get('/test', options)).resolves.toEqual({
-        res: { statusCode: 200 }
+        res: { statusCode: StatusCodes.OK }
       })
 
       expect(Wreck.get).toHaveBeenCalledWith('/test', {})
@@ -35,7 +38,7 @@ describe('HTTP service', () => {
 
     it('sends request as JSON', async () => {
       await expect(getJson('/test')).resolves.toEqual({
-        res: { statusCode: 200 }
+        res: { statusCode: StatusCodes.OK }
       })
 
       expect(Wreck.get).toHaveBeenCalledWith('/test', { json: true })
@@ -47,14 +50,16 @@ describe('HTTP service', () => {
 
     beforeEach(() => {
       jest.spyOn(Wreck, 'get').mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 404 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.NOT_FOUND
+        }),
         payload: error
       })
     })
 
     it('sends request (with error)', async () => {
       await expect(get('/error', options)).resolves.toEqual({
-        res: { statusCode: 404 },
+        res: { statusCode: StatusCodes.NOT_FOUND },
         error
       })
 
@@ -63,7 +68,7 @@ describe('HTTP service', () => {
 
     it('sends request as JSON (with error)', async () => {
       await expect(getJson('/error')).resolves.toEqual({
-        res: { statusCode: 404 },
+        res: { statusCode: StatusCodes.NOT_FOUND },
         error
       })
 
@@ -72,12 +77,14 @@ describe('HTTP service', () => {
 
     it('sends request (unknown error)', async () => {
       jest.spyOn(Wreck, 'get').mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 404 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.NOT_FOUND
+        }),
         payload: undefined
       })
 
       await expect(get('/error', options)).resolves.toEqual({
-        res: { statusCode: 404 },
+        res: { statusCode: StatusCodes.NOT_FOUND },
         error: new Error('Unknown error')
       })
 
@@ -88,14 +95,16 @@ describe('HTTP service', () => {
   describe('POST', () => {
     beforeEach(() => {
       jest.spyOn(Wreck, 'post').mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 200 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.OK
+        }),
         payload: { reference: '1234' }
       })
     })
 
     it('sends request', async () => {
       await expect(post('/test', options)).resolves.toEqual({
-        res: { statusCode: 200 },
+        res: { statusCode: StatusCodes.OK },
         payload: { reference: '1234' }
       })
 
@@ -104,7 +113,7 @@ describe('HTTP service', () => {
 
     it('sends request as JSON', async () => {
       await expect(postJson('/test', options)).resolves.toEqual({
-        res: { statusCode: 200 },
+        res: { statusCode: StatusCodes.OK },
         payload: { reference: '1234' }
       })
 
@@ -117,14 +126,16 @@ describe('HTTP service', () => {
 
     beforeEach(() => {
       jest.spyOn(Wreck, 'post').mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 404 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.NOT_FOUND
+        }),
         payload: error
       })
     })
 
     it('sends request (with error)', async () => {
       await expect(post('/error', options)).resolves.toEqual({
-        res: { statusCode: 404 },
+        res: { statusCode: StatusCodes.NOT_FOUND },
         error
       })
 
@@ -133,7 +144,7 @@ describe('HTTP service', () => {
 
     it('sends request as JSON (with error)', async () => {
       await expect(postJson('/error', options)).resolves.toEqual({
-        res: { statusCode: 404 },
+        res: { statusCode: StatusCodes.NOT_FOUND },
         error
       })
 
@@ -142,12 +153,14 @@ describe('HTTP service', () => {
 
     it('sends request (unknown error)', async () => {
       jest.spyOn(Wreck, 'post').mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 404 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.NOT_FOUND
+        }),
         payload: undefined
       })
 
       await expect(post('/error', options)).resolves.toEqual({
-        res: { statusCode: 404 },
+        res: { statusCode: StatusCodes.NOT_FOUND },
         error: new Error('Unknown error')
       })
 
@@ -158,14 +171,16 @@ describe('HTTP service', () => {
   describe('PUT', () => {
     beforeEach(() => {
       jest.spyOn(Wreck, 'put').mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 200 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.OK
+        }),
         payload: undefined
       })
     })
 
     it('sends request', async () => {
       await expect(put('/test', options)).resolves.toEqual({
-        res: { statusCode: 200 }
+        res: { statusCode: StatusCodes.OK }
       })
 
       expect(Wreck.put).toHaveBeenCalledWith('/test', {})
@@ -177,14 +192,16 @@ describe('HTTP service', () => {
 
     beforeEach(() => {
       jest.spyOn(Wreck, 'put').mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 404 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.NOT_FOUND
+        }),
         payload: error
       })
     })
 
     it('sends request (with error)', async () => {
       await expect(put('/error', options)).resolves.toEqual({
-        res: { statusCode: 404 },
+        res: { statusCode: StatusCodes.NOT_FOUND },
         error
       })
 
@@ -193,12 +210,14 @@ describe('HTTP service', () => {
 
     it('sends request (unknown error)', async () => {
       jest.spyOn(Wreck, 'put').mockResolvedValue({
-        res: /** @type {IncomingMessage} */ ({ statusCode: 404 }),
+        res: /** @type {IncomingMessage} */ ({
+          statusCode: StatusCodes.NOT_FOUND
+        }),
         payload: undefined
       })
 
       await expect(put('/error', options)).resolves.toEqual({
-        res: { statusCode: 404 },
+        res: { statusCode: StatusCodes.NOT_FOUND },
         error: new Error('Unknown error')
       })
 

--- a/test/condition/checkboxes.test.js
+++ b/test/condition/checkboxes.test.js
@@ -1,6 +1,8 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { StatusCodes } from 'http-status-codes'
+
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
@@ -87,7 +89,7 @@ describe('Checkboxes based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/second-page`)
   })
 
@@ -102,7 +104,7 @@ describe('Checkboxes based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/third-page`)
   })
 })

--- a/test/condition/checkboxes.test.js
+++ b/test/condition/checkboxes.test.js
@@ -7,6 +7,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/checkboxes'
 const key = 'wqJmSf'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
@@ -21,6 +22,7 @@ describe('Checkboxes based conditions', () => {
       formFileName: 'checkboxes.json',
       formFilePath: resolve(testDir, '../form/definitions')
     })
+
     await server.initialize()
   })
 
@@ -33,12 +35,9 @@ describe('Checkboxes based conditions', () => {
   })
 
   test('Checkboxes are rendered', async () => {
-    const options = {
-      method: 'GET',
-      url: '/checkboxes/first-page'
-    }
-
-    const { container } = await renderResponse(server, options)
+    const { container } = await renderResponse(server, {
+      url: `${basePath}/first-page`
+    })
 
     for (const example of [
       {
@@ -79,32 +78,32 @@ describe('Checkboxes based conditions', () => {
     }
   })
 
-  test('Testing POST /checkboxes/first-page with nothing checked redirects correctly', async () => {
+  test('Testing POST /first-page with nothing checked redirects correctly', async () => {
     const form = {}
 
     const res = await server.inject({
+      url: `${basePath}/first-page`,
       method: 'POST',
-      url: '/checkboxes/first-page',
       payload: form
     })
 
     expect(res.statusCode).toBe(302)
-    expect(res.headers.location).toBe('/checkboxes/second-page')
+    expect(res.headers.location).toBe(`${basePath}/second-page`)
   })
 
-  test('Testing POST /checkboxes/first-page with "other" checked redirects correctly', async () => {
+  test('Testing POST /first-page with "other" checked redirects correctly', async () => {
     const form = {
       [key]: 'other'
     }
 
     const res = await server.inject({
+      url: `${basePath}/first-page`,
       method: 'POST',
-      url: '/checkboxes/first-page',
       payload: form
     })
 
     expect(res.statusCode).toBe(302)
-    expect(res.headers.location).toBe('/checkboxes/third-page')
+    expect(res.headers.location).toBe(`${basePath}/third-page`)
   })
 })
 

--- a/test/condition/radios.test.js
+++ b/test/condition/radios.test.js
@@ -1,6 +1,8 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { StatusCodes } from 'http-status-codes'
+
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
@@ -87,7 +89,7 @@ describe('Radio based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/second-page`)
   })
 
@@ -102,7 +104,7 @@ describe('Radio based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/third-page`)
   })
 })

--- a/test/condition/radios.test.js
+++ b/test/condition/radios.test.js
@@ -7,6 +7,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/radios'
 const key = 'wqJmSf'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
@@ -21,6 +22,7 @@ describe('Radio based conditions', () => {
       formFileName: 'radios.json',
       formFilePath: resolve(testDir, '../form/definitions')
     })
+
     await server.initialize()
   })
 
@@ -33,12 +35,9 @@ describe('Radio based conditions', () => {
   })
 
   test('Radio are rendered', async () => {
-    const options = {
-      method: 'GET',
-      url: '/radios/first-page'
-    }
-
-    const { container } = await renderResponse(server, options)
+    const { container } = await renderResponse(server, {
+      url: `${basePath}/first-page`
+    })
 
     for (const example of [
       {
@@ -79,32 +78,32 @@ describe('Radio based conditions', () => {
     }
   })
 
-  test('Testing POST /radios/first-page with nothing checked redirects correctly', async () => {
+  test('Testing POST /first-page with nothing checked redirects correctly', async () => {
     const form = {}
 
     const res = await server.inject({
+      url: `${basePath}/first-page`,
       method: 'POST',
-      url: '/radios/first-page',
       payload: form
     })
 
     expect(res.statusCode).toBe(302)
-    expect(res.headers.location).toBe('/radios/second-page')
+    expect(res.headers.location).toBe(`${basePath}/second-page`)
   })
 
-  test('Testing POST /radios/first-page with "other" checked redirects correctly', async () => {
+  test('Testing POST /first-page with "other" checked redirects correctly', async () => {
     const form = {
       [key]: 'other'
     }
 
     const res = await server.inject({
+      url: `${basePath}/first-page`,
       method: 'POST',
-      url: '/radios/first-page',
       payload: form
     })
 
     expect(res.statusCode).toBe(302)
-    expect(res.headers.location).toBe('/radios/third-page')
+    expect(res.headers.location).toBe(`${basePath}/third-page`)
   })
 })
 

--- a/test/condition/text.test.js
+++ b/test/condition/text.test.js
@@ -1,6 +1,8 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { StatusCodes } from 'http-status-codes'
+
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
@@ -64,7 +66,7 @@ describe('TextField based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(StatusCodes.OK)
   })
 
   test('Testing POST /first-page with an empty string redirects correctly', async () => {
@@ -78,7 +80,7 @@ describe('TextField based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/second-page`)
   })
 
@@ -93,7 +95,7 @@ describe('TextField based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/third-page`)
   })
 })

--- a/test/condition/text.test.js
+++ b/test/condition/text.test.js
@@ -7,6 +7,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/text'
 const key = 'wqJmSf'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
@@ -21,6 +22,7 @@ describe('TextField based conditions', () => {
       formFileName: 'text.json',
       formFilePath: resolve(testDir, '../form/definitions')
     })
+
     await server.initialize()
   })
 
@@ -33,12 +35,9 @@ describe('TextField based conditions', () => {
   })
 
   test('TextField is rendered', async () => {
-    const options = {
-      method: 'GET',
-      url: '/text/first-page'
-    }
-
-    const { container } = await renderResponse(server, options)
+    const { container } = await renderResponse(server, {
+      url: `${basePath}/first-page`
+    })
 
     const $input = container.getByRole('textbox', {
       name: 'First page (optional)'
@@ -56,46 +55,46 @@ describe('TextField based conditions', () => {
     expect($input).not.toHaveValue()
   })
 
-  test('Testing POST /text/first-page without values does not redirect', async () => {
+  test('Testing POST /first-page without values does not redirect', async () => {
     const form = {}
 
     const res = await server.inject({
+      url: `${basePath}/first-page`,
       method: 'POST',
-      url: '/text/first-page',
       payload: form
     })
 
     expect(res.statusCode).toBe(200)
   })
 
-  test('Testing POST /text/first-page with an empty string redirects correctly', async () => {
+  test('Testing POST /first-page with an empty string redirects correctly', async () => {
     const form = {
       [key]: ''
     }
 
     const res = await server.inject({
+      url: `${basePath}/first-page`,
       method: 'POST',
-      url: '/text/first-page',
       payload: form
     })
 
     expect(res.statusCode).toBe(302)
-    expect(res.headers.location).toBe('/text/second-page')
+    expect(res.headers.location).toBe(`${basePath}/second-page`)
   })
 
-  test('Testing POST /text/first-page with an string "other" redirects correctly', async () => {
+  test('Testing POST /first-page with an string "other" redirects correctly', async () => {
     const form = {
       [key]: 'other'
     }
 
     const res = await server.inject({
+      url: `${basePath}/first-page`,
       method: 'POST',
-      url: '/text/first-page',
       payload: form
     })
 
     expect(res.statusCode).toBe(302)
-    expect(res.headers.location).toBe('/text/third-page')
+    expect(res.headers.location).toBe(`${basePath}/third-page`)
   })
 })
 

--- a/test/form/csrf.test.js
+++ b/test/form/csrf.test.js
@@ -1,6 +1,8 @@
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { StatusCodes } from 'http-status-codes'
+
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
@@ -40,7 +42,7 @@ describe('CSRF', () => {
       url: `${basePath}/start`
     })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(StatusCodes.OK)
 
     const csrfToken = getCookie(response, 'crumb')
     expect(csrfToken).toBeTruthy()
@@ -60,7 +62,7 @@ describe('CSRF', () => {
       }
     })
 
-    expect(response.statusCode).toBe(403)
+    expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
   })
 
   test('post request with CSRF token returns 302 redirect', async () => {
@@ -78,7 +80,7 @@ describe('CSRF', () => {
       }
     })
 
-    expect(response.statusCode).toBe(302)
+    expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
   })
 })
 

--- a/test/form/feedback.test.js
+++ b/test/form/feedback.test.js
@@ -8,6 +8,7 @@ import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 const { FEEDBACK_LINK } = process.env
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/feedback'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
@@ -21,6 +22,7 @@ describe('Feedback link', () => {
       formFileName: 'feedback.json',
       formFilePath: join(testDir, 'definitions')
     })
+
     await server.initialize()
   })
 
@@ -41,7 +43,7 @@ describe('Feedback link', () => {
     },
     {
       // Email address from feedback.json
-      url: '/feedback/uk-passport',
+      url: `${basePath}/uk-passport`,
       name: 'give your feedback by email',
       href: 'mailto:test@feedback.cat'
     }

--- a/test/form/fields-optional.test.js
+++ b/test/form/fields-optional.test.js
@@ -8,6 +8,7 @@ import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/fields-optional'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
@@ -17,8 +18,8 @@ describe('Form fields (optional)', () => {
       heading1: 'Fields optional',
 
       paths: {
-        current: '/fields-optional/components',
-        next: '/fields-optional/summary'
+        current: '/components',
+        next: '/summary'
       },
 
       fields: [
@@ -173,7 +174,7 @@ describe('Form fields (optional)', () => {
 
     // Navigate to start
     const response = await server.inject({
-      url: '/fields-optional/components'
+      url: `${basePath}${journey[0].paths.current}`
     })
 
     // Extract the session cookie
@@ -194,7 +195,7 @@ describe('Form fields (optional)', () => {
     ({ heading1, paths, fields = [] }) => {
       beforeEach(async () => {
         ;({ container } = await renderResponse(server, {
-          url: paths.current,
+          url: `${basePath}${paths.current}`,
           headers
         }))
       })
@@ -217,14 +218,14 @@ describe('Form fields (optional)', () => {
 
         // Submit form with populated values
         const response = await server.inject({
-          url: paths.current,
-          headers,
+          url: `${basePath}${paths.current}`,
           method: 'POST',
+          headers,
           payload: { ...payload, crumb: csrfToken }
         })
 
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toBe(paths.next)
+        expect(response.headers.location).toBe(`${basePath}${paths.next}`)
       })
     }
   )

--- a/test/form/fields-optional.test.js
+++ b/test/form/fields-optional.test.js
@@ -1,6 +1,8 @@
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { StatusCodes } from 'http-status-codes'
+
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
@@ -224,7 +226,7 @@ describe('Form fields (optional)', () => {
           payload: { ...payload, crumb: csrfToken }
         })
 
-        expect(response.statusCode).toBe(302)
+        expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
         expect(response.headers.location).toBe(`${basePath}${paths.next}`)
       })
     }

--- a/test/form/fields-required.test.js
+++ b/test/form/fields-required.test.js
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { within } from '@testing-library/dom'
+import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
@@ -254,7 +255,7 @@ describe('Form fields (required)', () => {
           payload: { ...payload, crumb: csrfToken }
         })
 
-        expect(response.statusCode).toBe(200)
+        expect(response.statusCode).toBe(StatusCodes.OK)
         expect(response.headers.location).toBeUndefined()
 
         const $errorSummary = container.getByRole('alert')
@@ -282,7 +283,7 @@ describe('Form fields (required)', () => {
           payload: { ...payload, crumb: csrfToken }
         })
 
-        expect(response.statusCode).toBe(302)
+        expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
         expect(response.headers.location).toBe(`${basePath}${paths.next}`)
       })
     }

--- a/test/form/fields-required.test.js
+++ b/test/form/fields-required.test.js
@@ -10,6 +10,7 @@ import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/fields-required'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
@@ -19,8 +20,8 @@ describe('Form fields (required)', () => {
       heading1: 'Fields required',
 
       paths: {
-        current: '/fields-required/components',
-        next: '/fields-required/summary'
+        current: '/components',
+        next: '/summary'
       },
 
       fields: [
@@ -203,7 +204,7 @@ describe('Form fields (required)', () => {
 
     // Navigate to start
     const response = await server.inject({
-      url: '/fields-required/components'
+      url: `${basePath}${journey[0].paths.current}`
     })
 
     // Extract the session cookie
@@ -224,7 +225,7 @@ describe('Form fields (required)', () => {
     ({ heading1, paths, fields = [] }) => {
       beforeEach(async () => {
         ;({ container } = await renderResponse(server, {
-          url: paths.current,
+          url: `${basePath}${paths.current}`,
           headers
         }))
       })
@@ -247,9 +248,9 @@ describe('Form fields (required)', () => {
 
         // Submit form with empty values
         const { container, response } = await renderResponse(server, {
-          url: paths.current,
-          headers,
+          url: `${basePath}${paths.current}`,
           method: 'POST',
+          headers,
           payload: { ...payload, crumb: csrfToken }
         })
 
@@ -275,14 +276,14 @@ describe('Form fields (required)', () => {
 
         // Submit form with populated values
         const response = await server.inject({
-          url: paths.current,
-          headers,
+          url: `${basePath}${paths.current}`,
           method: 'POST',
+          headers,
           payload: { ...payload, crumb: csrfToken }
         })
 
         expect(response.statusCode).toBe(302)
-        expect(response.headers.location).toBe(paths.next)
+        expect(response.headers.location).toBe(`${basePath}${paths.next}`)
       })
     }
   )

--- a/test/form/file-upload.test.js
+++ b/test/form/file-upload.test.js
@@ -15,18 +15,14 @@ import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/file-upload'
 
 jest.mock('~/src/server/plugins/engine/services/uploadService.js')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
-const okStatusCode = 200
-const redirectStatusCode = 302
-const badRequestStatusCode = 400
-
-const url = '/file-upload/methodology-statement'
 const metadata = {
   formId: '66c304662ad3b5fe57210e7c',
-  path: url,
+  path: `${basePath}/methodology-statement`,
   retrievalKey: 'enrique.chase@defra.gov.uk'
 }
 
@@ -92,6 +88,7 @@ describe('File upload GET tests', () => {
       formFileName: 'file-upload.js',
       formFilePath: resolve(testDir, '../form/definitions')
     })
+
     await server.initialize()
   })
 
@@ -103,16 +100,14 @@ describe('File upload GET tests', () => {
     await server.stop()
   })
 
-  test('GET /file-upload returns 200', async () => {
+  test('GET /methodology-statement returns 200', async () => {
     jest.mocked(initiateUpload).mockResolvedValueOnce(uploadInitiateResponse)
 
-    const options = {
-      method: 'GET',
-      url
-    }
+    const { container, response } = await renderResponse(server, {
+      url: `${basePath}/methodology-statement`
+    })
 
-    const { container, response } = await renderResponse(server, options)
-    expect(response.statusCode).toBe(okStatusCode)
+    expect(response.statusCode).toBe(200)
 
     const $heading1 = container.getByRole('heading', {
       name: 'Upload your methodology statement',
@@ -131,42 +126,46 @@ describe('File upload GET tests', () => {
     expect($heading2).toHaveClass('govuk-heading-m')
   })
 
-  test('GET /file-upload returns uses cached initiated upload', async () => {
+  test('GET /methodology-statement returns uses cached initiated upload', async () => {
     jest.mocked(initiateUpload).mockResolvedValueOnce(uploadInitiateResponse)
 
-    const options = {
-      method: 'GET',
-      url
-    }
+    const res1 = await server.inject({
+      url: `${basePath}/methodology-statement`
+    })
 
-    const res1 = await server.inject(options)
-    expect(res1.statusCode).toBe(okStatusCode)
+    expect(res1.statusCode).toBe(200)
 
     // Extract the session cookie
     const headers = getCookieHeader(res1, 'session')
 
     jest.mocked(getUploadStatus).mockResolvedValueOnce(initiatedStatusResponse)
 
-    const res2 = await server.inject({ ...options, headers })
-    expect(res2.statusCode).toBe(okStatusCode)
+    const res2 = await server.inject({
+      url: `${basePath}/methodology-statement`,
+      headers
+    })
+
+    expect(res2.statusCode).toBe(200)
 
     // Assert invalid status response from CDP throws
     jest.mocked(getUploadStatus).mockResolvedValueOnce(undefined)
 
-    const res3 = await server.inject({ ...options, headers })
-    expect(res3.statusCode).toBe(badRequestStatusCode)
+    const res3 = await server.inject({
+      url: `${basePath}/methodology-statement`,
+      headers
+    })
+
+    expect(res3.statusCode).toBe(400)
   })
 
-  test('GET /file-upload returns handles consumed upload', async () => {
+  test('GET /methodology-statement returns handles consumed upload', async () => {
     jest.mocked(initiateUpload).mockResolvedValueOnce(uploadInitiateResponse)
 
-    const options = {
-      method: 'GET',
-      url
-    }
+    const res1 = await server.inject({
+      url: `${basePath}/methodology-statement`
+    })
 
-    const res1 = await server.inject(options)
-    expect(res1.statusCode).toBe(okStatusCode)
+    expect(res1.statusCode).toBe(200)
 
     // Extract the session cookie
     const headers = getCookieHeader(res1, 'session')
@@ -174,8 +173,12 @@ describe('File upload GET tests', () => {
     jest.mocked(getUploadStatus).mockResolvedValue(pendingStatusResponse)
     jest.mocked(initiateUpload).mockResolvedValueOnce(uploadInitiateResponse)
 
-    const res2 = await server.inject({ ...options, headers })
-    expect(res2.statusCode).toBe(okStatusCode)
+    const res2 = await server.inject({
+      url: `${basePath}/methodology-statement`,
+      headers
+    })
+
+    expect(res2.statusCode).toBe(200)
   })
 })
 
@@ -189,6 +192,7 @@ describe('File upload POST tests', () => {
       formFileName: 'file-upload.js',
       formFilePath: resolve(testDir, '../form/definitions')
     })
+
     await server.initialize()
   })
 
@@ -200,16 +204,14 @@ describe('File upload POST tests', () => {
     await server.stop()
   })
 
-  test('POST /file-upload with pending file returns 200 with errors', async () => {
+  test('POST /methodology-statement with pending file returns 200 with errors', async () => {
     jest.mocked(initiateUpload).mockResolvedValue(uploadInitiateResponse)
 
-    const options = {
-      method: 'GET',
-      url
-    }
+    const res1 = await server.inject({
+      url: `${basePath}/methodology-statement`
+    })
 
-    const res1 = await server.inject(options)
-    expect(res1.statusCode).toBe(okStatusCode)
+    expect(res1.statusCode).toBe(200)
 
     // Extract the session cookie
     const headers = getCookieHeader(res1, 'session')
@@ -217,13 +219,13 @@ describe('File upload POST tests', () => {
     jest.mocked(getUploadStatus).mockResolvedValue(pendingStatusResponse)
 
     const { container, response } = await renderResponse(server, {
+      url: `${basePath}/methodology-statement`,
       method: 'POST',
-      url,
       headers,
       payload: {}
     })
 
-    expect(response.statusCode).toBe(okStatusCode)
+    expect(response.statusCode).toBe(200)
 
     const $errorSummary = container.getByRole('alert')
     const $errorItems = within($errorSummary).getAllByRole('listitem')
@@ -248,73 +250,67 @@ describe('File upload POST tests', () => {
     )
   })
 
-  test('POST /file-upload with 2 valid files returns 302 to /summary', async () => {
+  test('POST /methodology-statement with 2 valid files returns 302 to /summary', async () => {
     jest.mocked(initiateUpload).mockResolvedValue(uploadInitiateResponse)
     jest.mocked(getUploadStatus).mockResolvedValue(readyStatusResponse)
 
-    const options = {
-      method: 'GET',
-      url
-    }
+    const res1 = await server.inject({
+      url: `${basePath}/methodology-statement`
+    })
 
-    const res1 = await server.inject(options)
-    expect(res1.statusCode).toBe(okStatusCode)
+    expect(res1.statusCode).toBe(200)
 
     // Extract the session cookie
     const headers = getCookieHeader(res1, 'session')
 
     const res2 = await server.inject({
-      method: 'GET',
-      url,
+      url: `${basePath}/methodology-statement`,
       headers
     })
 
-    expect(res2.statusCode).toBe(okStatusCode)
+    expect(res2.statusCode).toBe(200)
 
     const res3 = await server.inject({
+      url: `${basePath}/methodology-statement`,
       method: 'POST',
-      url,
       headers,
       payload: {}
     })
 
-    expect(res3.statusCode).toBe(redirectStatusCode)
-    expect(res3.headers.location).toBe('/file-upload/summary')
+    expect(res3.statusCode).toBe(302)
+    expect(res3.headers.location).toBe(`${basePath}/summary`)
   })
 
-  test('POST /file-upload with remove deletes the file', async () => {
+  test('POST /methodology-statement with remove deletes the file', async () => {
     jest.mocked(initiateUpload).mockResolvedValue(uploadInitiateResponse)
     jest.mocked(getUploadStatus).mockResolvedValue(readyStatusResponse)
 
-    const options = {
-      method: 'GET',
-      url
-    }
+    const res1 = await server.inject({
+      url: `${basePath}/methodology-statement`
+    })
 
-    const res1 = await server.inject(options)
-    expect(res1.statusCode).toBe(okStatusCode)
+    expect(res1.statusCode).toBe(200)
 
     // Extract the session cookie
     const headers = getCookieHeader(res1, 'session')
 
     const res2 = await server.inject({
-      method: 'GET',
-      url,
+      url: `${basePath}/methodology-statement`,
       headers
     })
 
-    expect(res2.statusCode).toBe(okStatusCode)
+    expect(res2.statusCode).toBe(200)
 
     const res3 = await server.inject({
+      url: `${basePath}/methodology-statement`,
       method: 'POST',
-      url,
       headers,
       payload: {
         __remove: '15b2303c-9965-4632-acb6-0776081e0399'
       }
     })
 
-    expect(res3.statusCode).toBe(redirectStatusCode)
+    expect(res3.statusCode).toBe(302)
   })
 })
 

--- a/test/form/file-upload.test.js
+++ b/test/form/file-upload.test.js
@@ -2,6 +2,7 @@ import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { within } from '@testing-library/dom'
+import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
@@ -107,7 +108,7 @@ describe('File upload GET tests', () => {
       url: `${basePath}/methodology-statement`
     })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(StatusCodes.OK)
 
     const $heading1 = container.getByRole('heading', {
       name: 'Upload your methodology statement',
@@ -133,7 +134,7 @@ describe('File upload GET tests', () => {
       url: `${basePath}/methodology-statement`
     })
 
-    expect(res1.statusCode).toBe(200)
+    expect(res1.statusCode).toBe(StatusCodes.OK)
 
     // Extract the session cookie
     const headers = getCookieHeader(res1, 'session')
@@ -145,7 +146,7 @@ describe('File upload GET tests', () => {
       headers
     })
 
-    expect(res2.statusCode).toBe(200)
+    expect(res2.statusCode).toBe(StatusCodes.OK)
 
     // Assert invalid status response from CDP throws
     jest.mocked(getUploadStatus).mockResolvedValueOnce(undefined)
@@ -155,7 +156,7 @@ describe('File upload GET tests', () => {
       headers
     })
 
-    expect(res3.statusCode).toBe(400)
+    expect(res3.statusCode).toBe(StatusCodes.BAD_REQUEST)
   })
 
   test('GET /methodology-statement returns handles consumed upload', async () => {
@@ -165,7 +166,7 @@ describe('File upload GET tests', () => {
       url: `${basePath}/methodology-statement`
     })
 
-    expect(res1.statusCode).toBe(200)
+    expect(res1.statusCode).toBe(StatusCodes.OK)
 
     // Extract the session cookie
     const headers = getCookieHeader(res1, 'session')
@@ -178,7 +179,7 @@ describe('File upload GET tests', () => {
       headers
     })
 
-    expect(res2.statusCode).toBe(200)
+    expect(res2.statusCode).toBe(StatusCodes.OK)
   })
 })
 
@@ -211,7 +212,7 @@ describe('File upload POST tests', () => {
       url: `${basePath}/methodology-statement`
     })
 
-    expect(res1.statusCode).toBe(200)
+    expect(res1.statusCode).toBe(StatusCodes.OK)
 
     // Extract the session cookie
     const headers = getCookieHeader(res1, 'session')
@@ -225,7 +226,7 @@ describe('File upload POST tests', () => {
       payload: {}
     })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(StatusCodes.OK)
 
     const $errorSummary = container.getByRole('alert')
     const $errorItems = within($errorSummary).getAllByRole('listitem')
@@ -258,7 +259,7 @@ describe('File upload POST tests', () => {
       url: `${basePath}/methodology-statement`
     })
 
-    expect(res1.statusCode).toBe(200)
+    expect(res1.statusCode).toBe(StatusCodes.OK)
 
     // Extract the session cookie
     const headers = getCookieHeader(res1, 'session')
@@ -268,7 +269,7 @@ describe('File upload POST tests', () => {
       headers
     })
 
-    expect(res2.statusCode).toBe(200)
+    expect(res2.statusCode).toBe(StatusCodes.OK)
 
     const res3 = await server.inject({
       url: `${basePath}/methodology-statement`,
@@ -277,7 +278,7 @@ describe('File upload POST tests', () => {
       payload: {}
     })
 
-    expect(res3.statusCode).toBe(302)
+    expect(res3.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res3.headers.location).toBe(`${basePath}/summary`)
   })
 
@@ -289,7 +290,7 @@ describe('File upload POST tests', () => {
       url: `${basePath}/methodology-statement`
     })
 
-    expect(res1.statusCode).toBe(200)
+    expect(res1.statusCode).toBe(StatusCodes.OK)
 
     // Extract the session cookie
     const headers = getCookieHeader(res1, 'session')
@@ -299,7 +300,7 @@ describe('File upload POST tests', () => {
       headers
     })
 
-    expect(res2.statusCode).toBe(200)
+    expect(res2.statusCode).toBe(StatusCodes.OK)
 
     const res3 = await server.inject({
       url: `${basePath}/methodology-statement`,
@@ -310,7 +311,7 @@ describe('File upload POST tests', () => {
       }
     })
 
-    expect(res3.statusCode).toBe(302)
+    expect(res3.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
   })
 })
 

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { addDays, format } from 'date-fns'
+import { StatusCodes } from 'http-status-codes'
 import { outdent } from 'outdent'
 
 import { createServer } from '~/src/server/index.js'
@@ -93,7 +94,7 @@ describe('Submission journey test', () => {
       url: `${basePath}/all-components`
     })
 
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(StatusCodes.OK)
     expect(res.headers['content-type']).toContain('text/html')
   })
 
@@ -369,7 +370,7 @@ describe('Submission journey test', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/methodology-statement`)
 
     return res
@@ -393,7 +394,7 @@ describe('Submission journey test', () => {
       payload: {}
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/summary`)
 
     return res
@@ -416,7 +417,7 @@ describe('Submission journey test', () => {
       payload: {}
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/status`)
 
     return res
@@ -433,7 +434,7 @@ describe('Submission journey test', () => {
       headers
     })
 
-    expect(statusRes.statusCode).toBe(200)
+    expect(statusRes.statusCode).toBe(StatusCodes.OK)
     expect(statusRes.headers['content-type']).toContain('text/html')
   }
 })

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -20,19 +20,12 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/components'
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/uploadService.js')
 jest.mock('~/src/server/plugins/engine/services/formSubmissionService.js')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
-
-const okStatusCode = 200
-const redirectStatusCode = 302
-const htmlContentType = 'text/html'
-
-const componentsPath = '/components/all-components'
-const fileUploadPath = '/components/methodology-statement'
-const summaryPath = '/components/summary'
 
 /**
  * @satisfies {UploadInitiateResponse}
@@ -83,6 +76,7 @@ describe('Submission journey test', () => {
       formFileName: 'components.json',
       formFilePath: join(testDir, 'definitions')
     })
+
     await server.initialize()
   })
 
@@ -96,12 +90,11 @@ describe('Submission journey test', () => {
 
   test('GET /all-components returns 200', async () => {
     const res = await server.inject({
-      method: 'GET',
-      url: componentsPath
+      url: `${basePath}/all-components`
     })
 
-    expect(res.statusCode).toEqual(okStatusCode)
-    expect(res.headers['content-type']).toContain(htmlContentType)
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-type']).toContain('text/html')
   })
 
   test('POST /summary returns 302', async () => {
@@ -371,13 +364,13 @@ describe('Submission journey test', () => {
 
     // POST the form data to set the state
     const res = await server.inject({
+      url: `${basePath}/all-components`,
       method: 'POST',
-      url: componentsPath,
       payload: form
     })
 
-    expect(res.statusCode).toEqual(redirectStatusCode)
-    expect(res.headers.location).toBe(fileUploadPath)
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe(`${basePath}/methodology-statement`)
 
     return res
   }
@@ -389,20 +382,19 @@ describe('Submission journey test', () => {
    */
   async function fileUploadPage(headers) {
     await server.inject({
-      method: 'GET',
-      url: fileUploadPath,
+      url: `${basePath}/methodology-statement`,
       headers
     })
 
     const res = await server.inject({
+      url: `${basePath}/methodology-statement`,
       method: 'POST',
-      url: fileUploadPath,
       headers,
       payload: {}
     })
 
-    expect(res.statusCode).toEqual(redirectStatusCode)
-    expect(res.headers.location).toBe(summaryPath)
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe(`${basePath}/summary`)
 
     return res
   }
@@ -413,20 +405,19 @@ describe('Submission journey test', () => {
    */
   async function summaryPage(headers) {
     await server.inject({
-      method: 'GET',
-      url: summaryPath,
+      url: `${basePath}/summary`,
       headers
     })
 
     const res = await server.inject({
+      url: `${basePath}/summary`,
       method: 'POST',
-      url: summaryPath,
       headers,
       payload: {}
     })
 
-    expect(res.statusCode).toBe(redirectStatusCode)
-    expect(res.headers.location).toBe('/components/status')
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe(`${basePath}/status`)
 
     return res
   }
@@ -438,13 +429,12 @@ describe('Submission journey test', () => {
   async function statusPage(headers) {
     // Finally GET the /{slug}/status page
     const statusRes = await server.inject({
-      method: 'GET',
-      url: '/components/status',
+      url: `${basePath}/status`,
       headers
     })
 
-    expect(statusRes.statusCode).toBe(okStatusCode)
-    expect(statusRes.headers['content-type']).toContain(htmlContentType)
+    expect(statusRes.statusCode).toBe(200)
+    expect(statusRes.headers['content-type']).toContain('text/html')
   }
 })
 

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -11,6 +11,7 @@ import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/basic'
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
@@ -26,8 +27,8 @@ describe('Form journey', () => {
       heading2: 'Licence details',
 
       paths: {
-        current: '/basic/start',
-        next: '/basic/full-name'
+        current: '/start',
+        next: '/full-name'
       },
 
       fields: [
@@ -54,9 +55,9 @@ describe('Form journey', () => {
       heading2: 'Personal details',
 
       paths: {
-        current: '/basic/full-name',
-        previous: '/basic/start',
-        next: '/basic/summary'
+        current: '/full-name',
+        previous: '/start',
+        next: '/summary'
       },
 
       fields: [
@@ -82,8 +83,8 @@ describe('Form journey', () => {
       heading1: 'Summary',
 
       paths: {
-        current: '/basic/summary',
-        previous: '/basic/full-name'
+        current: '/summary',
+        previous: '/full-name'
       }
     }
   ]
@@ -112,7 +113,7 @@ describe('Form journey', () => {
 
     // Navigate to start
     const response = await server.inject({
-      url: '/basic/start'
+      url: `${basePath}${journey[0].paths.current}`
     })
 
     // Extract the session cookie
@@ -133,7 +134,7 @@ describe('Form journey', () => {
     ({ heading1, heading2, paths, fields = [] }) => {
       beforeEach(async () => {
         ;({ container } = await renderResponse(server, {
-          url: paths.current,
+          url: `${basePath}${paths.current}`,
           headers
         }))
       })
@@ -145,7 +146,10 @@ describe('Form journey', () => {
           })
 
           expect($backLink).toBeInTheDocument()
-          expect($backLink).toHaveAttribute('href', paths.previous)
+          expect($backLink).toHaveAttribute(
+            'href',
+            `${basePath}${paths.previous}`
+          )
         })
       }
 
@@ -179,9 +183,9 @@ describe('Form journey', () => {
 
           // Submit form with empty values
           const { container, response } = await renderResponse(server, {
-            url: paths.current,
-            headers,
+            url: `${basePath}${paths.current}`,
             method: 'POST',
+            headers,
             payload: { ...payload, crumb: csrfToken }
           })
 
@@ -212,20 +216,20 @@ describe('Form journey', () => {
 
           // Submit form with populated values
           const response = await server.inject({
-            url: paths.current,
-            headers,
+            url: `${basePath}${paths.current}`,
             method: 'POST',
+            headers,
             payload: { ...payload, crumb: csrfToken }
           })
 
           expect(response.statusCode).toBe(302)
-          expect(response.headers.location).toBe(paths.next)
+          expect(response.headers.location).toBe(`${basePath}${paths.next}`)
         })
       }
     }
   )
 
-  describe('Page: /basic/summary', () => {
+  describe('Page: /summary', () => {
     /** @type {HTMLElement[]} */
     let $titles
 
@@ -237,7 +241,7 @@ describe('Form journey', () => {
 
     beforeEach(async () => {
       ;({ container } = await renderResponse(server, {
-        url: '/basic/summary',
+        url: `${basePath}/summary`,
         headers
       }))
 
@@ -312,13 +316,13 @@ describe('Form journey', () => {
             name: `Change ${detail.title}`
           })
 
-          const returnUrl = '/basic/summary'
+          const returnUrl = `${basePath}/summary`
 
           // Check for change link
           expect($changeLink).toBeInTheDocument()
           expect($changeLink).toHaveAttribute(
             'href',
-            `${paths.current}?returnUrl=${encodeURIComponent(returnUrl)}`
+            `${basePath}${paths.current}?returnUrl=${encodeURIComponent(returnUrl)}`
           )
 
           // Follow change link
@@ -338,8 +342,8 @@ describe('Form journey', () => {
           // Submit and redirect back to summary page
           const response2 = await server.inject({
             url: $changeLink.href,
-            headers,
             method: 'POST',
+            headers,
             payload: { ...payload, crumb: csrfToken }
           })
 
@@ -351,13 +355,13 @@ describe('Form journey', () => {
 
     it('should prevent access to the complete page before submit', async () => {
       const response = await server.inject({
-        url: '/basic/status',
+        url: `${basePath}/status`,
         headers
       })
 
       // Redirect to base path
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe('/basic')
+      expect(response.headers.location).toBe(basePath)
     })
 
     it('should redirect to the complete page on submit', async () => {
@@ -372,9 +376,9 @@ describe('Form journey', () => {
       })
 
       const response = await server.inject({
-        url: '/basic/summary',
-        headers,
+        url: `${basePath}/summary`,
         method: 'POST',
+        headers,
         payload: { crumb: csrfToken }
       })
 
@@ -397,10 +401,10 @@ describe('Form journey', () => {
       })
 
       expect(response.statusCode).toBe(302)
-      expect(response.headers.location).toBe('/basic/status')
+      expect(response.headers.location).toBe(`${basePath}/status`)
 
       const { container } = await renderResponse(server, {
-        url: '/basic/status',
+        url: `${basePath}/status`,
         headers
       })
 

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -2,6 +2,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { within } from '@testing-library/dom'
+import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/server/index.js'
 import { submit } from '~/src/server/plugins/engine/services/formSubmissionService.js'
@@ -189,7 +190,7 @@ describe('Form journey', () => {
             payload: { ...payload, crumb: csrfToken }
           })
 
-          expect(response.statusCode).toBe(200)
+          expect(response.statusCode).toBe(StatusCodes.OK)
           expect(response.headers.location).toBeUndefined()
 
           const $errorSummary = container.getByRole('alert')
@@ -222,7 +223,7 @@ describe('Form journey', () => {
             payload: { ...payload, crumb: csrfToken }
           })
 
-          expect(response.statusCode).toBe(302)
+          expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
           expect(response.headers.location).toBe(`${basePath}${paths.next}`)
         })
       }
@@ -331,7 +332,7 @@ describe('Form journey', () => {
             headers
           })
 
-          expect(response1.statusCode).toBe(200)
+          expect(response1.statusCode).toBe(StatusCodes.OK)
 
           const payload = {}
 
@@ -347,7 +348,7 @@ describe('Form journey', () => {
             payload: { ...payload, crumb: csrfToken }
           })
 
-          expect(response2.statusCode).toBe(302)
+          expect(response2.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
           expect(response2.headers.location).toBe(returnUrl)
         }
       }
@@ -360,7 +361,7 @@ describe('Form journey', () => {
       })
 
       // Redirect to base path
-      expect(response.statusCode).toBe(302)
+      expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
       expect(response.headers.location).toBe(basePath)
     })
 
@@ -400,7 +401,7 @@ describe('Form journey', () => {
         sessionId: expect.any(String)
       })
 
-      expect(response.statusCode).toBe(302)
+      expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
       expect(response.headers.location).toBe(`${basePath}/status`)
 
       const { container } = await renderResponse(server, {

--- a/test/form/persist-files.test.js
+++ b/test/form/persist-files.test.js
@@ -1,6 +1,8 @@
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { StatusCodes } from 'http-status-codes'
+
 import { createServer } from '~/src/server/index.js'
 import {
   persistFiles,
@@ -103,7 +105,7 @@ describe('Submission journey test', () => {
       url: `${basePath}/file-upload-component`
     })
 
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(StatusCodes.OK)
     expect(res.headers['content-type']).toContain('text/html')
   })
 
@@ -153,7 +155,7 @@ describe('Submission journey test', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/summary`)
 
     // Extract the session cookie
@@ -192,7 +194,7 @@ describe('Submission journey test', () => {
       sessionId: expect.any(String)
     })
 
-    expect(submitRes.statusCode).toBe(302)
+    expect(submitRes.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(submitRes.headers.location).toBe(`${basePath}/status`)
 
     // Finally GET the /{slug}/status page
@@ -201,7 +203,7 @@ describe('Submission journey test', () => {
       headers
     })
 
-    expect(statusRes.statusCode).toBe(200)
+    expect(statusRes.statusCode).toBe(StatusCodes.OK)
     expect(statusRes.headers['content-type']).toContain('text/html')
     expect(persistFiles).toHaveBeenCalledWith(
       [

--- a/test/form/persist-files.test.js
+++ b/test/form/persist-files.test.js
@@ -14,15 +14,12 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/file-upload-basic'
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 jest.mock('~/src/server/plugins/engine/services/formSubmissionService.js')
 jest.mock('~/src/server/plugins/engine/services/uploadService.js')
-
-const okStatusCode = 200
-const redirectStatusCode = 302
-const htmlContentType = 'text/html'
 
 /**
  * @satisfies {FileState}
@@ -78,6 +75,7 @@ describe('Submission journey test', () => {
       formFileName: 'file-upload-basic.js',
       formFilePath: join(testDir, 'definitions')
     })
+
     await server.initialize()
   })
 
@@ -102,12 +100,11 @@ describe('Submission journey test', () => {
     })
 
     const res = await server.inject({
-      method: 'GET',
-      url: '/file-upload-basic/file-upload-component'
+      url: `${basePath}/file-upload-component`
     })
 
-    expect(res.statusCode).toEqual(okStatusCode)
-    expect(res.headers['content-type']).toContain(htmlContentType)
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-type']).toContain('text/html')
   })
 
   test('POST /file-upload-component returns 302', async () => {
@@ -151,21 +148,20 @@ describe('Submission journey test', () => {
 
     // POST the form data to set the state
     const res = await server.inject({
+      url: `${basePath}/file-upload-component`,
       method: 'POST',
-      url: '/file-upload-basic/file-upload-component',
       payload: form
     })
 
-    expect(res.statusCode).toEqual(redirectStatusCode)
-    expect(res.headers.location).toBe('/file-upload-basic/summary')
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe(`${basePath}/summary`)
 
     // Extract the session cookie
     const headers = getCookieHeader(res, 'session')
 
     // GET the summary page
     await server.inject({
-      method: 'GET',
-      url: '/file-upload-basic/summary',
+      url: `${basePath}/summary`,
       headers
     })
 
@@ -173,8 +169,8 @@ describe('Submission journey test', () => {
     // the mock sendNotification contains
     // the correct personalisation data
     const submitRes = await server.inject({
+      url: `${basePath}/summary`,
       method: 'POST',
-      url: '/file-upload-basic/summary',
       headers,
       payload: { form }
     })
@@ -196,18 +192,17 @@ describe('Submission journey test', () => {
       sessionId: expect.any(String)
     })
 
-    expect(submitRes.statusCode).toBe(redirectStatusCode)
-    expect(submitRes.headers.location).toBe('/file-upload-basic/status')
+    expect(submitRes.statusCode).toBe(302)
+    expect(submitRes.headers.location).toBe(`${basePath}/status`)
 
     // Finally GET the /{slug}/status page
     const statusRes = await server.inject({
-      method: 'GET',
-      url: '/file-upload-basic/status',
+      url: `${basePath}/status`,
       headers
     })
 
-    expect(statusRes.statusCode).toBe(okStatusCode)
-    expect(statusRes.headers['content-type']).toContain(htmlContentType)
+    expect(statusRes.statusCode).toBe(200)
+    expect(statusRes.headers['content-type']).toContain('text/html')
     expect(persistFiles).toHaveBeenCalledWith(
       [
         {

--- a/test/form/phase-banner.test.js
+++ b/test/form/phase-banner.test.js
@@ -25,18 +25,18 @@ describe(`Phase banner`, () => {
   })
 
   test('shows the server phase tag by default', async () => {
+    const basePath = '/phase-default'
+
     server = await createServer({
       formFileName: 'phase-default.json',
       formFilePath: join(testDir, 'definitions')
     })
+
     await server.initialize()
 
-    const options = {
-      method: 'GET',
-      url: '/phase-default/first-page'
-    }
-
-    await renderResponse(server, options)
+    await renderResponse(server, {
+      url: `${basePath}/first-page`
+    })
 
     const $phaseBanner = /** @type {HTMLElement} */ (
       document.querySelector('.govuk-phase-banner')
@@ -47,18 +47,18 @@ describe(`Phase banner`, () => {
   })
 
   test('shows the form phase tag if provided', async () => {
+    const basePath = '/phase-alpha'
+
     server = await createServer({
       formFileName: 'phase-alpha.json',
       formFilePath: join(testDir, 'definitions')
     })
+
     await server.initialize()
 
-    const options = {
-      method: 'GET',
-      url: '/phase-alpha/first-page'
-    }
-
-    await renderResponse(server, options)
+    await renderResponse(server, {
+      url: `${basePath}/first-page`
+    })
 
     const $phaseBanner = /** @type {HTMLElement} */ (
       document.querySelector('.govuk-phase-banner')

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -19,12 +19,7 @@ jest.mock('~/src/server/plugins/engine/services/formsService.js')
 jest.mock('~/src/server/plugins/engine/services/formSubmissionService.js')
 
 const testDir = dirname(fileURLToPath(import.meta.url))
-
-const okStatusCode = 200
-const redirectStatusCode = 302
-const notFoundStatusCode = 404
-
-const url = '/repeat/pizza-order'
+const basePath = '/repeat'
 
 /**
  * POST a new repeat item
@@ -40,31 +35,26 @@ async function createRepeatItem(
   headers,
   itemId = randomUUID()
 ) {
-  const itemUrl = `${url}/${itemId}`
-
   // Issue a GET request to the item
   // page to add to the progress stack
   await server.inject({
-    method: 'GET',
-    url: itemUrl,
+    url: `${basePath}/pizza-order/${itemId}`,
     headers
   })
 
-  const options = {
+  const res1 = await server.inject({
+    url: `${basePath}/pizza-order/${itemId}`,
     method: 'POST',
-    url: itemUrl,
     headers,
     payload: {
       toppings: 'Ham',
       quantity: 2
     }
-  }
+  })
 
-  const res1 = await server.inject(options)
-
-  expect(res1.statusCode).toBe(redirectStatusCode)
+  expect(res1.statusCode).toBe(302)
   expect(res1.headers.location).toBe(
-    `/repeat/pizza-order/summary?itemId=${itemId}`
+    `${basePath}/pizza-order/summary?itemId=${itemId}`
   )
 
   const repeatName = repeatPage.repeat.options.name
@@ -128,38 +118,31 @@ describe('Repeat GET tests', () => {
     await server.stop()
   })
 
-  test('GET /repeat/pizza-order returns 303', async () => {
-    const options = {
-      method: 'GET',
-      url
-    }
-
-    const res = await server.inject(options)
+  test('GET /pizza-order returns 303', async () => {
+    const res = await server.inject({
+      url: `${basePath}/pizza-order`
+    })
 
     expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
   })
 
-  test('GET /repeat/pizza-order/summary returns 200', async () => {
-    const options = {
-      method: 'GET',
-      url: `${url}/summary`
-    }
+  test('GET /pizza-order/summary returns 200', async () => {
+    const res = await server.inject({
+      url: `${basePath}/pizza-order/summary`
+    })
 
-    const res = await server.inject(options)
-
-    expect(res.statusCode).toBe(okStatusCode)
+    expect(res.statusCode).toBe(200)
   })
 
-  test('GET /repeat/pizza-order/{id} returns 200', async () => {
+  test('GET /pizza-order/{id} returns 200', async () => {
     const { item, headers } = await createRepeatItem(server, repeatPage)
-    const options = {
-      method: 'GET',
-      url: `${url}/${item.itemId}`,
-      headers
-    }
-    const { container, response } = await renderResponse(server, options)
 
-    expect(response.statusCode).toBe(okStatusCode)
+    const { container, response } = await renderResponse(server, {
+      url: `${basePath}/pizza-order/${item.itemId}`,
+      headers
+    })
+
+    expect(response.statusCode).toBe(200)
 
     const $heading1 = container.getByRole('heading', {
       name: 'Pizza order',
@@ -178,7 +161,7 @@ describe('Repeat GET tests', () => {
     expect($heading2).toHaveClass('govuk-caption-l')
   })
 
-  test('GET /repeat/pizza-order/{id} returns 200 with back link', async () => {
+  test('GET /pizza-order/{id} returns 200 with back link', async () => {
     const { item, headers, redirectLocation } = await createRepeatItem(
       server,
       repeatPage
@@ -191,19 +174,16 @@ describe('Repeat GET tests', () => {
     // Visit the summary page to append to the progress stack to
     // ensure the back link is rendered on the next page request
     await server.inject({
-      method: 'GET',
       url: redirectLocation,
       headers
     })
 
-    const options = {
-      method: 'GET',
-      url: `${url}/${item.itemId}`,
+    const { container, response } = await renderResponse(server, {
+      url: `${basePath}/pizza-order/${item.itemId}`,
       headers
-    }
-    const { container, response } = await renderResponse(server, options)
+    })
 
-    expect(response.statusCode).toBe(okStatusCode)
+    expect(response.statusCode).toBe(200)
 
     const $heading1 = container.getByRole('heading', {
       name: 'Pizza order',
@@ -228,43 +208,39 @@ describe('Repeat GET tests', () => {
     expect($backLink).toBeInTheDocument()
     expect($backLink).toHaveAttribute(
       'href',
-      `/repeat/pizza-order/summary?itemId=${item.itemId}`
+      `${basePath}/pizza-order/summary?itemId=${item.itemId}`
     )
   })
 
-  test('GET /repeat/pizza-order/{id}/confirm-delete returns 200', async () => {
+  test('GET /pizza-order/{id}/confirm-delete returns 200', async () => {
     const { item, headers } = await createRepeatItem(server, repeatPage)
+
     const res = await server.inject({
-      method: 'GET',
-      url: `${url}/${item.itemId}/confirm-delete`,
+      url: `${basePath}/pizza-order/${item.itemId}/confirm-delete`,
       headers
     })
 
-    expect(res.statusCode).toBe(okStatusCode)
+    expect(res.statusCode).toBe(200)
   })
 
-  test('GET /repeat/pizza-order/{id}/confirm-delete with unknown itemId returns 404', async () => {
+  test('GET /pizza-order/{id}/confirm-delete with unknown itemId returns 404', async () => {
     const res = await server.inject({
-      method: 'GET',
-      url: `${url}/00000000-0000-0000-0000-000000000000/confirm-delete`
+      url: `${basePath}/pizza-order/00000000-0000-0000-0000-000000000000/confirm-delete`
     })
 
-    expect(res.statusCode).toBe(notFoundStatusCode)
+    expect(res.statusCode).toBe(404)
   })
 
-  test('GET /repeat/pizza-order/summary with items returns 200', async () => {
+  test('GET /pizza-order/summary with items returns 200', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
     await createRepeatItem(server, repeatPage, 2, headers)
 
-    const options = {
-      method: 'GET',
-      url: `${url}/summary`,
+    const res = await server.inject({
+      url: `${basePath}/pizza-order/summary`,
       headers
-    }
+    })
 
-    const res = await server.inject(options)
-
-    expect(res.statusCode).toBe(okStatusCode)
+    expect(res.statusCode).toBe(200)
   })
 })
 
@@ -302,11 +278,12 @@ describe('Repeat POST tests', () => {
     await server.stop()
   })
 
-  test('POST /repeat/pizza-order/{id} returns 302', async () => {
+  test('POST /pizza-order/{id} returns 302', async () => {
     const { item, headers } = await createRepeatItem(server, repeatPage)
+
     const res = await server.inject({
+      url: `${basePath}/pizza-order/${item.itemId}`,
       method: 'POST',
-      url: `${url}/${item.itemId}`,
       headers,
       payload: {
         toppings: 'Ham',
@@ -314,68 +291,70 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(redirectStatusCode)
+    expect(res.statusCode).toBe(302)
     expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/summary?/)
   })
 
-  test('POST /repeat/pizza-order/{id}/confirm-delete returns 302', async () => {
+  test('POST /pizza-order/{id}/confirm-delete returns 302', async () => {
     const { item, headers } = await createRepeatItem(server, repeatPage)
+
     const res = await server.inject({
+      url: `${basePath}/pizza-order/${item.itemId}/confirm-delete`,
       method: 'POST',
-      url: `${url}/${item.itemId}/confirm-delete`,
       headers,
       payload: {
         confirm: true
       }
     })
 
-    expect(res.statusCode).toBe(redirectStatusCode)
+    expect(res.statusCode).toBe(302)
     expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/summary/)
   })
 
-  test('POST /repeat/pizza-order/summary ADD_ANOTHER returns 302', async () => {
+  test('POST /pizza-order/summary ADD_ANOTHER returns 302', async () => {
     const res = await server.inject({
       method: 'POST',
-      url: `${url}/summary`,
+      url: `${basePath}/pizza-order/summary`,
       payload: {
         action: ADD_ANOTHER
       }
     })
 
-    expect(res.statusCode).toBe(redirectStatusCode)
-    expect(res.headers.location).toBe('/repeat/pizza-order')
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe(`${basePath}/pizza-order`)
   })
 
-  test('POST /repeat/pizza-order/summary CONTINUE returns 302', async () => {
+  test('POST /pizza-order/summary CONTINUE returns 302', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
 
     const res = await server.inject({
+      url: `${basePath}/pizza-order/summary`,
       method: 'POST',
-      url: `${url}/summary`,
       headers,
       payload: {
         action: CONTINUE
       }
     })
 
-    expect(res.statusCode).toBe(redirectStatusCode)
-    expect(res.headers.location).toBe('/repeat/summary')
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe(`${basePath}/summary`)
   })
 
-  test('POST /repeat/pizza-order/summary ADD_ANOTHER returns 200 with errors over schema.max', async () => {
+  test('POST /pizza-order/summary ADD_ANOTHER returns 200 with errors over schema.max', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
+
     await createRepeatItem(server, repeatPage, 2, headers)
 
     const { container, response } = await renderResponse(server, {
+      url: `${basePath}/pizza-order/summary`,
       method: 'POST',
-      url: `${url}/summary`,
       headers,
       payload: {
         action: ADD_ANOTHER
       }
     })
 
-    expect(response.statusCode).toBe(okStatusCode)
+    expect(response.statusCode).toBe(200)
 
     const $errorSummary = container.getByRole('alert')
     const $errorItems = within($errorSummary).getAllByRole('listitem')
@@ -389,31 +368,30 @@ describe('Repeat POST tests', () => {
     expect($errorItems[0]).toHaveTextContent('You can only add up to 2 Pizzas')
   })
 
-  test('POST /repeat/pizza-order/summary CONTINUE returns 302 to /summary', async () => {
+  test('POST /pizza-order/summary CONTINUE returns 302 to /summary', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
 
     const res = await server.inject({
+      url: `${basePath}/pizza-order/summary`,
       method: 'POST',
-      url: `${url}/summary`,
       headers,
       payload: {
         action: CONTINUE
       }
     })
 
-    expect(res.statusCode).toBe(redirectStatusCode)
-    expect(res.headers.location).toBe('/repeat/summary')
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe(`${basePath}/summary`)
 
     const { container, response } = await renderResponse(server, {
-      method: 'GET',
-      url: '/repeat/summary',
+      url: `${basePath}/summary`,
       headers,
       payload: {
         action: CONTINUE
       }
     })
 
-    expect(response.statusCode).toBe(okStatusCode)
+    expect(response.statusCode).toBe(200)
 
     const $values = container
       .getAllByRole('definition')
@@ -424,32 +402,32 @@ describe('Repeat POST tests', () => {
     expect($values[0]).toHaveTextContent('You added 1 Pizza')
   })
 
-  test('POST /repeat/pizza-order/summary with 2 items CONTINUE returns 302 to /summary', async () => {
+  test('POST /pizza-order/summary with 2 items CONTINUE returns 302 to /summary', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
+
     await createRepeatItem(server, repeatPage, 2, headers)
 
     const res1 = await server.inject({
+      url: `${basePath}/pizza-order/summary`,
       method: 'POST',
-      url: `${url}/summary`,
       headers,
       payload: {
         action: CONTINUE
       }
     })
 
-    expect(res1.statusCode).toBe(redirectStatusCode)
-    expect(res1.headers.location).toBe('/repeat/summary')
+    expect(res1.statusCode).toBe(302)
+    expect(res1.headers.location).toBe(`${basePath}/summary`)
 
     const { container, response: res2 } = await renderResponse(server, {
-      method: 'GET',
-      url: '/repeat/summary',
+      url: `${basePath}/summary`,
       headers,
       payload: {
         action: CONTINUE
       }
     })
 
-    expect(res2.statusCode).toBe(okStatusCode)
+    expect(res2.statusCode).toBe(200)
 
     const $values = container
       .getAllByRole('definition')
@@ -462,7 +440,7 @@ describe('Repeat POST tests', () => {
     // POST the summary page
     await server.inject({
       method: 'POST',
-      url: '/repeat/summary',
+      url: `${basePath}/summary`,
       headers
     })
 

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -52,7 +52,7 @@ async function createRepeatItem(
     }
   })
 
-  expect(res1.statusCode).toBe(302)
+  expect(res1.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
   expect(res1.headers.location).toBe(
     `${basePath}/pizza-order/summary?itemId=${itemId}`
   )
@@ -131,7 +131,7 @@ describe('Repeat GET tests', () => {
       url: `${basePath}/pizza-order/summary`
     })
 
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(StatusCodes.OK)
   })
 
   test('GET /pizza-order/{id} returns 200', async () => {
@@ -142,7 +142,7 @@ describe('Repeat GET tests', () => {
       headers
     })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(StatusCodes.OK)
 
     const $heading1 = container.getByRole('heading', {
       name: 'Pizza order',
@@ -183,7 +183,7 @@ describe('Repeat GET tests', () => {
       headers
     })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(StatusCodes.OK)
 
     const $heading1 = container.getByRole('heading', {
       name: 'Pizza order',
@@ -220,7 +220,7 @@ describe('Repeat GET tests', () => {
       headers
     })
 
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(StatusCodes.OK)
   })
 
   test('GET /pizza-order/{id}/confirm-delete with unknown itemId returns 404', async () => {
@@ -228,7 +228,7 @@ describe('Repeat GET tests', () => {
       url: `${basePath}/pizza-order/00000000-0000-0000-0000-000000000000/confirm-delete`
     })
 
-    expect(res.statusCode).toBe(404)
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
   })
 
   test('GET /pizza-order/summary with items returns 200', async () => {
@@ -240,7 +240,7 @@ describe('Repeat GET tests', () => {
       headers
     })
 
-    expect(res.statusCode).toBe(200)
+    expect(res.statusCode).toBe(StatusCodes.OK)
   })
 })
 
@@ -291,7 +291,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/summary?/)
   })
 
@@ -307,7 +307,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/summary/)
   })
 
@@ -320,7 +320,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/pizza-order`)
   })
 
@@ -336,7 +336,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/summary`)
   })
 
@@ -354,7 +354,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(StatusCodes.OK)
 
     const $errorSummary = container.getByRole('alert')
     const $errorItems = within($errorSummary).getAllByRole('listitem')
@@ -380,7 +380,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(302)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toBe(`${basePath}/summary`)
 
     const { container, response } = await renderResponse(server, {
@@ -391,7 +391,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(response.statusCode).toBe(200)
+    expect(response.statusCode).toBe(StatusCodes.OK)
 
     const $values = container
       .getAllByRole('definition')
@@ -416,7 +416,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res1.statusCode).toBe(302)
+    expect(res1.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res1.headers.location).toBe(`${basePath}/summary`)
 
     const { container, response: res2 } = await renderResponse(server, {
@@ -427,7 +427,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res2.statusCode).toBe(200)
+    expect(res2.statusCode).toBe(StatusCodes.OK)
 
     const $values = container
       .getAllByRole('definition')

--- a/test/form/summary-submission-email.test.js
+++ b/test/form/summary-submission-email.test.js
@@ -7,11 +7,12 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/minimal'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 jest.mock('~/src/server/plugins/engine/services/formSubmissionService.js')
 
-describe('Page: /basic/summary', () => {
+describe('Page: /summary', () => {
   /** @type {Server} */
   let server
 
@@ -26,14 +27,11 @@ describe('Page: /basic/summary', () => {
   })
 
   it('should render the page with email notification warning', async () => {
-    const options = {
-      method: 'GET',
-      url: '/basic/summary'
-    }
-
     jest.mocked(getFormMetadata).mockResolvedValue(fixtures.form.metadata)
 
-    const { container } = await renderResponse(server, options)
+    const { container } = await renderResponse(server, {
+      url: `${basePath}/summary`
+    })
 
     const $warning = container.getByRole('link', {
       name: 'enter the email address (opens in new tab)'
@@ -43,16 +41,14 @@ describe('Page: /basic/summary', () => {
   })
 
   it('should render the page with no email notification warning', async () => {
-    const options = {
-      method: 'GET',
-      url: '/basic/summary'
-    }
-
     jest.mocked(getFormMetadata).mockResolvedValue({
       ...fixtures.form.metadata,
       notificationEmail: 'defra@gov.uk'
     })
-    const { container } = await renderResponse(server, options)
+
+    const { container } = await renderResponse(server, {
+      url: `${basePath}/summary`
+    })
 
     const $warning = container.queryByRole('link', {
       name: 'enter the email address (opens in new tab)'

--- a/test/form/titles.test.js
+++ b/test/form/titles.test.js
@@ -8,6 +8,7 @@ import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
 const testDir = dirname(fileURLToPath(import.meta.url))
+const basePath = '/titles'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
@@ -30,7 +31,7 @@ describe('Title and section title', () => {
     headers = getCookieHeader(
       await server.inject({
         method: 'GET',
-        url: '/titles/applicant-one'
+        url: `${basePath}/applicant-one`
       }),
       'session'
     )
@@ -41,14 +42,11 @@ describe('Title and section title', () => {
   })
 
   it('does not render the section title if it is the same as the title', async () => {
-    const options = {
-      method: 'GET',
-      url: '/titles/applicant-one'
-    }
-
     jest.mocked(getFormMetadata).mockResolvedValue(fixtures.form.metadata)
 
-    const { container } = await renderResponse(server, options)
+    const { container } = await renderResponse(server, {
+      url: `${basePath}/applicant-one`
+    })
 
     const $section = document.getElementById('section-title')
     const $heading = container.getByRole('heading', {
@@ -62,14 +60,11 @@ describe('Title and section title', () => {
   })
 
   it('render warning when notification email is not set', async () => {
-    const options = {
-      method: 'GET',
-      url: '/titles/applicant-one'
-    }
-
     jest.mocked(getFormMetadata).mockResolvedValue(fixtures.form.metadata)
 
-    const { container } = await renderResponse(server, options)
+    const { container } = await renderResponse(server, {
+      url: `${basePath}/applicant-one`
+    })
 
     const $warning = container.queryByRole('link', {
       name: 'enter the email address (opens in new tab)'
@@ -79,17 +74,14 @@ describe('Title and section title', () => {
   })
 
   it('does not render the warning when notification email is set', async () => {
-    const options = {
-      method: 'GET',
-      url: '/titles/applicant-one'
-    }
-
     jest.mocked(getFormMetadata).mockResolvedValue({
       ...fixtures.form.metadata,
       notificationEmail: 'defra@gov.uk'
     })
 
-    const { container } = await renderResponse(server, options)
+    const { container } = await renderResponse(server, {
+      url: `${basePath}/applicant-one`
+    })
 
     const $warning = container.queryByRole('link', {
       name: 'enter the email address (opens in new tab)'
@@ -99,13 +91,10 @@ describe('Title and section title', () => {
   })
 
   it('does render the section title if it is not the same as the title', async () => {
-    const options = {
-      method: 'GET',
-      url: '/titles/applicant-one-address',
+    const { container } = await renderResponse(server, {
+      url: `${basePath}/applicant-one-address`,
       headers
-    }
-
-    const { container } = await renderResponse(server, options)
+    })
 
     const $section = container.getByRole('heading', {
       name: 'Applicant 1',
@@ -124,14 +113,11 @@ describe('Title and section title', () => {
     expect($heading).toHaveClass('govuk-fieldset__heading')
   })
 
-  it('Does not render the section title if hideTitle is set to true', async () => {
-    const options = {
-      method: 'GET',
-      url: '/titles/applicant-two',
+  it('does not render the section title if hideTitle is set to true', async () => {
+    const { container } = await renderResponse(server, {
+      url: `${basePath}/applicant-two`,
       headers
-    }
-
-    const { container } = await renderResponse(server, options)
+    })
 
     const $section = document.getElementById('section-title')
     const $heading = container.getByRole('heading', {
@@ -145,13 +131,10 @@ describe('Title and section title', () => {
   })
 
   it('render title with optional when there is single component in page and is selected as optional', async () => {
-    const options = {
-      method: 'GET',
+    const { container } = await renderResponse(server, {
       url: '/titles/applicant-one-address-optional',
       headers
-    }
-
-    const { container } = await renderResponse(server, options)
+    })
 
     const $heading = container.getByRole('heading', {
       name: 'Address (optional)',


### PR DESCRIPTION
This PR adds new page controller getters/methods to assist when walking the form journey

* `page.href`
* `page.getStartPath()`

Mainly to avoid this everywhere:

```patch
- return `/${this.model.basePath || ''}${page.path}`
+ return page.href
```

I've also simplified some page methods where possible

## Test tweaks

I've also added `basePath` to form tests and removed the consts we added to appease Sonar:

```patch
- const okStatusCode = 200
- const redirectStatusCode = 302
- const badRequestStatusCode = 400
```