### PR TITLE
Exit pages: Reduce controller state read/write

### DIFF
--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -159,7 +159,7 @@ export class FileUploadPageController extends QuestionPageController {
       const { viewModel } = this
       const { params } = request
 
-      const state = await this.getState(request)
+      let state = await this.getState(request)
       const files = this.getFilesFromState(state)
 
       const fileToRemove = files.find(
@@ -172,7 +172,8 @@ export class FileUploadPageController extends QuestionPageController {
 
       const { filename: itemTitle } = fileToRemove.status.form.file
 
-      const { progress = [] } = await this.updateProgress(request, state)
+      state = await this.updateProgress(request, state)
+      const { progress = [] } = state
 
       return h.view(this.fileDeleteViewName, {
         ...viewModel,

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -482,13 +482,15 @@ describe('QuestionPageController', () => {
       const state: FormState = { yesNoField: false }
 
       for (const controller of [controller1, controller2]) {
-        jest.spyOn(controller, 'getState').mockResolvedValue(state)
+        jest
+          .spyOn(controller, 'buildMissingEmailWarningModel')
+          .mockResolvedValue(undefined)
 
         for (const method of [
-          jest.spyOn(controller, 'updateProgress'),
-          jest.spyOn(controller, 'buildMissingEmailWarningModel')
+          jest.spyOn(controller, 'getState'),
+          jest.spyOn(controller, 'updateProgress')
         ]) {
-          method.mockResolvedValue(undefined)
+          method.mockResolvedValue(state)
         }
       }
 

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -257,7 +257,7 @@ export class QuestionPageController extends PageController {
     ) => {
       const { model, path, viewName } = this
 
-      const state = await this.getState(request)
+      let state = await this.getState(request)
       const context = model.getFormContext(request, state)
       const relevantPath = this.getRelevantPath(context)
 
@@ -322,7 +322,8 @@ export class QuestionPageController extends PageController {
         return evaluatedComponent
       })
 
-      const { progress = [] } = await this.updateProgress(request, state)
+      state = await this.updateProgress(request, state)
+      const { progress = [] } = state
 
       viewModel.context = context
 

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -220,7 +220,7 @@ export class RepeatPageController extends QuestionPageController {
     ) => {
       const { path } = this
 
-      const state = await super.getState(request)
+      let state = await super.getState(request)
       const list = this.getListFromState(state)
 
       if (!list.length) {
@@ -228,7 +228,8 @@ export class RepeatPageController extends QuestionPageController {
         return super.proceed(request, h, nextPath)
       }
 
-      const { progress = [] } = await this.updateProgress(request, state)
+      state = await this.updateProgress(request, state)
+      const { progress = [] } = state
 
       const viewModel = this.getListSummaryViewModel(request, list)
       viewModel.backLink = this.getBackLink(progress)
@@ -313,7 +314,7 @@ export class RepeatPageController extends QuestionPageController {
     ) => {
       const { viewModel } = this
 
-      const state = await super.getState(request)
+      let state = await super.getState(request)
       const list = this.getListFromState(state)
 
       const { item } = this.setRepeatAppData(request, list)
@@ -329,7 +330,8 @@ export class RepeatPageController extends QuestionPageController {
       const { title } = this.repeat.options
       const itemTitle = `${title} ${item.index + 1}`
 
-      const { progress = [] } = await this.updateProgress(request, state)
+      state = await this.updateProgress(request, state)
+      const { progress = [] } = state
 
       return h.view(this.listDeleteViewName, {
         ...viewModel,

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -90,7 +90,7 @@ export class SummaryPageController extends QuestionPageController {
     ) => {
       const { model, path, viewName } = this
 
-      const state = await this.getState(request)
+      let state = await this.getState(request)
       const context = model.getFormContext(request, state)
       const relevantPath = this.getRelevantPath(context)
 
@@ -107,7 +107,8 @@ export class SummaryPageController extends QuestionPageController {
 
       const viewModel = this.getSummaryViewModel(request, context)
 
-      const { progress = [] } = await this.updateProgress(request, state)
+      state = await this.updateProgress(request, state)
+      const { progress = [] } = state
 
       viewModel.backLink = this.getBackLink(progress)
 

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -107,8 +107,7 @@ export class SummaryPageController extends QuestionPageController {
 
       const viewModel = this.getSummaryViewModel(request, context)
 
-      const { progress = [] } = context.state
-      await this.updateProgress(progress, request)
+      const { progress = [] } = await this.updateProgress(request, state)
 
       viewModel.backLink = this.getBackLink(progress)
 

--- a/src/server/services/cacheService.ts
+++ b/src/server/services/cacheService.ts
@@ -35,14 +35,23 @@ export class CacheService {
     return cached || {}
   }
 
-  async mergeState(request: FormRequest | FormRequestPayload, value: object) {
+  async setState(
+    request: FormRequest | FormRequestPayload,
+    state: FormSubmissionState
+  ) {
     const key = this.Key(request)
-    const state = merge(await this.getState(request), value)
     const ttl = config.get('sessionTimeout')
 
     await this.cache.set(key, state, ttl)
-
     return this.getState(request)
+  }
+
+  async mergeState(
+    request: FormRequest | FormRequestPayload,
+    state: FormSubmissionState,
+    update: object
+  ) {
+    return this.setState(request, merge(state, update))
   }
 
   async getConfirmationState(

--- a/src/typings/hapi/index.d.ts
+++ b/src/typings/hapi/index.d.ts
@@ -7,8 +7,7 @@ import { type Logger } from 'pino'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type RepeatItemState,
-  type RepeatListState,
-  type UploadState
+  type RepeatListState
 } from '~/src/server/plugins/engine/types.js'
 import {
   type FormRequest,
@@ -41,8 +40,6 @@ declare module '@hapi/hapi' {
 
   interface RequestApplicationState {
     model?: FormModel
-    files?: UploadState
-    formAction?: string
     repeat?: {
       list: RepeatListState
       item?: {


### PR DESCRIPTION
Reduces Redis read/write calls by sharing the existing state where possible

Flagged during the ["exit page bug" #482470](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/482470) fixes