### PR TITLE
Switch to HTTP 303 redirects (after POST)

### DIFF
--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -12,7 +12,7 @@ import {
   tempItemSchema,
   tempStatusSchema
 } from '~/src/server/plugins/engine/components/FileUploadField.js'
-import { getError, proceed } from '~/src/server/plugins/engine/helpers.js'
+import { getError } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import {
@@ -129,7 +129,7 @@ export class FileUploadPageController extends PageController {
       const removed = await this.checkRemovedFiles(request, state, cacheService)
 
       if (removed) {
-        return proceed(request, h, request.path)
+        return this.proceed(request, h, this.path)
       }
 
       await this.refreshUpload(request, state, cacheService)

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -506,13 +506,11 @@ export class PageControllerBase {
       | ResponseToolkit<FormRequestPayloadRefs>,
     nextPath?: string
   ) {
-    // Continue to same page
-    if (!nextPath) {
-      return proceed(request, h, request.path)
-    }
+    const nextUrl = nextPath
+      ? this.getHref(nextPath) // Redirect to next page
+      : this.href // Redirect to current page (refresh)
 
-    // Continue to next page
-    return proceed(request, h, this.getHref(nextPath))
+    return proceed(request, h, nextUrl)
   }
 
   /**

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -3,14 +3,9 @@ import { randomUUID } from 'crypto'
 import { ControllerType, type Page, type Repeat } from '@defra/forms-model'
 import { badImplementation, badRequest, notFound } from '@hapi/boom'
 import { type ResponseToolkit } from '@hapi/hapi'
-import { StatusCodes } from 'http-status-codes'
 import Joi from 'joi'
 
-import {
-  ADD_ANOTHER,
-  CONTINUE,
-  proceed
-} from '~/src/server/plugins/engine/helpers.js'
+import { ADD_ANOTHER, CONTINUE } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import {
@@ -182,10 +177,11 @@ export class RepeatPageController extends PageController {
       request: FormRequest,
       h: ResponseToolkit<FormRequestRefs>
     ) => {
+      const { path } = this
+
       if (!request.params.itemId) {
-        return h
-          .redirect(`${request.path}/${randomUUID()}${request.url.search}`)
-          .code(StatusCodes.SEE_OTHER)
+        const nextPath = `${path}/${randomUUID()}${request.url.search}`
+        return super.proceed(request, h, nextPath)
       }
 
       await this.setRepeatAppData(request)
@@ -228,7 +224,7 @@ export class RepeatPageController extends PageController {
       request: FormRequestPayload,
       h: ResponseToolkit<FormRequestPayloadRefs>
     ) => {
-      const { href, model, repeat } = this
+      const { model, path, repeat } = this
       const { payload } = request
       const { action } = payload
 
@@ -254,7 +250,7 @@ export class RepeatPageController extends PageController {
           return h.view(this.listSummaryViewName, viewModel)
         }
 
-        return proceed(request, h, `${href}${request.url.search}`)
+        return super.proceed(request, h, `${path}${request.url.search}`)
       } else if (action === CONTINUE) {
         return super.proceed(
           request,

--- a/test/condition/checkboxes.test.js
+++ b/test/condition/checkboxes.test.js
@@ -89,7 +89,7 @@ describe('Checkboxes based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/second-page`)
   })
 
@@ -104,7 +104,7 @@ describe('Checkboxes based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/third-page`)
   })
 })

--- a/test/condition/radios.test.js
+++ b/test/condition/radios.test.js
@@ -89,7 +89,7 @@ describe('Radio based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/second-page`)
   })
 
@@ -104,7 +104,7 @@ describe('Radio based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/third-page`)
   })
 })

--- a/test/condition/text.test.js
+++ b/test/condition/text.test.js
@@ -80,7 +80,7 @@ describe('TextField based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/second-page`)
   })
 
@@ -95,7 +95,7 @@ describe('TextField based conditions', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/third-page`)
   })
 })

--- a/test/form/csrf.test.js
+++ b/test/form/csrf.test.js
@@ -65,7 +65,7 @@ describe('CSRF', () => {
     expect(response.statusCode).toBe(StatusCodes.FORBIDDEN)
   })
 
-  test('post request with CSRF token returns 302 redirect', async () => {
+  test('post request with CSRF token returns 303 redirect', async () => {
     const csrfToken = 'dummy-token'
 
     const response = await server.inject({
@@ -80,7 +80,7 @@ describe('CSRF', () => {
       }
     })
 
-    expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
   })
 })
 

--- a/test/form/exit-page.test.js
+++ b/test/form/exit-page.test.js
@@ -112,7 +112,7 @@ describe('Exit pages', () => {
           payload: { ...payload, crumb: csrfToken }
         })
 
-        expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+        expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
         expect(response.headers.location).toBe(`${basePath}${paths.next}`)
       })
 

--- a/test/form/fields-optional.test.js
+++ b/test/form/fields-optional.test.js
@@ -226,7 +226,7 @@ describe('Form fields (optional)', () => {
           payload: { ...payload, crumb: csrfToken }
         })
 
-        expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+        expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
         expect(response.headers.location).toBe(`${basePath}${paths.next}`)
       })
     }

--- a/test/form/fields-required.test.js
+++ b/test/form/fields-required.test.js
@@ -283,7 +283,7 @@ describe('Form fields (required)', () => {
           payload: { ...payload, crumb: csrfToken }
         })
 
-        expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+        expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
         expect(response.headers.location).toBe(`${basePath}${paths.next}`)
       })
     }

--- a/test/form/file-upload.test.js
+++ b/test/form/file-upload.test.js
@@ -251,7 +251,7 @@ describe('File upload POST tests', () => {
     )
   })
 
-  test('POST /methodology-statement with 2 valid files returns 302 to /summary', async () => {
+  test('POST /methodology-statement with 2 valid files returns 303 to /summary', async () => {
     jest.mocked(initiateUpload).mockResolvedValue(uploadInitiateResponse)
     jest.mocked(getUploadStatus).mockResolvedValue(readyStatusResponse)
 
@@ -278,7 +278,7 @@ describe('File upload POST tests', () => {
       payload: {}
     })
 
-    expect(res3.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res3.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res3.headers.location).toBe(`${basePath}/summary`)
   })
 
@@ -311,7 +311,7 @@ describe('File upload POST tests', () => {
       }
     })
 
-    expect(res3.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res3.statusCode).toBe(StatusCodes.SEE_OTHER)
   })
 })
 

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -98,7 +98,7 @@ describe('Submission journey test', () => {
     expect(res.headers['content-type']).toContain('text/html')
   })
 
-  test('POST /summary returns 302', async () => {
+  test('POST /summary returns 303', async () => {
     const sender = jest.mocked(sendNotification)
     jest.mocked(initiateUpload).mockResolvedValue(uploadInitiateResponse)
     jest.mocked(getUploadStatus).mockResolvedValue(readyStatusResponse)
@@ -370,7 +370,7 @@ describe('Submission journey test', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/methodology-statement`)
 
     return res
@@ -394,7 +394,7 @@ describe('Submission journey test', () => {
       payload: {}
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/summary`)
 
     return res
@@ -417,7 +417,7 @@ describe('Submission journey test', () => {
       payload: {}
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/status`)
 
     return res

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -223,7 +223,7 @@ describe('Form journey', () => {
             payload: { ...payload, crumb: csrfToken }
           })
 
-          expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+          expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
           expect(response.headers.location).toBe(`${basePath}${paths.next}`)
         })
       }
@@ -348,7 +348,7 @@ describe('Form journey', () => {
             payload: { ...payload, crumb: csrfToken }
           })
 
-          expect(response2.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+          expect(response2.statusCode).toBe(StatusCodes.SEE_OTHER)
           expect(response2.headers.location).toBe(returnUrl)
         }
       }
@@ -401,7 +401,7 @@ describe('Form journey', () => {
         sessionId: expect.any(String)
       })
 
-      expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+      expect(response.statusCode).toBe(StatusCodes.SEE_OTHER)
       expect(response.headers.location).toBe(`${basePath}/status`)
 
       const { container } = await renderResponse(server, {

--- a/test/form/persist-files.test.js
+++ b/test/form/persist-files.test.js
@@ -109,7 +109,7 @@ describe('Submission journey test', () => {
     expect(res.headers['content-type']).toContain('text/html')
   })
 
-  test('POST /file-upload-component returns 302', async () => {
+  test('POST /file-upload-component returns 303', async () => {
     jest.spyOn(CacheService.prototype, 'getUploadState').mockResolvedValueOnce(
       /** @type {TempFileState} */ ({
         upload: {
@@ -155,7 +155,7 @@ describe('Submission journey test', () => {
       payload: form
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/summary`)
 
     // Extract the session cookie
@@ -194,7 +194,7 @@ describe('Submission journey test', () => {
       sessionId: expect.any(String)
     })
 
-    expect(submitRes.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(submitRes.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(submitRes.headers.location).toBe(`${basePath}/status`)
 
     // Finally GET the /{slug}/status page

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -52,7 +52,7 @@ async function createRepeatItem(
     }
   })
 
-  expect(res1.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+  expect(res1.statusCode).toBe(StatusCodes.SEE_OTHER)
   expect(res1.headers.location).toBe(
     `${basePath}/pizza-order/summary?itemId=${itemId}`
   )
@@ -118,12 +118,12 @@ describe('Repeat GET tests', () => {
     await server.stop()
   })
 
-  test('GET /pizza-order returns 303', async () => {
+  test('GET /pizza-order returns 302', async () => {
     const res = await server.inject({
       url: `${basePath}/pizza-order`
     })
 
-    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
   })
 
   test('GET /pizza-order/summary returns 200', async () => {
@@ -278,7 +278,7 @@ describe('Repeat POST tests', () => {
     await server.stop()
   })
 
-  test('POST /pizza-order/{id} returns 302', async () => {
+  test('POST /pizza-order/{id} returns 303', async () => {
     const { item, headers } = await createRepeatItem(server, repeatPage)
 
     const res = await server.inject({
@@ -291,11 +291,11 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/summary?/)
   })
 
-  test('POST /pizza-order/{id}/confirm-delete returns 302', async () => {
+  test('POST /pizza-order/{id}/confirm-delete returns 303', async () => {
     const { item, headers } = await createRepeatItem(server, repeatPage)
 
     const res = await server.inject({
@@ -307,11 +307,11 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/summary/)
   })
 
-  test('POST /pizza-order/summary ADD_ANOTHER returns 302', async () => {
+  test('POST /pizza-order/summary ADD_ANOTHER returns 303', async () => {
     const res = await server.inject({
       method: 'POST',
       url: `${basePath}/pizza-order/summary`,
@@ -320,11 +320,11 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/pizza-order`)
   })
 
-  test('POST /pizza-order/summary CONTINUE returns 302', async () => {
+  test('POST /pizza-order/summary CONTINUE returns 303', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
 
     const res = await server.inject({
@@ -336,7 +336,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/summary`)
   })
 
@@ -368,7 +368,7 @@ describe('Repeat POST tests', () => {
     expect($errorItems[0]).toHaveTextContent('You can only add up to 2 Pizzas')
   })
 
-  test('POST /pizza-order/summary CONTINUE returns 302 to /summary', async () => {
+  test('POST /pizza-order/summary CONTINUE returns 303 to /summary', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
 
     const res = await server.inject({
@@ -380,7 +380,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toBe(`${basePath}/summary`)
 
     const { container, response } = await renderResponse(server, {
@@ -402,7 +402,7 @@ describe('Repeat POST tests', () => {
     expect($values[0]).toHaveTextContent('You added 1 Pizza')
   })
 
-  test('POST /pizza-order/summary with 2 items CONTINUE returns 302 to /summary', async () => {
+  test('POST /pizza-order/summary with 2 items CONTINUE returns 303 to /summary', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
 
     await createRepeatItem(server, repeatPage, 2, headers)
@@ -416,7 +416,7 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res1.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res1.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res1.headers.location).toBe(`${basePath}/summary`)
 
     const { container, response: res2 } = await renderResponse(server, {


### PR DESCRIPTION
Improvements added to https://github.com/DEFRA/forms-runner/pull/570 as discussed

* Change more redirects over to `this.proceed()`
* Switch to HTTP 303 redirects (after POST)