### PR TITLE
Match label font size/weight when amongst legends

### DIFF
--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -225,7 +225,8 @@ describe('QuestionPageController', () => {
 
       // Page 2, component 3, default label
       expect(components2[2].model).toHaveProperty('label', {
-        text: 'Remarks'
+        text: 'Remarks',
+        classes: 'govuk-label--m'
       })
 
       // Page 2, component 3, optional legend

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -134,6 +134,21 @@ export class QuestionPageController extends PageController {
       }
 
       showTitle = !isPageHeading
+    } else {
+      const legends = formComponents.flatMap(
+        ({ model }) => model.fieldset?.legend ?? []
+      )
+
+      // Match label font size/weight when amongst legends
+      if (legends.length < formComponents.length) {
+        for (const { model } of formComponents) {
+          if (!model.label || model.fieldset) {
+            continue
+          }
+
+          model.label.classes = 'govuk-label--m'
+        }
+      }
     }
 
     return {


### PR DESCRIPTION
Demo PR to show Dan

Parked for future discussions

# Before

The default GOV.UK Frontend styling uses regular weight field labels

We apply bold weight for page headings and legends as shown in [address](https://design-system.service.gov.uk/patterns/addresses/multiple/), [date](https://design-system.service.gov.uk/patterns/dates/default/) and [bank details](https://design-system.service.gov.uk/patterns/bank-details/default/) examples

<img width="682" alt="Label weight before" src="https://github.com/user-attachments/assets/003a33ab-96b5-4e4a-8840-81ba5682c64d" />

# After

This PR shows automatic bold weight styling added to field labels when amongst legends

<img width="683" alt="Label weight after" src="https://github.com/user-attachments/assets/c309bd96-ff64-4aa6-91d7-4773515ee2ef" />
