### PR TITLE
Add base component/page `viewModel` as getter

### DIFF
--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -12,10 +12,6 @@ import { type ComponentCollection } from '~/src/server/plugins/engine/components
 import { type Component } from '~/src/server/plugins/engine/components/helpers.js'
 import { type ViewModel } from '~/src/server/plugins/engine/components/types.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
-import {
-  type FormPayload,
-  type FormSubmissionError
-} from '~/src/server/plugins/engine/types.js'
 
 export class ComponentBase {
   parent: Component | undefined
@@ -57,16 +53,7 @@ export class ComponentBase {
     this.model = props.model
   }
 
-  /**
-   * parses form payload and returns an object provided to a govuk-frontend template to render
-   */
-  getViewModel(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    payload: FormPayload,
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    errors?: FormSubmissionError[]
-  ) {
+  get viewModel() {
     const { options, type } = this
 
     const viewModel: ViewModel = {

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -13,7 +13,8 @@ import {
 import {
   createComponent,
   type Component,
-  type Field
+  type Field,
+  type Guidance
 } from '~/src/server/plugins/engine/components/helpers.js'
 import { type ComponentViewModel } from '~/src/server/plugins/engine/components/types.js'
 import { getErrors } from '~/src/server/plugins/engine/helpers.js'
@@ -34,6 +35,7 @@ export class ComponentCollection {
 
   components: Component[]
   fields: Field[]
+  guidance: Guidance[]
 
   formSchema: ObjectSchema<FormPayload>
   stateSchema: ObjectSchema<FormSubmissionState>
@@ -62,6 +64,10 @@ export class ComponentCollection {
 
     const fields = components.filter(
       (component): component is Field => component.isFormComponent
+    )
+
+    const guidance = components.filter(
+      (component): component is Guidance => !component.isFormComponent
     )
 
     let formSchema = joi.object<FormPayload>().required()
@@ -138,6 +144,8 @@ export class ComponentCollection {
 
     this.components = components
     this.fields = fields
+    this.guidance = guidance
+
     this.formSchema = formSchema
     this.stateSchema = stateSchema
   }

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -6,6 +6,7 @@ import joi, {
 } from 'joi'
 
 import {
+  FormComponent,
   isFormState,
   isFormValue
 } from '~/src/server/plugins/engine/components/FormComponent.js'
@@ -231,11 +232,14 @@ export class ComponentCollection {
     const { components } = this
 
     const result: ComponentViewModel[] = components.map((component) => {
-      return {
-        type: component.type,
-        isFormComponent: component.isFormComponent,
-        model: component.getViewModel(payload, errors)
-      }
+      const { isFormComponent, type } = component
+
+      const model =
+        component instanceof FormComponent
+          ? component.getViewModel(payload, errors)
+          : component.getViewModel()
+
+      return { type, isFormComponent, model }
     })
 
     if (conditions) {

--- a/src/server/plugins/engine/components/Details.test.ts
+++ b/src/server/plugins/engine/components/Details.test.ts
@@ -1,0 +1,49 @@
+import { ComponentType, type DetailsComponent } from '@defra/forms-model'
+
+import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
+import { type Guidance } from '~/src/server/plugins/engine/components/helpers.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import definition from '~/test/form/definitions/basic.js'
+
+describe('Details', () => {
+  let model: FormModel
+
+  beforeEach(() => {
+    model = new FormModel(definition, {
+      basePath: 'test'
+    })
+  })
+
+  describe('Defaults', () => {
+    let def: DetailsComponent
+    let collection: ComponentCollection
+    let guidance: Guidance
+
+    beforeEach(() => {
+      def = {
+        title: 'Details guidance',
+        name: 'myComponent',
+        type: ComponentType.Details,
+        content: 'Lorem ipsum dolor sit amet',
+        options: {}
+      } satisfies DetailsComponent
+
+      collection = new ComponentCollection([def], { model })
+      guidance = collection.guidance[0]
+    })
+
+    describe('View model', () => {
+      it('sets Nunjucks component defaults', () => {
+        const viewModel = guidance.getViewModel()
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            attributes: {},
+            html: def.content,
+            summaryHtml: def.title
+          })
+        )
+      })
+    })
+  })
+})

--- a/src/server/plugins/engine/components/Details.ts
+++ b/src/server/plugins/engine/components/Details.ts
@@ -1,10 +1,6 @@
 import { type DetailsComponent } from '@defra/forms-model'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
-import {
-  type FormPayload,
-  type FormSubmissionError
-} from '~/src/server/plugins/engine/types.js'
 
 export class Details extends ComponentBase {
   declare options: DetailsComponent['options']
@@ -22,10 +18,8 @@ export class Details extends ComponentBase {
     this.options = options
   }
 
-  getViewModel(payload: FormPayload, errors?: FormSubmissionError[]) {
-    const { content, title } = this
-
-    const viewModel = super.getViewModel(payload, errors)
+  getViewModel() {
+    const { content, title, viewModel } = this
 
     return {
       ...viewModel,

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -102,9 +102,7 @@ export class FormComponent extends ComponentBase {
   }
 
   getViewModel(payload: FormPayload, errors?: FormSubmissionError[]) {
-    const { hint, name, options = {}, title } = this
-
-    const viewModel = super.getViewModel(payload, errors)
+    const { hint, name, options = {}, title, viewModel } = this
 
     const isRequired = !('required' in options) || options.required !== false
     const hideOptional = 'optionalText' in options && options.optionalText

--- a/src/server/plugins/engine/components/Html.test.ts
+++ b/src/server/plugins/engine/components/Html.test.ts
@@ -1,0 +1,48 @@
+import { ComponentType, type HtmlComponent } from '@defra/forms-model'
+
+import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
+import { type Guidance } from '~/src/server/plugins/engine/components/helpers.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import definition from '~/test/form/definitions/basic.js'
+
+describe('HTML', () => {
+  let model: FormModel
+
+  beforeEach(() => {
+    model = new FormModel(definition, {
+      basePath: 'test'
+    })
+  })
+
+  describe('Defaults', () => {
+    let def: HtmlComponent
+    let collection: ComponentCollection
+    let guidance: Guidance
+
+    beforeEach(() => {
+      def = {
+        title: 'HTML guidance',
+        name: 'myComponent',
+        type: ComponentType.Html,
+        content: '<p class="govuk-body">\nLorem ipsum dolor sit amet</p>',
+        options: {}
+      } satisfies HtmlComponent
+
+      collection = new ComponentCollection([def], { model })
+      guidance = collection.guidance[0]
+    })
+
+    describe('View model', () => {
+      it('sets Nunjucks component defaults', () => {
+        const viewModel = guidance.getViewModel()
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            attributes: {},
+            content: def.content
+          })
+        )
+      })
+    })
+  })
+})

--- a/src/server/plugins/engine/components/Html.ts
+++ b/src/server/plugins/engine/components/Html.ts
@@ -1,10 +1,6 @@
 import { type HtmlComponent } from '@defra/forms-model'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
-import {
-  type FormPayload,
-  type FormSubmissionError
-} from '~/src/server/plugins/engine/types.js'
 
 export class Html extends ComponentBase {
   declare options: HtmlComponent['options']
@@ -22,10 +18,8 @@ export class Html extends ComponentBase {
     this.options = options
   }
 
-  getViewModel(payload: FormPayload, errors?: FormSubmissionError[]) {
-    const { content } = this
-
-    const viewModel = super.getViewModel(payload, errors)
+  getViewModel() {
+    const { content, viewModel } = this
 
     return {
       ...viewModel,

--- a/src/server/plugins/engine/components/InsetText.test.ts
+++ b/src/server/plugins/engine/components/InsetText.test.ts
@@ -1,0 +1,48 @@
+import { ComponentType, type InsetTextComponent } from '@defra/forms-model'
+
+import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
+import { type Guidance } from '~/src/server/plugins/engine/components/helpers.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import definition from '~/test/form/definitions/basic.js'
+
+describe('InsetText', () => {
+  let model: FormModel
+
+  beforeEach(() => {
+    model = new FormModel(definition, {
+      basePath: 'test'
+    })
+  })
+
+  describe('Defaults', () => {
+    let def: InsetTextComponent
+    let collection: ComponentCollection
+    let guidance: Guidance
+
+    beforeEach(() => {
+      def = {
+        title: 'Inset text guidance',
+        name: 'myComponent',
+        type: ComponentType.InsetText,
+        content: 'Lorem ipsum dolor sit amet',
+        options: {}
+      } satisfies InsetTextComponent
+
+      collection = new ComponentCollection([def], { model })
+      guidance = collection.guidance[0]
+    })
+
+    describe('View model', () => {
+      it('sets Nunjucks component defaults', () => {
+        const viewModel = guidance.getViewModel()
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            attributes: {},
+            content: def.content
+          })
+        )
+      })
+    })
+  })
+})

--- a/src/server/plugins/engine/components/InsetText.ts
+++ b/src/server/plugins/engine/components/InsetText.ts
@@ -1,10 +1,6 @@
 import { type InsetTextComponent } from '@defra/forms-model'
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
-import {
-  type FormPayload,
-  type FormSubmissionError
-} from '~/src/server/plugins/engine/types.js'
 
 export class InsetText extends ComponentBase {
   content: InsetTextComponent['content']
@@ -20,10 +16,8 @@ export class InsetText extends ComponentBase {
     this.content = content
   }
 
-  getViewModel(payload: FormPayload, errors?: FormSubmissionError[]) {
-    const { content } = this
-
-    const viewModel = super.getViewModel(payload, errors)
+  getViewModel() {
+    const { content, viewModel } = this
 
     return {
       ...viewModel,

--- a/src/server/plugins/engine/components/List.test.ts
+++ b/src/server/plugins/engine/components/List.test.ts
@@ -1,0 +1,76 @@
+import { ComponentType, type ListComponent } from '@defra/forms-model'
+
+import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
+import { type Guidance } from '~/src/server/plugins/engine/components/helpers.js'
+import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
+import definition from '~/test/form/definitions/basic.js'
+
+describe('List', () => {
+  let model: FormModel
+
+  beforeEach(() => {
+    model = new FormModel(definition, {
+      basePath: 'test'
+    })
+  })
+
+  describe('Defaults', () => {
+    let def: ListComponent
+    let collection: ComponentCollection
+    let guidance: Guidance
+
+    beforeEach(() => {
+      def = {
+        title: 'List guidance',
+        name: 'myComponent',
+        type: ComponentType.List,
+        list: 'licenceLengthDays',
+        options: {}
+      } satisfies ListComponent
+
+      collection = new ComponentCollection([def], { model })
+      guidance = collection.guidance[0]
+    })
+
+    describe('View model', () => {
+      it('sets Nunjucks component defaults', () => {
+        const viewModel = guidance.getViewModel()
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            attributes: {},
+            content: {
+              title: def.title,
+              text: ''
+            }
+          })
+        )
+      })
+    })
+
+    describe('List items', () => {
+      it('returns list items', () => {
+        expect(guidance).toHaveProperty('items', [
+          {
+            text: '1 day',
+            value: 1,
+            description:
+              'Valid for 24 hours from the start time that you select'
+          },
+          {
+            text: '8 day',
+            value: 8,
+            description:
+              'Valid for 8 consecutive days from the start time that you select'
+          },
+          {
+            text: '12 months',
+            value: 365,
+            description:
+              '12-month licences are now valid for 365 days from their start date and can be purchased at any time during the year'
+          }
+        ])
+      })
+    })
+  })
+})

--- a/src/server/plugins/engine/components/List.ts
+++ b/src/server/plugins/engine/components/List.ts
@@ -6,10 +6,6 @@ import {
 
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { type ListItem } from '~/src/server/plugins/engine/components/types.js'
-import {
-  type FormPayload,
-  type FormSubmissionError
-} from '~/src/server/plugins/engine/types.js'
 
 export class List extends ComponentBase {
   declare options: ListComponent['options']
@@ -34,10 +30,9 @@ export class List extends ComponentBase {
     this.options = options
   }
 
-  getViewModel(payload: FormPayload, errors?: FormSubmissionError[]) {
-    const { items: listItems, options } = this
+  getViewModel() {
+    const { items: listItems, options, viewModel } = this
 
-    const viewModel = super.getViewModel(payload, errors)
     let { classes, content, items, type } = viewModel
 
     if (options.type) {

--- a/src/server/plugins/engine/components/helpers.ts
+++ b/src/server/plugins/engine/components/helpers.ts
@@ -63,6 +63,14 @@ export type Field = InstanceType<
   | typeof Components.FileUploadField
 >
 
+// Guidance component instances only
+export type Guidance = InstanceType<
+  | typeof Components.Details
+  | typeof Components.Html
+  | typeof Components.InsetText
+  | typeof Components.List
+>
+
 /**
  * Create field instance for each {@link ComponentDef} type
  */

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -19,11 +19,7 @@ import {
   normalisePath
 } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
-import {
-  type FormPayload,
-  type FormSubmissionError,
-  type PageViewModelBase
-} from '~/src/server/plugins/engine/types.js'
+import { type PageViewModelBase } from '~/src/server/plugins/engine/types.js'
 import {
   type FormRequest,
   type FormRequestPayload,
@@ -86,6 +82,26 @@ export class PageController {
     return {}
   }
 
+  get viewModel(): PageViewModelBase {
+    const { name, section, title } = this
+
+    const showTitle = true
+    const pageTitle = title
+    const sectionTitle = section?.hideTitle !== true ? section?.title : ''
+
+    return {
+      name,
+      page: this,
+      pageTitle,
+      sectionTitle,
+      showTitle,
+      isStartPage: false,
+      serviceUrl: this.getHref('/'),
+      feedbackLink: this.feedbackLink,
+      phaseTag: this.phaseTag
+    }
+  }
+
   get feedbackLink() {
     const { def } = this
 
@@ -126,42 +142,12 @@ export class PageController {
     return ControllerPath.Status.valueOf()
   }
 
-  getViewModel(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    request: FormRequest | FormRequestPayload,
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    payload: FormPayload,
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    errors?: FormSubmissionError[]
-  ): PageViewModelBase {
-    const { name, section, title } = this
-
-    const showTitle = true
-    const pageTitle = title
-    const sectionTitle = section?.hideTitle !== true ? section?.title : ''
-
-    return {
-      name,
-      page: this,
-      pageTitle,
-      sectionTitle,
-      showTitle,
-      isStartPage: false,
-      serviceUrl: this.getHref('/'),
-      feedbackLink: this.feedbackLink,
-      phaseTag: this.phaseTag
-    }
-  }
-
   makeGetRouteHandler(): (
     request: FormRequest,
     h: Pick<ResponseToolkit, 'redirect' | 'view'>
   ) => ReturnType<Lifecycle.Method<FormRequestRefs>> {
     return (request, h) => {
-      const { viewName } = this
-      const viewModel = this.getViewModel(request, {})
+      const { viewModel, viewName } = this
       return h.view(viewName, viewModel)
     }
   }

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -5,6 +5,7 @@ import { QuestionPageController } from '~/src/server/plugins/engine/pageControll
 import {
   type FormContextProgress,
   type FormContextRequest,
+  type FormPageViewModel,
   type FormState,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
@@ -137,77 +138,6 @@ describe('QuestionPageController', () => {
       expect(components2[2].name).toBe('multilineTextField')
     })
 
-    describe('Component view models', () => {
-      it('hides the page title for single form component pages', () => {
-        const viewModel1 = controller1.getViewModel(requestPage1, {})
-        const viewModel2 = controller2.getViewModel(requestPage2, {})
-
-        // Page 1 hides page title (single component)
-        expect(viewModel1).toHaveProperty('showTitle', false)
-        expect(viewModel1).toHaveProperty('pageTitle', 'Previous marriages')
-
-        // Page 2 shows page title (multiple components)
-        expect(viewModel2).toHaveProperty('showTitle', true)
-        expect(viewModel2).toHaveProperty(
-          'pageTitle',
-          'When will you get married?'
-        )
-      })
-
-      it('returns the component view models for the page', () => {
-        const viewModel1 = controller1.getViewModel(requestPage1, {})
-        const viewModel2 = controller2.getViewModel(requestPage2, {})
-
-        const { components: components1 } = viewModel1
-        const { components: components2 } = viewModel2
-
-        expect(components1).toHaveLength(1)
-        expect(components2).toHaveLength(3)
-
-        // Page 1, component 1, default label
-        expect(components1[0].model).toHaveProperty('label', {
-          text: 'Have you previously been married?'
-        })
-
-        // Page 1, component 1, optional legend
-        expect(components1[0].model).toHaveProperty('fieldset', {
-          legend: {
-            text: 'Previous marriages',
-            classes: 'govuk-fieldset__legend--l',
-            isPageHeading: true
-          }
-        })
-
-        // Page 2, component 1, content only
-        expect(components2[0].model).toEqual({
-          attributes: {},
-          summaryHtml: 'Find out more',
-          html: 'Some content goes here'
-        })
-
-        // Page 2, component 2, default label
-        expect(components2[1].model).toHaveProperty('label', {
-          text: 'Date of marriage'
-        })
-
-        // Page 2, component 2, optional legend
-        expect(components2[1].model).toHaveProperty('fieldset', {
-          legend: {
-            text: 'Date of marriage',
-            classes: 'govuk-fieldset__legend--m'
-          }
-        })
-
-        // Page 2, component 3, default label
-        expect(components2[2].model).toHaveProperty('label', {
-          text: 'Remarks'
-        })
-
-        // Page 2, component 3, optional legend
-        expect(components2[2].model).not.toHaveProperty('fieldset')
-      })
-    })
-
     it('returns the fields for the page', () => {
       const { fields: fields1 } = controller1.collection
       const { fields: fields2 } = controller2.collection
@@ -218,6 +148,79 @@ describe('QuestionPageController', () => {
       expect(fields2).toHaveLength(2)
       expect(fields2[0].name).toBe('dateField')
       expect(fields2[1].name).toBe('multilineTextField')
+    })
+  })
+
+  describe('Component view models', () => {
+    let viewModel1: FormPageViewModel
+    let viewModel2: FormPageViewModel
+
+    beforeEach(() => {
+      viewModel1 = controller1.getViewModel(requestPage1, {})
+      viewModel2 = controller2.getViewModel(requestPage2, {})
+    })
+
+    it('hides the page title for single form component pages', () => {
+      // Page 1 hides page title (single component)
+      expect(viewModel1).toHaveProperty('showTitle', false)
+      expect(viewModel1).toHaveProperty('pageTitle', 'Previous marriages')
+
+      // Page 2 shows page title (multiple components)
+      expect(viewModel2).toHaveProperty('showTitle', true)
+      expect(viewModel2).toHaveProperty(
+        'pageTitle',
+        'When will you get married?'
+      )
+    })
+
+    it('returns the component view models for the page', () => {
+      const { components: components1 } = viewModel1
+      const { components: components2 } = viewModel2
+
+      expect(components1).toHaveLength(1)
+      expect(components2).toHaveLength(3)
+
+      // Page 1, component 1, default label
+      expect(components1[0].model).toHaveProperty('label', {
+        text: 'Have you previously been married?'
+      })
+
+      // Page 1, component 1, optional legend
+      expect(components1[0].model).toHaveProperty('fieldset', {
+        legend: {
+          text: 'Previous marriages',
+          classes: 'govuk-fieldset__legend--l',
+          isPageHeading: true
+        }
+      })
+
+      // Page 2, component 1, content only
+      expect(components2[0].model).toEqual({
+        attributes: {},
+        summaryHtml: 'Find out more',
+        html: 'Some content goes here'
+      })
+
+      // Page 2, component 2, default label
+      expect(components2[1].model).toHaveProperty('label', {
+        text: 'Date of marriage'
+      })
+
+      // Page 2, component 2, optional legend
+      expect(components2[1].model).toHaveProperty('fieldset', {
+        legend: {
+          text: 'Date of marriage',
+          classes: 'govuk-fieldset__legend--m'
+        }
+      })
+
+      // Page 2, component 3, default label
+      expect(components2[2].model).toHaveProperty('label', {
+        text: 'Remarks'
+      })
+
+      // Page 2, component 3, optional legend
+      expect(components2[2].model).not.toHaveProperty('fieldset')
     })
   })
 
@@ -390,27 +393,16 @@ describe('QuestionPageController', () => {
     let contextYes: FormContextProgress
 
     beforeEach(() => {
-      const request = {
-        method: 'get',
-        url: new URL('http://example.com/test/first-page'),
-        path: '/test/first-page',
-        params: {
-          path: 'first-page',
-          slug: 'test'
-        },
-        query: {}
-      } satisfies FormContextRequest
-
       // Empty state
-      context = controller1.model.getFormContext(request, {})
+      context = controller1.model.getFormContext(requestPage1, {})
 
       // Question 1: Selected 'No'
-      contextNo = controller1.model.getFormContext(request, {
+      contextNo = controller1.model.getFormContext(requestPage1, {
         yesNoField: false
       })
 
       // Question 1: Selected 'Yes'
-      contextYes = controller1.model.getFormContext(request, {
+      contextYes = controller1.model.getFormContext(requestPage1, {
         yesNoField: true
       })
     })

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -149,6 +149,15 @@ describe('QuestionPageController', () => {
       expect(fields2[0].name).toBe('dateField')
       expect(fields2[1].name).toBe('multilineTextField')
     })
+
+    it('returns the guidance for the page', () => {
+      const { guidance: guidance1 } = controller1.collection
+      const { guidance: guidance2 } = controller2.collection
+
+      expect(guidance1).toHaveLength(0)
+      expect(guidance2).toHaveLength(1)
+      expect(guidance2[0].name).toBe('detailsField')
+    })
   })
 
   describe('Component view models', () => {

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -81,9 +81,8 @@ export class QuestionPageController extends PageController {
     payload: FormPayload,
     errors?: FormSubmissionError[]
   ): FormPageViewModel {
-    const { collection } = this
+    const { collection, viewModel } = this
 
-    const viewModel = super.getViewModel(request, payload, errors)
     let { pageTitle, showTitle } = viewModel
 
     const components = collection.getViewModel(payload, errors)


### PR DESCRIPTION
Tiny bit of tech debt to remove some ESLint disable comments

I've added ~`getViewModel()`~ `get viewModel` for the base page and component

Leaving only form components and question pages with `getViewModel()` + payload/errors

## Base component

```patch
- getViewModel(
-   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-   payload: FormPayload,
-
-   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-   errors?: FormSubmissionError[]
- ) {
+ get viewModel() {
```

## Base page

```patch
- getViewModel(
-   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-   request: FormRequest | FormRequestPayload,
-
-   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-   payload: FormPayload,
-
-   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-   errors?: FormSubmissionError[]
- ): PageViewModelBase {
+ get viewModel() {
```

