### PR TITLE
Exit pages: Avoid `returnUrl` unless continuing

### DIFF
--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -14,7 +14,7 @@ import {
 } from '~/src/server/plugins/engine/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { type FormContextRequest } from '~/src/server/plugins/engine/types.js'
-import { FormStatus } from '~/src/server/routes/types.js'
+import { FormAction, FormStatus } from '~/src/server/routes/types.js'
 import definition from '~/test/form/definitions/basic.js'
 
 describe('Helpers', () => {
@@ -79,7 +79,9 @@ describe('Helpers', () => {
 
         request: {
           method: 'post',
-          payload: {}
+          payload: {
+            action: FormAction.Continue
+          }
         } satisfies Partial<FormContextRequest>,
 
         redirect: {
@@ -121,7 +123,9 @@ describe('Helpers', () => {
 
         request: {
           method: 'post',
-          payload: {},
+          payload: {
+            action: FormAction.Continue
+          },
           query: {
             myParam1: 'myValue1',
             myParam2: 'myValue2',
@@ -164,7 +168,9 @@ describe('Helpers', () => {
 
         request: {
           method: 'post',
-          payload: {},
+          payload: {
+            action: FormAction.Continue
+          },
           query: { returnUrl: 'https://www.gov.uk/help/privacy-notice' }
         } satisfies Partial<FormContextRequest>,
 

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -106,22 +106,6 @@ describe('Helpers', () => {
         href: '/test/page-two',
 
         request: {
-          method: 'get',
-          query: {
-            myParam1: 'myValue1',
-            myParam2: 'myValue2',
-            returnUrl: '/test/summary'
-          }
-        } satisfies Partial<FormContextRequest>,
-
-        redirect: {
-          statusCode: StatusCodes.MOVED_TEMPORARILY
-        } satisfies Partial<ResponseObject>
-      },
-      {
-        href: '/test/page-two',
-
-        request: {
           method: 'post',
           payload: {
             action: FormAction.Continue
@@ -176,6 +160,25 @@ describe('Helpers', () => {
 
         redirect: {
           statusCode: StatusCodes.SEE_OTHER
+        } satisfies Partial<ResponseObject>
+      },
+      {
+        href: '/test/repeater/page-two',
+
+        request: {
+          method: 'post',
+          query: {
+            myParam1: 'myValue1',
+            myParam2: 'myValue2',
+            returnUrl: '/test/repeater/summary'
+          },
+          payload: {
+            action: FormAction.AddAnother
+          }
+        } satisfies Partial<FormContextRequest>,
+
+        redirect: {
+          statusCode: StatusCodes.MOVED_TEMPORARILY
         } satisfies Partial<ResponseObject>
       }
     ])(

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -18,9 +18,6 @@ import { FormStatus, type FormQuery } from '~/src/server/routes/types.js'
 
 const logger = createLogger()
 
-export const ADD_ANOTHER = 'add-another'
-export const CONTINUE = 'continue'
-
 export function proceed(
   request: Pick<FormContextRequest, 'method' | 'query'>,
   h: Pick<ResponseToolkit, 'redirect' | 'view'>,

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -92,6 +92,18 @@ export class FileUploadPageController extends QuestionPageController {
     this.viewName = 'file-upload'
   }
 
+  getFormData(request: FormContextRequest) {
+    const formData = super.getFormData(request)
+
+    const name = this.getComponentName()
+    const files = request.app.files ?? []
+
+    // Append the files to the payload
+    formData[name] = files.length ? files : undefined
+
+    return formData
+  }
+
   async getState(request: FormRequest | FormRequestPayload) {
     // Get the actual state
     const state = await super.getState(request)
@@ -137,18 +149,6 @@ export class FileUploadPageController extends QuestionPageController {
 
       return super.makePostRouteHandler()(request, h)
     }
-  }
-
-  validate(request: FormRequestPayload) {
-    const { payload } = request
-
-    const name = this.getComponentName()
-    const files = request.app.files ?? []
-
-    // Append the files to the payload
-    payload[name] = files.length ? files : undefined
-
-    return super.validate(request)
   }
 
   getErrors(details?: ValidationErrorItem[]) {
@@ -363,8 +363,7 @@ export class FileUploadPageController extends QuestionPageController {
     state: TempFileState,
     cacheService: CacheService
   ) {
-    const { payload } = request
-    const removeId = payload.__remove
+    const { __remove: removeId } = this.getFormData(request)
 
     if (removeId) {
       const fileToRemove = state.files.find(

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -26,6 +26,7 @@ import {
   type FormPageViewModel,
   type FormPayload,
   type FormSubmissionError,
+  type FormSubmissionPayload,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
 import {
@@ -178,7 +179,14 @@ export class QuestionPageController extends PageController {
   }
 
   /**
-   * gets the state for the values that can be entered on just this page
+   * Gets the form payload (from request) for this page only
+   */
+  getFormData(request: FormContextRequest): FormSubmissionPayload {
+    return request.payload ?? {}
+  }
+
+  /**
+   * Gets the form payload (from state) for this page only
    */
   getFormDataFromState(state: FormSubmissionState): FormPayload {
     return {
@@ -395,7 +403,10 @@ export class QuestionPageController extends PageController {
   }
 
   validate(request: FormRequestPayload) {
-    return this.collection.validate(request.payload)
+    const { collection } = this
+
+    const formData = this.getFormData(request)
+    return collection.validate(formData)
   }
 
   proceed(

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -6,7 +6,7 @@ import {
   type Page
 } from '@defra/forms-model'
 import { type ResponseToolkit, type RouteOptions } from '@hapi/hapi'
-import joi, { type ValidationErrorItem } from 'joi'
+import { type ValidationErrorItem } from 'joi'
 
 import { config } from '~/src/config/index.js'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
@@ -35,6 +35,7 @@ import {
   type FormRequestPayloadRefs,
   type FormRequestRefs
 } from '~/src/server/routes/types.js'
+import { actionSchema, crumbSchema } from '~/src/server/schemas/index.js'
 
 export class QuestionPageController extends PageController {
   collection: ComponentCollection
@@ -50,7 +51,8 @@ export class QuestionPageController extends PageController {
     )
 
     this.collection.formSchema = this.collection.formSchema.keys({
-      crumb: joi.string().optional().allow('')
+      crumb: crumbSchema,
+      action: actionSchema
     })
   }
 

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -5,7 +5,6 @@ import { badRequest, notFound } from '@hapi/boom'
 import { type ResponseToolkit } from '@hapi/hapi'
 import Joi from 'joi'
 
-import { ADD_ANOTHER, CONTINUE } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
@@ -20,6 +19,7 @@ import {
   type SummaryListAction
 } from '~/src/server/plugins/engine/types.js'
 import {
+  FormAction,
   type FormRequest,
   type FormRequestPayload
 } from '~/src/server/routes/types.js'
@@ -224,7 +224,7 @@ export class RepeatPageController extends QuestionPageController {
 
       const { action } = this.getFormData(request)
 
-      if (action === ADD_ANOTHER) {
+      if (action === FormAction.AddAnother) {
         const list = this.getListFromState(state)
         const { schema, options } = repeat
 
@@ -245,7 +245,7 @@ export class RepeatPageController extends QuestionPageController {
         }
 
         return super.proceed(request, h, `${path}${request.url.search}`)
-      } else if (action === CONTINUE) {
+      } else if (action === FormAction.Continue) {
         return super.proceed(
           request,
           h,

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -54,13 +54,13 @@ export class RepeatPageController extends QuestionPageController {
     return [this.repeat.options.name]
   }
 
-  validate(request: FormRequestPayload) {
-    const { payload } = request
+  getFormData(request: FormContextRequest) {
+    const formData = super.getFormData(request)
 
     // Apply an itemId to the form payload
-    payload.itemId = request.params.itemId ?? randomUUID()
+    formData.itemId = request.params.itemId ?? randomUUID()
 
-    return super.validate(request)
+    return formData
   }
 
   getStateFromValidForm(
@@ -219,10 +219,10 @@ export class RepeatPageController extends QuestionPageController {
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { model, path, repeat } = this
-      const { payload } = request
-      const { action } = payload
 
       const state = await super.getState(request)
+
+      const { action } = this.getFormData(request)
 
       if (action === ADD_ANOTHER) {
         const list = this.getListFromState(state)
@@ -303,8 +303,8 @@ export class RepeatPageController extends QuestionPageController {
       request: FormRequestPayload,
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
-      const { payload } = request
-      const { confirm } = payload
+      const { repeat } = this
+      const { confirm } = this.getFormData(request)
 
       if (confirm === true) {
         const { item, list } = await this.setRepeatAppData(request)
@@ -316,7 +316,7 @@ export class RepeatPageController extends QuestionPageController {
           list.splice(item.index, 1)
 
           const update = {
-            [this.repeat.options.name]: list
+            [repeat.options.name]: list
           }
 
           await cacheService.mergeState(request, update)

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -268,7 +268,14 @@ export const plugin = {
             slug: slugSchema,
             path: pathSchema,
             itemId: itemIdSchema.optional()
-          })
+          }),
+          payload: Joi.object()
+            .keys({
+              crumb: crumbSchema,
+              action: actionSchema
+            })
+            .unknown(true)
+            .required()
         }
       }
     })
@@ -285,7 +292,14 @@ export const plugin = {
             slug: slugSchema,
             path: pathSchema,
             itemId: itemIdSchema.optional()
-          })
+          }),
+          payload: Joi.object()
+            .keys({
+              crumb: crumbSchema,
+              action: actionSchema
+            })
+            .unknown(true)
+            .required()
         }
       }
     })
@@ -476,6 +490,7 @@ export const plugin = {
           payload: Joi.object()
             .keys({
               crumb: crumbSchema,
+              action: actionSchema,
               confirm: confirmSchema
             })
             .required()
@@ -499,6 +514,7 @@ export const plugin = {
           payload: Joi.object()
             .keys({
               crumb: crumbSchema,
+              action: actionSchema,
               confirm: confirmSchema
             })
             .required()

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -10,8 +10,6 @@ import Joi from 'joi'
 
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
 import {
-  ADD_ANOTHER,
-  CONTINUE,
   checkEmailAddressForLiveFormSubmission,
   checkFormStatus,
   getPage,
@@ -25,8 +23,9 @@ import {
   getFormDefinition,
   getFormMetadata
 } from '~/src/server/plugins/engine/services/formsService.js'
-import { FormStatus } from '~/src/server/routes/types.js'
 import {
+  FormAction,
+  FormStatus,
   type FormRequest,
   type FormRequestPayload,
   type FormRequestPayloadRefs,
@@ -40,10 +39,20 @@ export interface PluginOptions {
 const stateSchema = Joi.string()
   .valid(FormStatus.Draft, FormStatus.Live)
   .required()
+
+const actionSchema = Joi.string()
+  .valid(
+    FormAction.Continue,
+    FormAction.Delete,
+    FormAction.AddAnother,
+    FormAction.Send
+  )
+  .default(FormAction.Continue)
+  .optional()
+
 const pathSchema = Joi.string().required()
 const itemIdSchema = Joi.string().uuid().required()
 const crumbSchema = Joi.string().optional().allow('')
-const actionSchema = Joi.string().valid(ADD_ANOTHER, CONTINUE).required()
 const confirmSchema = Joi.boolean().default(false)
 
 export const plugin = {

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -24,36 +24,23 @@ import {
   getFormMetadata
 } from '~/src/server/plugins/engine/services/formsService.js'
 import {
-  FormAction,
-  FormStatus,
   type FormRequest,
   type FormRequestPayload,
   type FormRequestPayloadRefs,
   type FormRequestRefs
 } from '~/src/server/routes/types.js'
+import {
+  actionSchema,
+  confirmSchema,
+  crumbSchema,
+  itemIdSchema,
+  pathSchema,
+  stateSchema
+} from '~/src/server/schemas/index.js'
 
 export interface PluginOptions {
   model?: FormModel
 }
-
-const stateSchema = Joi.string()
-  .valid(FormStatus.Draft, FormStatus.Live)
-  .required()
-
-const actionSchema = Joi.string()
-  .valid(
-    FormAction.Continue,
-    FormAction.Delete,
-    FormAction.AddAnother,
-    FormAction.Send
-  )
-  .default(FormAction.Continue)
-  .optional()
-
-const pathSchema = Joi.string().required()
-const itemIdSchema = Joi.string().uuid().required()
-const crumbSchema = Joi.string().optional().allow('')
-const confirmSchema = Joi.boolean().default(false)
 
 export const plugin = {
   name: '@defra/forms-runner/engine',
@@ -236,7 +223,7 @@ export const plugin = {
           params: Joi.object().keys({
             slug: slugSchema,
             path: pathSchema,
-            itemId: Joi.string().uuid()
+            itemId: itemIdSchema.optional()
           })
         }
       }
@@ -253,7 +240,7 @@ export const plugin = {
             state: stateSchema,
             slug: slugSchema,
             path: pathSchema,
-            itemId: Joi.string().uuid()
+            itemId: itemIdSchema.optional()
           })
         }
       }
@@ -280,7 +267,7 @@ export const plugin = {
           params: Joi.object().keys({
             slug: slugSchema,
             path: pathSchema,
-            itemId: Joi.string().uuid()
+            itemId: itemIdSchema.optional()
           })
         }
       }
@@ -297,7 +284,7 @@ export const plugin = {
             state: stateSchema,
             slug: slugSchema,
             path: pathSchema,
-            itemId: Joi.string().uuid()
+            itemId: itemIdSchema.optional()
           })
         }
       }

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -8,7 +8,7 @@ import {
 } from '~/src/server/plugins/engine/components/types.js'
 import { type PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
-import { type FormRequest } from '~/src/server/routes/types.js'
+import { type FormAction, type FormRequest } from '~/src/server/routes/types.js'
 
 /**
  * Form submission state stores the following in Redis:
@@ -76,7 +76,7 @@ export interface FormSubmissionError
  * (after Joi has converted value types)
  */
 export type FormSubmissionPayload = {
-  action?: string
+  action?: FormAction
   confirm?: boolean
   crumb?: string
 } & FormPayload

--- a/src/server/plugins/engine/views/file-upload.html
+++ b/src/server/plugins/engine/views/file-upload.html
@@ -12,7 +12,11 @@
     {{ govukFileUpload(model) }}
 
     {% if formAction %}
-      {{ govukButton({ text: "Upload file", classes: "govuk-button--secondary", preventDoubleClick: true }) }}
+      {{ govukButton({
+        text: "Upload file",
+        classes: "govuk-button--secondary",
+        preventDoubleClick: true
+      }) }}
     {% else %}
       {{ govukWarningText({
         text: "You have reached the maximum number of files. Please remove a file to upload more.",

--- a/src/server/plugins/engine/views/partials/form.html
+++ b/src/server/plugins/engine/views/partials/form.html
@@ -4,11 +4,12 @@
 <form method="post" novalidate>
   <input type="hidden" name="crumb" value="{{ crumb }}">
   <input type="hidden" name="action" value="continue">
+
   {{ componentList(components) }}
 
-  {% if isStartPage %}
-    {{ govukButton({ attributes: { id: "submit" }, text: "Start now", isStartButton: true }) }}
-  {% else %}
-    {{ govukButton({ attributes: { id: "submit" }, text: "Continue" }) }}
-  {% endif %}
+  {{ govukButton({
+    text: "Start now" if isStartPage else "Continue",
+    isStartButton: isStartPage,
+    preventDoubleClick: true
+  }) }}
 </form>

--- a/src/server/plugins/engine/views/partials/form.html
+++ b/src/server/plugins/engine/views/partials/form.html
@@ -2,7 +2,8 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
 
 <form method="post" novalidate>
-  <input type="hidden" name="crumb" value="{{crumb}}">
+  <input type="hidden" name="crumb" value="{{ crumb }}">
+  <input type="hidden" name="action" value="continue">
   {{ componentList(components) }}
 
   {% if isStartPage %}

--- a/src/server/plugins/engine/views/repeat-item-delete.html
+++ b/src/server/plugins/engine/views/repeat-item-delete.html
@@ -21,7 +21,8 @@
       {% include "partials/heading.html" %}
 
       <form method="post" novalidate>
-        <input type="hidden" name="crumb" value="{{crumb}}">
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+        <input type="hidden" name="action" value="delete">
         {{ govukRadios(field) }}
         {{ govukButton({ attributes: { id: "submit", type: "submit" }, text: "Continue" }) }}
       </form>

--- a/src/server/plugins/engine/views/repeat-item-delete.html
+++ b/src/server/plugins/engine/views/repeat-item-delete.html
@@ -23,8 +23,13 @@
       <form method="post" novalidate>
         <input type="hidden" name="crumb" value="{{ crumb }}">
         <input type="hidden" name="action" value="delete">
+
         {{ govukRadios(field) }}
-        {{ govukButton({ attributes: { id: "submit", type: "submit" }, text: "Continue" }) }}
+
+        {{ govukButton({
+          text: "Continue",
+          preventDoubleClick: true
+        }) }}
       </form>
     </div>
   </div>

--- a/src/server/plugins/engine/views/repeat-list-summary.html
+++ b/src/server/plugins/engine/views/repeat-list-summary.html
@@ -26,9 +26,22 @@
 
       <div class="govuk-button-group">
         <form method="post" novalidate>
-          <input type="hidden" name="crumb" value="{{crumb}}">
-          {{ govukButton({ attributes: { id: "submit", type: "submit" }, text: "Continue", name: "action", value: "continue" }) }}
-          {{ govukButton({ attributes: { id: "add-another", type: "submit" }, text: "Add another " + repeatTitle, classes: "govuk-button--secondary", name: "action", value: "add-another" }) }}
+          <input type="hidden" name="crumb" value="{{ crumb }}">
+
+          {{ govukButton({
+            text: "Continue",
+            name: "action",
+            value: "continue",
+            preventDoubleClick: true
+          }) }}
+
+          {{ govukButton({
+            text: "Add another " + repeatTitle,
+            name: "action",
+            value: "add-another",
+            classes: "govuk-button--secondary",
+            preventDoubleClick: true
+          }) }}
         </form>
       </div>
 

--- a/src/server/routes/types.ts
+++ b/src/server/routes/types.ts
@@ -26,6 +26,13 @@ export interface FormRequestPayloadRefs extends FormRequestRefs {
 export type FormRequest = Request<FormRequestRefs>
 export type FormRequestPayload = Request<FormRequestPayloadRefs>
 
+export enum FormAction {
+  Continue = 'continue',
+  Delete = 'delete',
+  AddAnother = 'add-another',
+  Send = 'send'
+}
+
 export enum FormStatus {
   Draft = 'draft',
   Live = 'live'

--- a/src/server/schemas/index.ts
+++ b/src/server/schemas/index.ts
@@ -1,0 +1,22 @@
+import Joi from 'joi'
+
+import { FormAction, FormStatus } from '~/src/server/routes/types.js'
+
+export const stateSchema = Joi.string()
+  .valid(FormStatus.Draft, FormStatus.Live)
+  .required()
+
+export const actionSchema = Joi.string()
+  .valid(
+    FormAction.Continue,
+    FormAction.Delete,
+    FormAction.AddAnother,
+    FormAction.Send
+  )
+  .default(FormAction.Continue)
+  .optional()
+
+export const pathSchema = Joi.string().required()
+export const itemIdSchema = Joi.string().uuid().required()
+export const crumbSchema = Joi.string().optional().allow('')
+export const confirmSchema = Joi.boolean().default(false)

--- a/src/server/views/summary.html
+++ b/src/server/views/summary.html
@@ -29,7 +29,8 @@
       {% endfor %}
 
       <form method="post" autocomplete="off" novalidate>
-        <input type="hidden" name="crumb" value="{{crumb}}">
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+        <input type="hidden" name="action" value="send">
 
         {% if declaration %}
           <h2 class="govuk-heading-m" id="declaration">Declaration</h2>

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -15,6 +15,7 @@ import {
   initiateUpload
 } from '~/src/server/plugins/engine/services/uploadService.js'
 import { FileStatus, UploadStatus } from '~/src/server/plugins/engine/types.js'
+import { FormAction } from '~/src/server/routes/types.js'
 import { sendNotification } from '~/src/server/utils/notify.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
@@ -416,7 +417,9 @@ describe('Submission journey test', () => {
       url: `${basePath}/summary`,
       method: 'POST',
       headers,
-      payload: {}
+      payload: {
+        action: FormAction.Send
+      }
     })
 
     expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -7,6 +7,7 @@ import { StatusCodes } from 'http-status-codes'
 import { createServer } from '~/src/server/index.js'
 import { submit } from '~/src/server/plugins/engine/services/formSubmissionService.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
+import { FormAction } from '~/src/server/routes/types.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
@@ -380,7 +381,10 @@ describe('Form journey', () => {
         url: `${basePath}/summary`,
         method: 'POST',
         headers,
-        payload: { crumb: csrfToken }
+        payload: {
+          crumb: csrfToken,
+          action: FormAction.Send
+        }
       })
 
       expect(submit).toHaveBeenCalledWith({

--- a/test/form/persist-files.test.js
+++ b/test/form/persist-files.test.js
@@ -11,6 +11,7 @@ import {
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as uploadService from '~/src/server/plugins/engine/services/uploadService.js'
 import { FileStatus, UploadStatus } from '~/src/server/plugins/engine/types.js'
+import { FormAction } from '~/src/server/routes/types.js'
 import { CacheService } from '~/src/server/services/cacheService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
@@ -144,15 +145,14 @@ describe('Submission journey test', () => {
       }
     })
 
-    const form = {
-      crumb: 'dummyCrumb'
-    }
-
     // POST the form data to set the state
     const res = await server.inject({
       url: `${basePath}/file-upload-component`,
       method: 'POST',
-      payload: form
+      payload: {
+        crumb: 'dummyCrumb',
+        action: FormAction.Continue
+      }
     })
 
     expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
@@ -174,7 +174,7 @@ describe('Submission journey test', () => {
       url: `${basePath}/summary`,
       method: 'POST',
       headers,
-      payload: { form }
+      payload: {}
     })
 
     expect(persistFiles).toHaveBeenCalledTimes(1)

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -7,9 +7,9 @@ import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/server/index.js'
-import { ADD_ANOTHER, CONTINUE } from '~/src/server/plugins/engine/helpers.js'
 import { submit } from '~/src/server/plugins/engine/services/formSubmissionService.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
+import { FormAction } from '~/src/server/routes/types.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
@@ -316,7 +316,7 @@ describe('Repeat POST tests', () => {
       method: 'POST',
       url: `${basePath}/pizza-order/summary`,
       payload: {
-        action: ADD_ANOTHER
+        action: FormAction.AddAnother
       }
     })
 
@@ -332,7 +332,7 @@ describe('Repeat POST tests', () => {
       method: 'POST',
       headers,
       payload: {
-        action: CONTINUE
+        action: FormAction.Continue
       }
     })
 
@@ -350,7 +350,7 @@ describe('Repeat POST tests', () => {
       method: 'POST',
       headers,
       payload: {
-        action: ADD_ANOTHER
+        action: FormAction.AddAnother
       }
     })
 
@@ -376,7 +376,7 @@ describe('Repeat POST tests', () => {
       method: 'POST',
       headers,
       payload: {
-        action: CONTINUE
+        action: FormAction.Continue
       }
     })
 
@@ -409,7 +409,7 @@ describe('Repeat POST tests', () => {
       method: 'POST',
       headers,
       payload: {
-        action: CONTINUE
+        action: FormAction.Continue
       }
     })
 

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -435,7 +435,10 @@ describe('Repeat POST tests', () => {
     await server.inject({
       method: 'POST',
       url: `${basePath}/summary`,
-      headers
+      headers,
+      payload: {
+        action: FormAction.Send
+      }
     })
 
     expect(submit).toHaveBeenCalledWith({

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -385,10 +385,7 @@ describe('Repeat POST tests', () => {
 
     const { container, response } = await renderResponse(server, {
       url: `${basePath}/summary`,
-      headers,
-      payload: {
-        action: CONTINUE
-      }
+      headers
     })
 
     expect(response.statusCode).toBe(StatusCodes.OK)
@@ -421,10 +418,7 @@ describe('Repeat POST tests', () => {
 
     const { container, response: res2 } = await renderResponse(server, {
       url: `${basePath}/summary`,
-      headers,
-      payload: {
-        action: CONTINUE
-      }
+      headers
     })
 
     expect(res2.statusCode).toBe(StatusCodes.OK)


### PR DESCRIPTION
This PR suppresses the `returnUrl` query string for "Add another" and "Delete" actions

Fixes a bug in [#482470](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/482470) where changing a repeater answer would see the next "Add another" button press be redirected to the summary page

i.e. Only the "Continue" action is allowed to redirect back to the summary page