### PR TITLE
Remove collection field `customValidationMessages` support

### DIFF
--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -2,7 +2,6 @@ import { type ComponentDef } from '@defra/forms-model'
 import joi, {
   type CustomValidator,
   type ErrorReportCollection,
-  type LanguageMessages,
   type ObjectSchema
 } from 'joi'
 
@@ -56,11 +55,6 @@ export class ComponentCollection {
        * Defines a custom validation rule for the object schema
        */
       custom?: CustomValidator
-
-      /**
-       * Defines custom validation messages for the object schema
-       */
-      messages?: LanguageMessages
     }
   ) {
     const components = defs.map((def) => createComponent(def, props))
@@ -83,10 +77,6 @@ export class ComponentCollection {
       stateSchema = collection
         ? stateSchema.concat(collection.stateSchema)
         : stateSchema.keys({ [name]: field.stateSchema })
-    }
-
-    if (schema?.messages) {
-      formSchema = formSchema.messages(schema.messages)
     }
 
     // Add parent field title to collection field errors

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -92,7 +92,6 @@ export class DatePartsField extends FormComponent {
       { ...props, parent: this },
       {
         custom: getValidatorDate(this),
-        messages: customValidationMessages,
         peers: [`${name}__day`, `${name}__month`, `${name}__year`]
       }
     )

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -80,7 +80,6 @@ export class MonthYearField extends FormComponent {
       { ...props, parent: this },
       {
         custom: getValidatorMonthYear(this),
-        messages: customValidationMessages,
         peers: [`${name}__month`, `${name}__year`]
       }
     )


### PR DESCRIPTION
This PR removes collection field `customValidationMessages` support to fix [bug #483388](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/483388)

Thankfully this feature wasn't used as date fields set `customValidationMessages` per field already

<img width="678" alt="Date field custom message" src="https://github.com/user-attachments/assets/9322e9a8-e7e8-4bb1-85bb-6db1e6656902">

## Context

We added support for nested field `customValidationMessages` in:

* https://github.com/DEFRA/forms-runner/pull/534

Applying these messages at both `joi.object()` (date) and `joi.number()` (day, month, year) level:

https://github.com/DEFRA/forms-runner/blob/df09df5437104c5f18fa40beddae8932960b60aa/src/server/plugins/engine/components/DatePartsField.ts#L43-L51

## The bug

Due to Joi `formSchema.concat()` these object-level messages overwrite the page collection messages

https://github.com/DEFRA/forms-runner/blob/df09df5437104c5f18fa40beddae8932960b60aa/src/server/plugins/engine/components/ComponentCollection.ts#L69-L75