### PR TITLE
Add tests for page controller properties + methods

### DIFF
--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -4,7 +4,7 @@ import joi, { type ArraySchema } from 'joi'
 import { isFormValue } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { SelectionControlField } from '~/src/server/plugins/engine/components/SelectionControlField.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
-import { type PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
+import { type QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
   type FormState,
   type FormStateValue,
@@ -83,7 +83,7 @@ export class CheckboxesField extends SelectionControlField {
      * with an undefined value (i.e. nothing selected) should default to [].
      * This way conditions are not evaluated against `undefined` which throws errors.
      * Currently these errors are caught and the evaluation returns default `false`.
-     * @see {@link PageControllerBase.getNextPath} for `undefined` return value
+     * @see {@link QuestionPageController.getNextPath} for `undefined` return value
      * @see {@link FormModel.makeCondition} for try/catch block with default `false`
      * For negative conditions this is a problem because E.g.
      * The condition: 'selectedchecks' does not contain 'someval'

--- a/src/server/plugins/engine/components/UkAddressField.ts
+++ b/src/server/plugins/engine/components/UkAddressField.ts
@@ -7,7 +7,7 @@ import {
   isFormState
 } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { TextField } from '~/src/server/plugins/engine/components/TextField.js'
-import { type PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
+import { type QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
   type FormPayload,
   type FormState,
@@ -124,7 +124,7 @@ export class UkAddressField extends FormComponent {
 
         /**
          * For screen readers, only hide legend visually. This can be overridden
-         * by single component {@link PageControllerBase | `showTitle` handling}
+         * by single component {@link QuestionPageController | `showTitle` handling}
          */
         classes: options.hideTitle
           ? 'govuk-visually-hidden'

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -17,7 +17,7 @@ import { FormStatus } from '~/src/server/routes/types.js'
 
 describe('Helpers', () => {
   let request: FormContextRequest
-  let h: Pick<ResponseToolkit, 'redirect'>
+  let h: Pick<ResponseToolkit, 'redirect' | 'view'>
 
   beforeEach(() => {
     const pageUrl = new URL('http://example.com/test/page-one')
@@ -38,7 +38,8 @@ describe('Helpers', () => {
     }
 
     h = {
-      redirect: jest.fn().mockImplementation(() => response)
+      redirect: jest.fn().mockImplementation(() => response),
+      view: jest.fn()
     }
   })
 
@@ -84,6 +85,7 @@ describe('Helpers', () => {
 
         const response = proceed(request, h, href)
 
+        expect(h.view).not.toHaveBeenCalled()
         expect(h.redirect).toHaveBeenCalledWith(href)
         expect(response.code).toHaveBeenCalledWith(redirect.statusCode)
       }
@@ -129,6 +131,7 @@ describe('Helpers', () => {
 
         const response = proceed(request, h, href)
 
+        expect(h.view).not.toHaveBeenCalled()
         expect(h.redirect).toHaveBeenCalledWith(request.query.returnUrl)
         expect(response.code).toHaveBeenCalledWith(redirect.statusCode)
       }

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -23,7 +23,7 @@ export const CONTINUE = 'continue'
 
 export function proceed(
   request: Pick<FormContextRequest, 'method' | 'query'>,
-  h: Pick<ResponseToolkit, 'redirect'>,
+  h: Pick<ResponseToolkit, 'redirect' | 'view'>,
   nextUrl: string
 ) {
   const { returnUrl } = request.query

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -1,4 +1,4 @@
-import { type Page, type Section } from '@defra/forms-model'
+import { type PageSummary, type Section } from '@defra/forms-model'
 
 import {
   getAnswer,
@@ -48,7 +48,7 @@ export class SummaryViewModel {
 
   constructor(
     model: FormModel,
-    pageDef: Page,
+    pageDef: PageSummary,
     request: FormContextRequest,
     context: FormContext | FormContextProgress
   ) {

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.test.ts
@@ -42,7 +42,7 @@ describe('FileUploadPageController', () => {
       const { pages } = structuredClone(definition)
 
       // @ts-expect-error - Allow invalid component for test
-      pages[0].components?.unshift(textComponent)
+      pages[0].components.unshift(textComponent)
 
       expect(() => new FileUploadPageController(model, pages[0])).toThrow(
         `Expected 'fileUpload' to be the first form component in FileUploadPageController '${pages[0].path}'`

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -32,9 +32,7 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 import {
   type FormRequest,
-  type FormRequestPayload,
-  type FormRequestPayloadRefs,
-  type FormRequestRefs
+  type FormRequestPayload
 } from '~/src/server/routes/types.js'
 import { type CacheService } from '~/src/server/services/cacheService.js'
 
@@ -106,7 +104,7 @@ export class FileUploadPageController extends PageController {
   makeGetRouteHandler() {
     return async (
       request: FormRequest,
-      h: ResponseToolkit<FormRequestRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { cacheService } = request.services([])
       const state = await cacheService.getUploadState(request)
@@ -120,7 +118,7 @@ export class FileUploadPageController extends PageController {
   makePostRouteHandler() {
     return async (
       request: FormRequestPayload,
-      h: ResponseToolkit<FormRequestPayloadRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { cacheService } = request.services([])
       const state = await cacheService.getUploadState(request)

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -2,7 +2,7 @@ import {
   ComponentType,
   hasComponents,
   type FileUploadFieldComponent,
-  type Page
+  type PageFileUpload
 } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { type ResponseToolkit } from '@hapi/hapi'
@@ -56,10 +56,11 @@ function prepareFileState(fileState: FileState) {
 }
 
 export class FileUploadPageController extends PageController {
-  viewName = 'file-upload'
+  declare pageDef: PageFileUpload
+
   fileUploadComponent: FileUploadFieldComponent
 
-  constructor(model: FormModel, pageDef: Page) {
+  constructor(model: FormModel, pageDef: PageFileUpload) {
     // Get the file upload components from the list of components
     const fileUploadComponents = hasComponents(pageDef)
       ? pageDef.components.filter(
@@ -87,6 +88,7 @@ export class FileUploadPageController extends PageController {
 
     // Assign the file upload component to the controller
     this.fileUploadComponent = fileUploadComponents[0]
+    this.viewName = 'file-upload'
   }
 
   async getState(request: FormRequest) {

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -14,7 +14,7 @@ import {
 } from '~/src/server/plugins/engine/components/FileUploadField.js'
 import { getError } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
-import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
+import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
   getUploadStatus,
   initiateUpload
@@ -55,7 +55,7 @@ function prepareFileState(fileState: FileState) {
   return fileState
 }
 
-export class FileUploadPageController extends PageControllerBase {
+export class FileUploadPageController extends QuestionPageController {
   declare pageDef: PageFileUpload
 
   fileUploadComponent: FileUploadFieldComponent

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -14,7 +14,7 @@ import {
 } from '~/src/server/plugins/engine/components/FileUploadField.js'
 import { getError } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
-import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
+import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 import {
   getUploadStatus,
   initiateUpload
@@ -55,7 +55,7 @@ function prepareFileState(fileState: FileState) {
   return fileState
 }
 
-export class FileUploadPageController extends PageController {
+export class FileUploadPageController extends PageControllerBase {
   declare pageDef: PageFileUpload
 
   fileUploadComponent: FileUploadFieldComponent

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -191,7 +191,7 @@ export class FileUploadPageController extends QuestionPageController {
     request: FormRequest | FormRequestPayload,
     payload: FormPayload,
     errors?: FormSubmissionError[]
-  ) {
+  ): FileUploadPageViewModel {
     const viewModel = super.getViewModel(request, payload, errors)
 
     const name = this.fileUploadComponent.name
@@ -206,12 +206,11 @@ export class FileUploadPageController extends QuestionPageController {
 
     return {
       ...viewModel,
-      page: this,
       path: request.path,
       formAction: request.app.formAction,
       fileUploadComponent,
       preUploadComponents: components.slice(0, id)
-    } satisfies FileUploadPageViewModel
+    }
   }
 
   private getComponentName() {

--- a/src/server/plugins/engine/pageControllers/PageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.test.ts
@@ -1,0 +1,69 @@
+import { type ResponseToolkit } from '@hapi/hapi'
+
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
+import { type FormRequest } from '~/src/server/routes/types.js'
+import definition from '~/test/form/definitions/basic.js'
+
+describe('PageController', () => {
+  let model: FormModel
+  let controller1: PageController
+  let controller2: PageController
+
+  beforeEach(() => {
+    const { pages } = definition
+
+    const page1 = pages[0]
+    const page2 = pages[1]
+
+    model = new FormModel(definition, {
+      basePath: 'test'
+    })
+
+    controller1 = new PageController(model, page1)
+    controller2 = new PageController(model, page2)
+  })
+
+  describe('Route handlers', () => {
+    const page1Url = new URL('http://example.com/test/licence')
+
+    const request = {
+      method: 'get',
+      url: page1Url,
+      path: page1Url.pathname,
+      params: {
+        path: 'licence',
+        slug: 'test'
+      },
+      query: {},
+      app: { model }
+    } as FormRequest
+
+    const h: Pick<ResponseToolkit, 'redirect' | 'view'> = {
+      redirect: jest.fn(),
+      view: jest.fn()
+    }
+
+    it('returns default route options', () => {
+      expect(controller1.getRouteOptions).toEqual({})
+      expect(controller1.postRouteOptions).toEqual({})
+    })
+
+    it('supports GET route handler', async () => {
+      expect(() => controller1.makeGetRouteHandler()).not.toThrow()
+      expect(() => controller1.makeGetRouteHandler()).toBeInstanceOf(Function)
+
+      await controller1.makeGetRouteHandler()(request, h)
+      await controller2.makeGetRouteHandler()(request, h)
+
+      expect(h.view).toHaveBeenNthCalledWith(1, controller1.viewName)
+      expect(h.view).toHaveBeenNthCalledWith(2, controller1.viewName)
+    })
+
+    it('does not support POST route handler', () => {
+      expect(() => controller1.makePostRouteHandler()).toThrow(
+        'Unsupported POST route handler for this page'
+      )
+    })
+  })
+})

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -1,44 +1,65 @@
-import { type RouteOptions } from '@hapi/hapi'
-
-import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
+import { type FormDefinition, type Page } from '@defra/forms-model'
+import Boom from '@hapi/boom'
 import {
+  type Lifecycle,
+  type ResponseToolkit,
+  type RouteOptions
+} from '@hapi/hapi'
+
+import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
+import {
+  type FormRequest,
+  type FormRequestPayload,
   type FormRequestPayloadRefs,
   type FormRequestRefs
 } from '~/src/server/routes/types.js'
 
-export class PageController extends PageControllerBase {
+export class PageController {
+  /**
+   * The base class for all page controllers. Page controllers are responsible for generating the get and post route handlers when a user navigates to `/{id}/{path*}`.
+   */
+  def: FormDefinition
+  name?: string
+  model: FormModel
+  pageDef: Page
+  title: string
+  viewName = 'index'
+
+  constructor(model: FormModel, pageDef: Page) {
+    const { def } = model
+
+    this.def = def
+    this.name = def.name
+    this.model = model
+    this.pageDef = pageDef
+    this.title = pageDef.title
+  }
+
   /**
    * {@link https://hapi.dev/api/?v=20.1.2#route-options}
    */
   get getRouteOptions(): RouteOptions<FormRequestRefs> {
-    return {
-      ext: {
-        onPostHandler: {
-          method(_request, h) {
-            return h.continue
-          }
-        }
-      }
-    }
+    return {}
   }
 
   /**
    * {@link https://hapi.dev/api/?v=20.1.2#route-options}
    */
   get postRouteOptions(): RouteOptions<FormRequestPayloadRefs> {
-    return {
-      payload: {
-        parse: true,
-        maxBytes: Number.MAX_SAFE_INTEGER,
-        failAction: 'ignore'
-      },
-      ext: {
-        onPostHandler: {
-          method(_request, h) {
-            return h.continue
-          }
-        }
-      }
-    }
+    return {}
+  }
+
+  makeGetRouteHandler(): (
+    request: FormRequest,
+    h: Pick<ResponseToolkit, 'redirect' | 'view'>
+  ) => ReturnType<Lifecycle.Method<FormRequestRefs>> {
+    return (request, h) => h.view(this.viewName)
+  }
+
+  makePostRouteHandler(): (
+    request: FormRequestPayload,
+    h: Pick<ResponseToolkit, 'redirect' | 'view'>
+  ) => ReturnType<Lifecycle.Method<FormRequestPayloadRefs>> {
+    throw Boom.badRequest('Unsupported POST route handler for this page')
   }
 }

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -192,7 +192,10 @@ export class PageControllerBase {
 
   getHref(path: string) {
     const { model } = this
-    return `/${model.basePath}${path}`
+
+    return path === '/'
+      ? `/${model.basePath}` // Strip trailing slash
+      : `/${model.basePath}${path}`
   }
 
   getStartPath() {

--- a/src/server/plugins/engine/pageControllers/PageControllerBase.ts
+++ b/src/server/plugins/engine/pageControllers/PageControllerBase.ts
@@ -8,13 +8,7 @@ import {
   type Page,
   type Section
 } from '@defra/forms-model'
-import { type Boom } from '@hapi/boom'
-import {
-  type ResponseObject,
-  type ResponseToolkit,
-  type RouteOptions,
-  type ServerRoute
-} from '@hapi/hapi'
+import { type ResponseToolkit, type RouteOptions } from '@hapi/hapi'
 import joi, { type ValidationErrorItem } from 'joi'
 
 import { config } from '~/src/config/index.js'
@@ -281,11 +275,11 @@ export class PageControllerBase {
     return cacheService.mergeState(request, state)
   }
 
-  makeGetRouteHandler(): (
-    request: FormRequest,
-    h: ResponseToolkit<FormRequestRefs>
-  ) => Promise<ResponseObject | Boom> {
-    return async (request, h) => {
+  makeGetRouteHandler() {
+    return async (
+      request: FormRequest,
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
+    ) => {
       const { model, path, viewName } = this
 
       const state = await this.getState(request)
@@ -417,11 +411,11 @@ export class PageControllerBase {
     return progress.at(-2)
   }
 
-  makePostRouteHandler(): (
-    request: FormRequestPayload,
-    h: ResponseToolkit<FormRequestPayloadRefs>
-  ) => Promise<ResponseObject | Boom> {
-    return async (request, h) => {
+  makePostRouteHandler() {
+    return async (
+      request: FormRequestPayload,
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
+    ) => {
       const { model } = this
 
       const state = await this.getState(request)
@@ -480,33 +474,13 @@ export class PageControllerBase {
     return phaseBanner?.phase ?? config.get('phaseTag')
   }
 
-  makeGetRoute() {
-    return {
-      method: 'get',
-      path: this.pageDef.path,
-      options: this.getRouteOptions,
-      handler: this.makeGetRouteHandler()
-    } satisfies ServerRoute<FormRequestRefs>
-  }
-
-  makePostRoute() {
-    return {
-      method: 'post',
-      path: this.pageDef.path,
-      options: this.postRouteOptions,
-      handler: this.makePostRouteHandler()
-    } satisfies ServerRoute<FormRequestPayloadRefs>
-  }
-
   validate(request: FormRequestPayload) {
     return this.collection.validate(request.payload)
   }
 
   proceed(
     request: FormRequest | FormRequestPayload,
-    h:
-      | ResponseToolkit<FormRequestRefs>
-      | ResponseToolkit<FormRequestPayloadRefs>,
+    h: Pick<ResponseToolkit, 'redirect' | 'view'>,
     nextPath?: string
   ) {
     const nextUrl = nextPath
@@ -532,9 +506,7 @@ export class PageControllerBase {
 
   protected renderWithErrors(
     request: FormRequest | FormRequestPayload,
-    h:
-      | ResponseToolkit<FormRequestRefs>
-      | ResponseToolkit<FormRequestPayloadRefs>,
+    h: Pick<ResponseToolkit, 'redirect' | 'view'>,
     payload: FormPayload,
     progress: string[],
     errors?: FormSubmissionError[]

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -1,5 +1,5 @@
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
-import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
+import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
   type FormContextProgress,
   type FormContextRequest,
@@ -10,9 +10,9 @@ import definitionConditionsBasic from '~/test/form/definitions/conditions-basic.
 import definitionConditionsComplex from '~/test/form/definitions/conditions-complex.js'
 import definitionConditionsDates from '~/test/form/definitions/conditions-dates.js'
 
-describe('PageControllerBase', () => {
-  let controller1: PageControllerBase
-  let controller2: PageControllerBase
+describe('QuestionPageController', () => {
+  let controller1: QuestionPageController
+  let controller2: QuestionPageController
   let requestPage1: FormRequest
   let requestPage2: FormRequest
 
@@ -29,8 +29,8 @@ describe('PageControllerBase', () => {
       basePath: 'test'
     })
 
-    controller1 = new PageControllerBase(model, page1)
-    controller2 = new PageControllerBase(model, page2)
+    controller1 = new QuestionPageController(model, page1)
+    controller2 = new QuestionPageController(model, page2)
 
     requestPage1 = {
       method: 'get',
@@ -165,7 +165,7 @@ describe('PageControllerBase', () => {
 
       // Selected page appears after convergence and contains a conditional field
       // This is the page we're theoretically browsing to
-      const controller = new PageControllerBase(model, pages[7])
+      const controller = new QuestionPageController(model, pages[7])
 
       // The state below shows we said we had a UKPassport and entered details for an applicant
       const state: FormSubmissionState = {
@@ -275,7 +275,7 @@ describe('PageControllerBase', () => {
         basePath: 'test'
       })
 
-      const controller = new PageControllerBase(model, pages[0])
+      const controller = new QuestionPageController(model, pages[0])
 
       const request = {
         method: 'get',

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -1,8 +1,11 @@
+import { type ResponseToolkit } from '@hapi/hapi'
+
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
   type FormContextProgress,
   type FormContextRequest,
+  type FormState,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
@@ -11,6 +14,7 @@ import definitionConditionsComplex from '~/test/form/definitions/conditions-comp
 import definitionConditionsDates from '~/test/form/definitions/conditions-dates.js'
 
 describe('QuestionPageController', () => {
+  let model: FormModel
   let controller1: QuestionPageController
   let controller2: QuestionPageController
   let requestPage1: FormRequest
@@ -25,7 +29,7 @@ describe('QuestionPageController', () => {
     const page2 = pages[1]
     const page2Url = new URL('http://example.com/test/second-page')
 
-    const model = new FormModel(definitionConditionsBasic, {
+    model = new FormModel(definitionConditionsBasic, {
       basePath: 'test'
     })
 
@@ -55,6 +59,138 @@ describe('QuestionPageController', () => {
       query: {},
       app: { model }
     } as FormRequest
+  })
+
+  describe('Properties', () => {
+    it('returns path', () => {
+      expect(controller1).toHaveProperty('path', '/first-page')
+      expect(controller2).toHaveProperty('path', '/second-page')
+    })
+
+    it('returns href', () => {
+      expect(controller1).toHaveProperty('href', '/test/first-page')
+      expect(controller2).toHaveProperty('href', '/test/second-page')
+    })
+
+    it('returns keys', () => {
+      expect(controller1).toHaveProperty('keys', ['yesNoField'])
+      expect(controller2).toHaveProperty('keys', [
+        'dateField',
+        'dateField__day',
+        'dateField__month',
+        'dateField__year',
+        'multilineTextField'
+      ])
+    })
+
+    it('returns the page section', () => {
+      expect(controller1).toHaveProperty('section', undefined)
+      expect(controller2).toHaveProperty('section', {
+        name: 'marriage',
+        title: 'Your marriage',
+        hideTitle: false
+      })
+    })
+
+    it('returns feedback link (from config)', () => {
+      expect(controller1).toHaveProperty(
+        'feedbackLink',
+        'https://test.defra.gov.uk/'
+      )
+    })
+
+    it('returns feedback link (from form definition)', () => {
+      const emailAddress = 'test@feedback.cat'
+
+      model.def.feedback = {
+        emailAddress
+      }
+
+      expect(controller1).toHaveProperty(
+        'feedbackLink',
+        `mailto:${emailAddress}`
+      )
+    })
+
+    it('returns phase tag (from config)', () => {
+      expect(controller1).toHaveProperty('phaseTag', 'beta')
+    })
+
+    it('returns phase tag (from form definition)', () => {
+      model.def.phaseBanner = {
+        phase: 'alpha'
+      }
+
+      expect(controller1).toHaveProperty('phaseTag', 'alpha')
+    })
+  })
+
+  describe('Path methods', () => {
+    describe('Link href', () => {
+      it('prefixes paths into link hrefs', () => {
+        const href1 = controller1.getHref('/')
+        const href2 = controller1.getHref('/page-one')
+
+        expect(href1).toBe('/test')
+        expect(href2).toBe('/test/page-one')
+      })
+    })
+
+    describe('Next getter', () => {
+      it('returns page links', () => {
+        expect(controller1).toHaveProperty('next', [
+          { path: '/second-page' },
+          { path: '/summary', condition: 'isPreviouslyMarried' }
+        ])
+
+        expect(controller2).toHaveProperty('next', [{ path: '/summary' }])
+      })
+
+      it('returns page links (none found)', () => {
+        const pageDef1 = structuredClone(controller1.pageDef)
+        const pageDef2 = structuredClone(controller2.pageDef)
+
+        controller1.pageDef = pageDef1
+        controller2.pageDef = pageDef2
+
+        // @ts-expect-error - Allow invalid property for test
+        controller1.pageDef.next = []
+
+        // @ts-expect-error - Allow invalid property for test
+        delete controller2.pageDef.next
+
+        expect(controller1).toHaveProperty('next', [])
+        expect(controller2).toHaveProperty('next', [])
+      })
+    })
+
+    describe('Start path', () => {
+      it('returns path to start page', () => {
+        const startPath = controller1.getStartPath()
+        expect(startPath).toBe('/first-page')
+      })
+
+      it('returns path to start page (default)', () => {
+        delete model.def.startPage
+
+        const startPath = controller1.getStartPath()
+        expect(startPath).toBe('/start')
+      })
+    })
+
+    describe('Summary path', () => {
+      it('returns path to summary page', () => {
+        const summaryPath = controller1.getSummaryPath()
+        expect(summaryPath).toBe('/summary')
+      })
+    })
+
+    describe('Status path', () => {
+      it('returns path to status page', () => {
+        const summaryPath = controller1.getStatusPath()
+        expect(summaryPath).toBe('/status')
+      })
+    })
   })
 
   describe('Component collection', () => {
@@ -349,18 +485,7 @@ describe('QuestionPageController', () => {
       })
     })
 
-    describe('Next getter', () => {
-      it('returns the next page links', () => {
-        expect(controller1).toHaveProperty('next', [
-          { path: '/second-page' },
-          { path: '/summary', condition: 'isPreviouslyMarried' }
-        ])
-
-        expect(controller2).toHaveProperty('next', [{ path: '/summary' }])
-      })
-    })
-
-    describe('Next', () => {
+    describe('Next page', () => {
       it('returns the next page path', () => {
         expect(controller1.getNextPath(context)).toBe('/second-page')
         expect(controller1.getNextPath(contextNo)).toBe('/second-page')
@@ -371,12 +496,73 @@ describe('QuestionPageController', () => {
         expect(controller2.getNextPath(contextYes)).toBe('/summary')
       })
     })
+  })
 
-    describe('Summary', () => {
-      it('returns the summary path', () => {
-        expect(controller1.getSummaryPath()).toBe('/summary')
-        expect(controller2.getSummaryPath()).toBe('/summary')
+  describe('Route handlers', () => {
+    const response = {
+      code: jest.fn().mockImplementation(() => response)
+    }
+
+    const h: Pick<ResponseToolkit, 'redirect' | 'view'> = {
+      redirect: jest.fn().mockReturnValue(response),
+      view: jest.fn()
+    }
+
+    it('returns default route options', () => {
+      expect(controller1.getRouteOptions).toMatchObject({
+        ext: {
+          onPostHandler: {
+            method: expect.any(Function)
+          }
+        }
       })
+
+      expect(controller1.postRouteOptions).toMatchObject({
+        ext: {
+          onPostHandler: {
+            method: expect.any(Function)
+          }
+        }
+      })
+    })
+
+    it('supports GET route handler', async () => {
+      const state: FormState = { yesNoField: false }
+
+      for (const controller of [controller1, controller2]) {
+        jest.spyOn(controller, 'getState').mockResolvedValue(state)
+
+        for (const method of [
+          jest.spyOn(controller, 'updateProgress'),
+          jest.spyOn(controller, 'buildMissingEmailWarningModel')
+        ]) {
+          method.mockResolvedValue(undefined)
+        }
+      }
+
+      expect(() => controller1.makeGetRouteHandler()).not.toThrow()
+      expect(() => controller1.makeGetRouteHandler()).toBeInstanceOf(Function)
+
+      await controller1.makeGetRouteHandler()(requestPage1, h)
+      await controller2.makeGetRouteHandler()(requestPage2, h)
+
+      expect(h.view).toHaveBeenNthCalledWith(
+        1,
+        controller1.viewName,
+        expect.objectContaining({
+          pageTitle: 'Previous marriages',
+          sectionTitle: undefined
+        })
+      )
+
+      expect(h.view).toHaveBeenNthCalledWith(
+        2,
+        controller2.viewName,
+        expect.objectContaining({
+          pageTitle: 'When will you get married?',
+          sectionTitle: 'Your marriage'
+        })
+      )
     })
   })
 })

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -38,7 +38,7 @@ import {
   type FormRequestRefs
 } from '~/src/server/routes/types.js'
 
-export class PageControllerBase extends PageController {
+export class QuestionPageController extends PageController {
   section?: Section
   collection: ComponentCollection
   errorSummaryTitle = 'There is a problem'

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -163,8 +163,8 @@ export class QuestionPageController extends PageController {
       errors,
       isStartPage: false,
       serviceUrl: this.getHref('/'),
-      feedbackLink: this.getFeedbackLink(),
-      phaseTag: this.getPhaseTag()
+      feedbackLink: this.feedbackLink,
+      phaseTag: this.phaseTag
     }
   }
 
@@ -363,7 +363,7 @@ export class QuestionPageController extends PageController {
    * Used for when a user clicks the "back" link.
    * Progress is stored in the state.
    */
-  protected async updateProgress(progress: string[], request: FormRequest) {
+  async updateProgress(progress: string[], request: FormRequest) {
     const { cacheService } = request.services([])
 
     const lastVisited = progress.at(-1)
@@ -438,13 +438,13 @@ export class QuestionPageController extends PageController {
     }
   }
 
-  protected getFeedbackLink() {
-    const { feedback } = this.def
+  get feedbackLink() {
+    const { def } = this
 
     // setting the feedbackLink to undefined here for feedback forms prevents the feedback link from being shown
-    let feedbackLink = feedback?.emailAddress
-      ? `mailto:${feedback.emailAddress}`
-      : feedback?.url
+    let feedbackLink = def.feedback?.emailAddress
+      ? `mailto:${def.feedback.emailAddress}`
+      : def.feedback?.url
 
     if (!feedbackLink) {
       feedbackLink = config.get('feedbackLink')
@@ -453,9 +453,9 @@ export class QuestionPageController extends PageController {
     return encodeUrl(feedbackLink)
   }
 
-  protected getPhaseTag() {
-    const { phaseBanner } = this.def
-    return phaseBanner?.phase ?? config.get('phaseTag')
+  get phaseTag() {
+    const { def } = this
+    return def.phaseBanner?.phase ?? config.get('phaseTag')
   }
 
   validate(request: FormRequestPayload) {

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -26,10 +26,10 @@ import { getFormMetadata } from '~/src/server/plugins/engine/services/formsServi
 import {
   type FormContext,
   type FormContextProgress,
+  type FormPageViewModel,
   type FormPayload,
   type FormSubmissionError,
-  type FormSubmissionState,
-  type PageViewModel
+  type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
 import {
   type FormRequest,
@@ -102,7 +102,7 @@ export class QuestionPageController extends PageController {
     request: FormRequest | FormRequestPayload,
     payload: FormPayload,
     errors?: FormSubmissionError[]
-  ): PageViewModel {
+  ): FormPageViewModel {
     let showTitle = true
 
     let { title: pageTitle, section } = this
@@ -338,7 +338,7 @@ export class QuestionPageController extends PageController {
 
   async buildMissingEmailWarningModel(
     request: FormRequest
-  ): Promise<PageViewModel['notificationEmailWarning']> {
+  ): Promise<FormPageViewModel['notificationEmailWarning']> {
     const { path } = this
     const { params } = request
 

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
@@ -1,5 +1,3 @@
-import { ControllerType } from '@defra/forms-model'
-
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { RepeatPageController } from '~/src/server/plugins/engine/pageControllers/RepeatPageController.js'
 import {
@@ -20,24 +18,6 @@ describe('RepeatPageController', () => {
     })
 
     controller = new RepeatPageController(model, pages[0])
-  })
-
-  describe('Constructor', () => {
-    it('throws if page controller is not ControllerType.Repeat', () => {
-      const { pages } = structuredClone(definition)
-
-      // Change the controller type
-      // @ts-expect-error - Allow invalid property for test
-      pages[0].controller = ControllerType.Summary
-
-      // Remove specific controller options
-      // @ts-expect-error - Allow invalid property for test
-      delete pages[0].repeat
-
-      expect(() => new RepeatPageController(model, pages[0])).toThrow(
-        'Invalid controller for Repeat page'
-      )
-    })
   })
 
   describe('Form validation', () => {

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
@@ -27,7 +27,11 @@ describe('RepeatPageController', () => {
       const { pages } = structuredClone(definition)
 
       // Change the controller type
+      // @ts-expect-error - Allow invalid property for test
       pages[0].controller = ControllerType.Summary
+
+      // Remove specific controller options
+      // @ts-expect-error - Allow invalid property for test
       delete pages[0].repeat
 
       expect(() => new RepeatPageController(model, pages[0])).toThrow(

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
@@ -20,64 +20,18 @@ describe('RepeatPageController', () => {
     controller = new RepeatPageController(model, pages[0])
   })
 
-  describe('Form validation', () => {
-    it('includes title text and errors', () => {
-      const result = controller.collection.validate()
-
-      expect(result.errors).toEqual<FormSubmissionError[]>([
-        {
-          path: ['toppings'],
-          href: '#toppings',
-          name: 'toppings',
-          text: 'Select toppings',
-          context: {
-            key: 'toppings',
-            label: 'toppings',
-            title: 'Toppings'
-          }
-        },
-        {
-          path: ['quantity'],
-          href: '#quantity',
-          name: 'quantity',
-          text: 'Enter quantity',
-          context: {
-            key: 'quantity',
-            label: 'quantity',
-            title: 'Quantity'
-          }
-        },
-        {
-          path: ['itemId'],
-          href: '#itemId',
-          name: 'itemId',
-          text: 'Select itemId',
-          context: {
-            key: 'itemId',
-            label: 'itemId'
-          }
-        }
-      ])
-    })
-
-    it('includes all field errors', () => {
-      const result = controller.collection.validate()
-      expect(result.errors).toHaveLength(3)
-    })
-  })
-
-  describe('Form journey', () => {
-    describe('Summary', () => {
+  describe('Path methods', () => {
+    describe('Summary path', () => {
       let request: FormContextRequest
 
       const itemId1 = 'abc-123'
       const itemId2 = 'xyz-987'
 
-      it('returns the summary path', () => {
+      it('returns path to summary page', () => {
         expect(controller.getSummaryPath()).toBe('/summary')
       })
 
-      it('returns the repeater summary path', () => {
+      it('returns path to repeater summary page', () => {
         const pageUrl = new URL('http://example.com/repeat/pizza-order')
 
         request = {
@@ -140,6 +94,52 @@ describe('RepeatPageController', () => {
 
         expect(controller.getSummaryPath(request)).toBe('/pizza-order/summary')
       })
+    })
+  })
+
+  describe('Form validation', () => {
+    it('includes title text and errors', () => {
+      const result = controller.collection.validate()
+
+      expect(result.errors).toEqual<FormSubmissionError[]>([
+        {
+          path: ['toppings'],
+          href: '#toppings',
+          name: 'toppings',
+          text: 'Select toppings',
+          context: {
+            key: 'toppings',
+            label: 'toppings',
+            title: 'Toppings'
+          }
+        },
+        {
+          path: ['quantity'],
+          href: '#quantity',
+          name: 'quantity',
+          text: 'Enter quantity',
+          context: {
+            key: 'quantity',
+            label: 'quantity',
+            title: 'Quantity'
+          }
+        },
+        {
+          path: ['itemId'],
+          href: '#itemId',
+          name: 'itemId',
+          text: 'Select itemId',
+          context: {
+            key: 'itemId',
+            label: 'itemId'
+          }
+        }
+      ])
+    })
+
+    it('includes all field errors', () => {
+      const result = controller.collection.validate()
+      expect(result.errors).toHaveLength(3)
     })
   })
 })

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -7,7 +7,7 @@ import Joi from 'joi'
 
 import { ADD_ANOTHER, CONTINUE } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
-import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
+import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 import {
   type CheckAnswers,
   type FormContextRequest,
@@ -24,7 +24,7 @@ import {
   type FormRequestPayload
 } from '~/src/server/routes/types.js'
 
-export class RepeatPageController extends PageController {
+export class RepeatPageController extends PageControllerBase {
   declare pageDef: PageRepeat
 
   listSummaryViewName = 'repeat-list-summary'

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -7,7 +7,7 @@ import Joi from 'joi'
 
 import { ADD_ANOTHER, CONTINUE } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
-import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
+import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
   type CheckAnswers,
   type FormContextRequest,
@@ -24,7 +24,7 @@ import {
   type FormRequestPayload
 } from '~/src/server/routes/types.js'
 
-export class RepeatPageController extends PageControllerBase {
+export class RepeatPageController extends QuestionPageController {
   declare pageDef: PageRepeat
 
   listSummaryViewName = 'repeat-list-summary'

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -21,9 +21,7 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 import {
   type FormRequest,
-  type FormRequestPayload,
-  type FormRequestPayloadRefs,
-  type FormRequestRefs
+  type FormRequestPayload
 } from '~/src/server/routes/types.js'
 
 export class RepeatPageController extends PageController {
@@ -107,12 +105,7 @@ export class RepeatPageController extends PageController {
     return state
   }
 
-  proceed(
-    request: FormRequest,
-    h:
-      | ResponseToolkit<FormRequestRefs>
-      | ResponseToolkit<FormRequestPayloadRefs>
-  ) {
+  proceed(request: FormRequest, h: Pick<ResponseToolkit, 'redirect' | 'view'>) {
     const nextPath = this.getSummaryPath(request)
     return super.proceed(request, h, nextPath)
   }
@@ -175,7 +168,7 @@ export class RepeatPageController extends PageController {
   makeGetRouteHandler() {
     return async (
       request: FormRequest,
-      h: ResponseToolkit<FormRequestRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { path } = this
 
@@ -193,7 +186,7 @@ export class RepeatPageController extends PageController {
   makePostRouteHandler() {
     return async (
       request: FormRequestPayload,
-      h: ResponseToolkit<FormRequestPayloadRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       await this.setRepeatAppData(request)
 
@@ -204,7 +197,7 @@ export class RepeatPageController extends PageController {
   makeGetListSummaryRouteHandler() {
     return async (
       request: FormRequest,
-      h: ResponseToolkit<FormRequestRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const state = await super.getState(request)
       const list = this.getListFromState(state)
@@ -222,7 +215,7 @@ export class RepeatPageController extends PageController {
   makePostListSummaryRouteHandler() {
     return async (
       request: FormRequestPayload,
-      h: ResponseToolkit<FormRequestPayloadRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { model, path, repeat } = this
       const { payload } = request
@@ -271,7 +264,7 @@ export class RepeatPageController extends PageController {
   makeGetListDeleteRouteHandler() {
     return async (
       request: FormRequest,
-      h: ResponseToolkit<FormRequestRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { item } = await this.setRepeatAppData(request)
 
@@ -307,7 +300,7 @@ export class RepeatPageController extends PageController {
   makePostListDeleteRouteHandler() {
     return async (
       request: FormRequestPayload,
-      h: ResponseToolkit<FormRequestPayloadRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { payload } = request
       const { confirm } = payload

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto'
 
-import { ControllerType, type Page, type Repeat } from '@defra/forms-model'
-import { badImplementation, badRequest, notFound } from '@hapi/boom'
+import { type PageRepeat, type Repeat } from '@defra/forms-model'
+import { badRequest, notFound } from '@hapi/boom'
 import { type ResponseToolkit } from '@hapi/hapi'
 import Joi from 'joi'
 
@@ -25,16 +25,14 @@ import {
 } from '~/src/server/routes/types.js'
 
 export class RepeatPageController extends PageController {
+  declare pageDef: PageRepeat
+
   listSummaryViewName = 'repeat-list-summary'
   listDeleteViewName = 'repeat-item-delete'
   repeat: Repeat
 
-  constructor(model: FormModel, pageDef: Page) {
+  constructor(model: FormModel, pageDef: PageRepeat) {
     super(model, pageDef)
-
-    if (pageDef.controller !== ControllerType.Repeat) {
-      throw badImplementation('Invalid controller for Repeat page')
-    }
 
     this.repeat = pageDef.repeat
 

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -11,10 +11,10 @@ import { QuestionPageController } from '~/src/server/plugins/engine/pageControll
 import {
   type CheckAnswers,
   type FormContextRequest,
+  type FormPageViewModel,
   type FormPayload,
   type FormSubmissionError,
   type FormSubmissionState,
-  type PageViewModel,
   type RepeatState,
   type SummaryList,
   type SummaryListAction
@@ -328,17 +328,21 @@ export class RepeatPageController extends QuestionPageController {
     request: FormRequest | FormRequestPayload,
     payload: FormPayload,
     errors?: FormSubmissionError[]
-  ): PageViewModel {
+  ): FormPageViewModel {
     const viewModel = super.getViewModel(request, payload, errors)
+
     const { list, item } = this.getRepeatAppData(request)
+
     const itemNumber = item ? item.index + 1 : list.length + 1
     const repeatCaption = `${this.repeat.options.title} ${itemNumber}`
 
-    viewModel.sectionTitle = viewModel.sectionTitle
-      ? `${viewModel.sectionTitle}: ${repeatCaption}`
-      : repeatCaption
+    return {
+      ...viewModel,
 
-    return viewModel
+      sectionTitle: viewModel.sectionTitle
+        ? `${viewModel.sectionTitle}: ${repeatCaption}`
+        : repeatCaption
+    }
   }
 
   getListSummaryViewModel(

--- a/src/server/plugins/engine/pageControllers/StartPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StartPageController.ts
@@ -1,11 +1,11 @@
-import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
+import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
   type FormPayload,
   type FormSubmissionError
 } from '~/src/server/plugins/engine/types.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
 
-export class StartPageController extends PageControllerBase {
+export class StartPageController extends QuestionPageController {
   /**
    * The controller which is used when Page["controller"] is defined as "./pages/start.js"
    * This page should not be used in production. This page is helpful for prototyping start pages within the app,

--- a/src/server/plugins/engine/pageControllers/StartPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StartPageController.ts
@@ -1,11 +1,11 @@
-import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
+import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 import {
   type FormPayload,
   type FormSubmissionError
 } from '~/src/server/plugins/engine/types.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
 
-export class StartPageController extends PageController {
+export class StartPageController extends PageControllerBase {
   /**
    * The controller which is used when Page["controller"] is defined as "./pages/start.js"
    * This page should not be used in production. This page is helpful for prototyping start pages within the app,

--- a/src/server/plugins/engine/pageControllers/StatusPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StatusPageController.ts
@@ -2,11 +2,11 @@ import { type PageStatus } from '@defra/forms-model'
 import { type ResponseToolkit } from '@hapi/hapi'
 
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
-import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
+import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
 
-export class StatusPageController extends PageControllerBase {
+export class StatusPageController extends QuestionPageController {
   declare pageDef: PageStatus
 
   constructor(model: FormModel, pageDef: PageStatus) {

--- a/src/server/plugins/engine/pageControllers/StatusPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StatusPageController.ts
@@ -2,11 +2,11 @@ import { type PageStatus } from '@defra/forms-model'
 import { type ResponseToolkit } from '@hapi/hapi'
 
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
-import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
+import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
 
-export class StatusPageController extends PageController {
+export class StatusPageController extends PageControllerBase {
   declare pageDef: PageStatus
 
   constructor(model: FormModel, pageDef: PageStatus) {

--- a/src/server/plugins/engine/pageControllers/StatusPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StatusPageController.ts
@@ -1,19 +1,15 @@
-import { type Boom } from '@hapi/boom'
-import { type ResponseObject, type ResponseToolkit } from '@hapi/hapi'
+import { type ResponseToolkit } from '@hapi/hapi'
 
 import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
-import {
-  type FormRequest,
-  type FormRequestRefs
-} from '~/src/server/routes/types.js'
+import { type FormRequest } from '~/src/server/routes/types.js'
 
 export class StatusPageController extends PageController {
-  makeGetRouteHandler(): (
-    request: FormRequest,
-    h: ResponseToolkit<FormRequestRefs>
-  ) => Promise<ResponseObject | Boom> {
-    return async (request, h) => {
+  makeGetRouteHandler() {
+    return async (
+      request: FormRequest,
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
+    ) => {
       const { model, title } = this
 
       const { cacheService } = request.services([])

--- a/src/server/plugins/engine/pageControllers/StatusPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StatusPageController.ts
@@ -1,16 +1,25 @@
+import { type PageStatus } from '@defra/forms-model'
 import { type ResponseToolkit } from '@hapi/hapi'
 
+import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
 
 export class StatusPageController extends PageController {
+  declare pageDef: PageStatus
+
+  constructor(model: FormModel, pageDef: PageStatus) {
+    super(model, pageDef)
+    this.viewName = 'confirmation'
+  }
+
   makeGetRouteHandler() {
     return async (
       request: FormRequest,
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
-      const { model, title } = this
+      const { model, title, viewName } = this
 
       const { cacheService } = request.services([])
       const confirmationState = await cacheService.getConfirmationState(request)
@@ -24,7 +33,7 @@ export class StatusPageController extends PageController {
       const slug = request.params.slug
       const { submissionGuidance } = await getFormMetadata(slug)
 
-      return h.view('confirmation', {
+      return h.view(viewName, {
         pageTitle: title,
         name: model.name,
         submissionGuidance,

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -25,7 +25,7 @@ import {
   type Detail,
   type DetailItem
 } from '~/src/server/plugins/engine/models/types.js'
-import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
+import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 import {
   persistFiles,
   submit
@@ -47,7 +47,7 @@ import { sendNotification } from '~/src/server/utils/notify.js'
 const designerUrl = config.get('designerUrl')
 const templateId = config.get('notifyTemplateId')
 
-export class SummaryPageController extends PageController {
+export class SummaryPageController extends PageControllerBase {
   declare pageDef: PageSummary
 
   /**

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -72,8 +72,8 @@ export class SummaryPageController extends QuestionPageController {
 
     // We already figure these out in the base page controller. Take them and apply them to our page-specific model.
     // This is a stop-gap until we can add proper inheritance in place.
-    viewModel.feedbackLink = this.getFeedbackLink()
-    viewModel.phaseTag = this.getPhaseTag()
+    viewModel.feedbackLink = this.feedbackLink
+    viewModel.phaseTag = this.phaseTag
 
     return viewModel
   }

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -25,7 +25,7 @@ import {
   type Detail,
   type DetailItem
 } from '~/src/server/plugins/engine/models/types.js'
-import { PageControllerBase } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
+import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
   persistFiles,
   submit
@@ -47,7 +47,7 @@ import { sendNotification } from '~/src/server/utils/notify.js'
 const designerUrl = config.get('designerUrl')
 const templateId = config.get('notifyTemplateId')
 
-export class SummaryPageController extends PageControllerBase {
+export class SummaryPageController extends QuestionPageController {
   declare pageDef: PageSummary
 
   /**

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -2,12 +2,8 @@ import {
   type SubmitPayload,
   type SubmitResponsePayload
 } from '@defra/forms-model'
-import { badRequest, type Boom } from '@hapi/boom'
-import {
-  type ResponseObject,
-  type ResponseToolkit,
-  type RouteOptions
-} from '@hapi/hapi'
+import { badRequest } from '@hapi/boom'
+import { type ResponseToolkit, type RouteOptions } from '@hapi/hapi'
 import { addDays, format } from 'date-fns'
 
 import { config } from '~/src/config/index.js'
@@ -43,8 +39,7 @@ import {
 import {
   type FormRequest,
   type FormRequestPayload,
-  type FormRequestPayloadRefs,
-  type FormRequestRefs
+  type FormRequestPayloadRefs
 } from '~/src/server/routes/types.js'
 import { sendNotification } from '~/src/server/utils/notify.js'
 
@@ -78,11 +73,11 @@ export class SummaryPageController extends PageController {
   /**
    * Returns an async function. This is called in plugin.ts when there is a GET request at `/{id}/{path*}`,
    */
-  makeGetRouteHandler(): (
-    request: FormRequest,
-    h: ResponseToolkit<FormRequestRefs>
-  ) => Promise<ResponseObject | Boom> {
-    return async (request, h) => {
+  makeGetRouteHandler() {
+    return async (
+      request: FormRequest,
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
+    ) => {
       const { model, path } = this
 
       const state = await this.getState(request)
@@ -111,11 +106,11 @@ export class SummaryPageController extends PageController {
    * Returns an async function. This is called in plugin.ts when there is a POST request at `/{id}/{path*}`.
    * If a form is incomplete, a user will be redirected to the start page.
    */
-  makePostRouteHandler(): (
-    request: FormRequestPayload,
-    h: ResponseToolkit<FormRequestPayloadRefs>
-  ) => Promise<ResponseObject | Boom> {
-    return async (request, h) => {
+  makePostRouteHandler() {
+    return async (
+      request: FormRequestPayload,
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
+    ) => {
       const { model } = this
 
       const { cacheService } = request.services([])

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -1,4 +1,5 @@
 import {
+  type PageSummary,
   type SubmitPayload,
   type SubmitResponsePayload
 } from '@defra/forms-model'
@@ -47,9 +48,16 @@ const designerUrl = config.get('designerUrl')
 const templateId = config.get('notifyTemplateId')
 
 export class SummaryPageController extends PageController {
+  declare pageDef: PageSummary
+
   /**
    * The controller which is used when Page["controller"] is defined as "./pages/summary.js"
    */
+
+  constructor(model: FormModel, pageDef: PageSummary) {
+    super(model, pageDef)
+    this.viewName = 'summary'
+  }
 
   getSummaryViewModel(
     request: FormContextRequest,
@@ -78,7 +86,7 @@ export class SummaryPageController extends PageController {
       request: FormRequest,
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
-      const { model, path } = this
+      const { model, path, viewName } = this
 
       const state = await this.getState(request)
       const context = model.getFormContext(request, state)
@@ -98,7 +106,7 @@ export class SummaryPageController extends PageController {
       viewModel.notificationEmailWarning =
         await this.buildMissingEmailWarningModel(request)
 
-      return h.view('summary', viewModel)
+      return h.view(viewName, viewModel)
     }
   }
 

--- a/src/server/plugins/engine/pageControllers/helpers.test.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.test.ts
@@ -14,7 +14,7 @@ import {
 } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import {
   FileUploadPageController,
-  PageController,
+  QuestionPageController,
   RepeatPageController,
   StartPageController,
   StatusPageController,
@@ -34,7 +34,7 @@ describe('Page controller helpers', () => {
         break
 
       case ControllerType.Page:
-        controller = PageController
+        controller = QuestionPageController
         break
 
       case ControllerType.Repeat:

--- a/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.ts
@@ -25,7 +25,7 @@ export function createPage(model: FormModel, pageDef: Page) {
   const controllerName = controllerNameFromPath(pageDef.controller)
 
   if (!pageDef.controller) {
-    return new PageControllers.PageController(model, pageDef)
+    return new PageControllers.QuestionPageController(model, pageDef)
   }
 
   // Patch legacy controllers
@@ -41,7 +41,7 @@ export function createPage(model: FormModel, pageDef: Page) {
       break
 
     case ControllerType.Page:
-      controller = new PageControllers.PageController(model, pageDef)
+      controller = new PageControllers.QuestionPageController(model, pageDef)
       break
 
     case ControllerType.Summary:

--- a/src/server/plugins/engine/pageControllers/index.ts
+++ b/src/server/plugins/engine/pageControllers/index.ts
@@ -1,4 +1,4 @@
-export { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
+export { PageControllerBase as PageController } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 export { StartPageController } from '~/src/server/plugins/engine/pageControllers/StartPageController.js'
 export { SummaryPageController } from '~/src/server/plugins/engine/pageControllers/SummaryPageController.js'
 export { StatusPageController } from '~/src/server/plugins/engine/pageControllers/StatusPageController.js'

--- a/src/server/plugins/engine/pageControllers/index.ts
+++ b/src/server/plugins/engine/pageControllers/index.ts
@@ -1,5 +1,8 @@
-export { PageControllerBase as PageController } from '~/src/server/plugins/engine/pageControllers/PageControllerBase.js'
 export { StartPageController } from '~/src/server/plugins/engine/pageControllers/StartPageController.js'
+export {
+  QuestionPageController, // Export alongside alias
+  QuestionPageController as PageController
+} from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 export { SummaryPageController } from '~/src/server/plugins/engine/pageControllers/SummaryPageController.js'
 export { StatusPageController } from '~/src/server/plugins/engine/pageControllers/StatusPageController.js'
 export { FileUploadPageController } from '~/src/server/plugins/engine/pageControllers/FileUploadPageController.js'

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -62,9 +62,7 @@ export const plugin = {
 
     const loadFormPreHandler = async (
       request: FormRequest | FormRequestPayload,
-      h:
-        | ResponseToolkit<FormRequestRefs>
-        | ResponseToolkit<FormRequestPayloadRefs>
+      h: Pick<ResponseToolkit, 'continue'>
     ) => {
       if (server.app.model) {
         request.app.model = server.app.model
@@ -141,7 +139,7 @@ export const plugin = {
 
     const dispatchHandler = (
       request: FormRequest,
-      h: ResponseToolkit<FormRequestRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { model } = request.app
 
@@ -151,7 +149,7 @@ export const plugin = {
 
     const getHandler = (
       request: FormRequest,
-      h: ResponseToolkit<FormRequestRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { model } = request.app
       const { path } = request.params
@@ -166,7 +164,7 @@ export const plugin = {
 
     const postHandler = (
       request: FormRequestPayload,
-      h: ResponseToolkit<FormRequestPayloadRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { model } = request.app
 
@@ -303,7 +301,7 @@ export const plugin = {
     // List summary GET route
     const getListSummaryHandler = (
       request: FormRequest,
-      h: ResponseToolkit<FormRequestRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { app, params } = request
       const page = getPage(app.model, request)
@@ -349,7 +347,7 @@ export const plugin = {
     // List summary POST route
     const postListSummaryHandler = (
       request: FormRequestPayload,
-      h: ResponseToolkit<FormRequestPayloadRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { app, params } = request
       const page = getPage(app.model, request)
@@ -407,7 +405,7 @@ export const plugin = {
     // List delete GET route
     const getListDeleteHandler = (
       request: FormRequest,
-      h: ResponseToolkit<FormRequestRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { app, params } = request
       const page = getPage(app.model, request)
@@ -455,7 +453,7 @@ export const plugin = {
     // List delete POST route
     const postListDeleteHandler = (
       request: FormRequestPayload,
-      h: ResponseToolkit<FormRequestPayloadRefs>
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { app, params } = request
       const page = getPage(app.model, request)

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -1,5 +1,4 @@
 import { type Item } from '@defra/forms-model'
-import { type ResponseObject } from '@hapi/hapi'
 import { type ValidationErrorItem } from 'joi'
 
 import { type FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
@@ -7,11 +6,8 @@ import {
   type ComponentText,
   type ComponentViewModel
 } from '~/src/server/plugins/engine/components/types.js'
+import { type PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
-import {
-  type FileUploadPageController,
-  type PageController
-} from '~/src/server/plugins/engine/pageControllers/index.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
 
 /**
@@ -247,26 +243,30 @@ export interface PageViewModelBase {
   pageTitle: string
   sectionTitle?: string
   showTitle: boolean
-  components: ComponentViewModel[]
-  errors?: FormSubmissionError[]
   isStartPage: boolean
-  startPage?: ResponseObject
   backLink?: string
   feedbackLink?: string
   serviceUrl: string
   phaseTag?: string
+}
+
+export interface FormPageViewModel extends PageViewModelBase {
+  components: ComponentViewModel[]
+  errors?: FormSubmissionError[]
   notificationEmailWarning?: {
     slug: string
     designerUrl: string
   }
 }
 
-export interface FileUploadPageViewModel extends PageViewModelBase {
-  page: FileUploadPageController
+export interface FileUploadPageViewModel extends FormPageViewModel {
   path: string
   formAction?: string
   fileUploadComponent: ComponentViewModel
   preUploadComponents: ComponentViewModel[]
 }
 
-export type PageViewModel = PageViewModelBase | FileUploadPageViewModel
+export type PageViewModel =
+  | PageViewModelBase
+  | FormPageViewModel
+  | FileUploadPageViewModel

--- a/test/form/csrf.test.js
+++ b/test/form/csrf.test.js
@@ -39,7 +39,7 @@ describe('CSRF', () => {
 
   test('get request returns CSRF header', async () => {
     const { response } = await renderResponse(server, {
-      url: `${basePath}/start`
+      url: `${basePath}/licence`
     })
 
     expect(response.statusCode).toBe(StatusCodes.OK)
@@ -55,7 +55,7 @@ describe('CSRF', () => {
 
   test('post request without CSRF token returns 403 forbidden', async () => {
     const response = await server.inject({
-      url: `${basePath}/start`,
+      url: `${basePath}/licence`,
       method: 'POST',
       payload: {
         licenceLength: '1'
@@ -69,7 +69,7 @@ describe('CSRF', () => {
     const csrfToken = 'dummy-token'
 
     const response = await server.inject({
-      url: `${basePath}/start`,
+      url: `${basePath}/licence`,
       method: 'POST',
       headers: {
         cookie: `crumb=${csrfToken}`

--- a/test/form/definitions/basic.js
+++ b/test/form/definitions/basic.js
@@ -6,11 +6,11 @@ import {
 
 export default /** @satisfies {FormDefinition} */ ({
   name: 'Basic',
-  startPage: '/start',
+  startPage: '/licence',
   pages: /** @type {const} */ ([
     {
       title: 'Buy a rod fishing licence',
-      path: '/start',
+      path: '/licence',
       components: [
         {
           options: {

--- a/test/form/definitions/basic.js
+++ b/test/form/definitions/basic.js
@@ -7,7 +7,7 @@ import {
 export default /** @satisfies {FormDefinition} */ ({
   name: 'Basic',
   startPage: '/start',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       title: 'Buy a rod fishing licence',
       path: '/start',
@@ -55,7 +55,7 @@ export default /** @satisfies {FormDefinition} */ ({
       controller: ControllerType.Summary,
       title: 'Summary'
     }
-  ],
+  ]),
   sections: [
     {
       name: 'licenceDetails',

--- a/test/form/definitions/conditions-basic.js
+++ b/test/form/definitions/conditions-basic.js
@@ -9,7 +9,7 @@ import {
 export default /** @satisfies {FormDefinition} */ ({
   name: 'Conditions',
   startPage: '/first-page',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       title: 'Previous marriages',
       path: '/first-page',
@@ -58,7 +58,7 @@ export default /** @satisfies {FormDefinition} */ ({
       path: ControllerPath.Summary,
       controller: ControllerType.Summary
     }
-  ],
+  ]),
   lists: [],
   sections: [],
   conditions: [

--- a/test/form/definitions/conditions-basic.js
+++ b/test/form/definitions/conditions-basic.js
@@ -51,6 +51,7 @@ export default /** @satisfies {FormDefinition} */ ({
           schema: {}
         }
       ],
+      section: 'marriage',
       next: [{ path: '/summary' }]
     },
     {
@@ -60,7 +61,12 @@ export default /** @satisfies {FormDefinition} */ ({
     }
   ]),
   lists: [],
-  sections: [],
+  sections: [
+    {
+      name: 'marriage',
+      title: 'Your marriage'
+    }
+  ],
   conditions: [
     {
       displayName: 'Previously married',

--- a/test/form/definitions/conditions-complex.js
+++ b/test/form/definitions/conditions-complex.js
@@ -133,7 +133,6 @@ export default /** @satisfies {FormDefinition} */ ({
       path: '/applicant-two',
       title: 'Applicant 2',
       section: 'applicantTwoDetails',
-      controller: ControllerType.Page,
       components: [
         {
           type: ComponentType.Html,

--- a/test/form/definitions/conditions-complex.js
+++ b/test/form/definitions/conditions-complex.js
@@ -9,7 +9,7 @@ import {
 export default /** @satisfies {FormDefinition} */ ({
   name: 'Conditions complex',
   startPage: '/uk-passport',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       path: '/uk-passport',
       components: [
@@ -224,7 +224,7 @@ export default /** @satisfies {FormDefinition} */ ({
         }
       ]
     }
-  ],
+  ]),
   lists: [
     {
       name: 'numberOfApplicants',

--- a/test/form/definitions/conditions-dates.js
+++ b/test/form/definitions/conditions-dates.js
@@ -9,7 +9,7 @@ import {
 export default /** @satisfies {FormDefinition} */ ({
   name: 'Conditions dates',
   startPage: '/page-one',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       path: '/page-one',
       title: 'Page one',
@@ -43,7 +43,7 @@ export default /** @satisfies {FormDefinition} */ ({
       components: [],
       next: []
     }
-  ],
+  ]),
   lists: [],
   sections: [],
   conditions: [

--- a/test/form/definitions/conditions-escaping.js
+++ b/test/form/definitions/conditions-escaping.js
@@ -10,7 +10,7 @@ import {
 export default /** @satisfies {FormDefinition} */ ({
   name: 'Conditions escaping',
   startPage: '/page-one',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       title: 'Page one',
       path: '/page-one',
@@ -65,7 +65,7 @@ export default /** @satisfies {FormDefinition} */ ({
       controller: ControllerType.Summary,
       title: 'Summary'
     }
-  ],
+  ]),
   lists: [
     {
       title: 'test',

--- a/test/form/definitions/fields-optional.js
+++ b/test/form/definitions/fields-optional.js
@@ -7,7 +7,7 @@ import {
 export default /** @satisfies {FormDefinition} */ ({
   name: 'Fields optional',
   startPage: '/components',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       path: '/components',
       title: 'Fields optional',
@@ -143,7 +143,7 @@ export default /** @satisfies {FormDefinition} */ ({
       controller: ControllerType.Summary,
       title: 'Summary'
     }
-  ],
+  ]),
   lists: [
     {
       name: 'companyType',

--- a/test/form/definitions/fields-required.js
+++ b/test/form/definitions/fields-required.js
@@ -7,7 +7,7 @@ import {
 export default /** @satisfies {FormDefinition} */ ({
   name: 'Fields required',
   startPage: '/components',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       path: '/components',
       title: 'Fields required',
@@ -143,7 +143,7 @@ export default /** @satisfies {FormDefinition} */ ({
       controller: ControllerType.Summary,
       title: 'Summary'
     }
-  ],
+  ]),
   lists: [
     {
       name: 'companyType',

--- a/test/form/definitions/file-upload-basic.js
+++ b/test/form/definitions/file-upload-basic.js
@@ -7,7 +7,7 @@ import {
 export default /** @satisfies {FormDefinition} */ ({
   name: 'File upload basic',
   startPage: '/file-upload-component',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       path: '/file-upload-component',
       title: 'File upload component',
@@ -32,7 +32,7 @@ export default /** @satisfies {FormDefinition} */ ({
       controller: ControllerType.Summary,
       title: 'Summary'
     }
-  ],
+  ]),
   lists: [],
   sections: [],
   conditions: [],

--- a/test/form/definitions/file-upload.js
+++ b/test/form/definitions/file-upload.js
@@ -7,7 +7,7 @@ import {
 export default /** @satisfies {FormDefinition} */ ({
   name: 'File upload',
   startPage: '/methodology-statement',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       path: '/methodology-statement',
       title: 'Upload your methodology statement',
@@ -48,7 +48,7 @@ export default /** @satisfies {FormDefinition} */ ({
       controller: ControllerType.Summary,
       title: 'Summary'
     }
-  ],
+  ]),
   sections: [
     {
       name: 'section',

--- a/test/form/definitions/repeat-mixed.js
+++ b/test/form/definitions/repeat-mixed.js
@@ -7,7 +7,7 @@ export default /** @satisfies {FormDefinition} */ ({
 
   name: 'Repeat form mixed',
   startPage: '/delivery-or-collection',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       title: 'Delivery or collection',
       path: '/delivery-or-collection',
@@ -29,7 +29,7 @@ export default /** @satisfies {FormDefinition} */ ({
 
     // Combine with repeat form pages
     ...definition.pages
-  ],
+  ]),
   lists: [
     {
       name: 'orderTypeOption',
@@ -50,5 +50,5 @@ export default /** @satisfies {FormDefinition} */ ({
 })
 
 /**
- * @import { FormDefinition, Page } from '@defra/forms-model'
+ * @import { FormDefinition } from '@defra/forms-model'
  */

--- a/test/form/definitions/repeat.js
+++ b/test/form/definitions/repeat.js
@@ -7,7 +7,7 @@ import {
 export default /** @satisfies {FormDefinition} */ ({
   name: 'Repeat form',
   startPage: '/pizza-order',
-  pages: [
+  pages: /** @type {const} */ ([
     {
       title: 'Pizza order',
       path: '/pizza-order',
@@ -52,7 +52,7 @@ export default /** @satisfies {FormDefinition} */ ({
       controller: ControllerType.Summary,
       title: 'Summary'
     }
-  ],
+  ]),
   sections: [
     {
       name: 'food',

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -28,7 +28,7 @@ describe('Form journey', () => {
       heading2: 'Licence details',
 
       paths: {
-        current: '/start',
+        current: '/licence',
         next: '/full-name'
       },
 
@@ -57,7 +57,7 @@ describe('Form journey', () => {
 
       paths: {
         current: '/full-name',
-        previous: '/start',
+        previous: '/licence',
         next: '/summary'
       },
 
@@ -362,7 +362,7 @@ describe('Form journey', () => {
 
       // Redirect back to start
       expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-      expect(response.headers.location).toBe(`${basePath}/start`)
+      expect(response.headers.location).toBe(`${basePath}/licence`)
     })
 
     it('should redirect to the complete page on submit', async () => {
@@ -431,7 +431,7 @@ describe('Form journey', () => {
 
       // Redirect back to start
       expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-      expect(response.headers.location).toBe(`${basePath}/start`)
+      expect(response.headers.location).toBe(`${basePath}/licence`)
     })
   })
 })


### PR DESCRIPTION
This PR adds missing test coverage for page controllers plus:

* Imported specific page types `PageSummary`, `PageFileUpload` from **forms-designer** etc
* Renamed `PageControllerBase` → `QuestionPageController`

Protected methods have been replaced with getters for easy testing:

```patch
- protected getFeedbackLink() {
+ get feedbackLink() {
```

```patch
- protected getPhaseTag() {
+ get phaseTag() {
```
