### PR TITLE
Add repeater state helpers

### DIFF
--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -8,7 +8,9 @@ import {
   type FormStateValue,
   type FormSubmissionError,
   type FormSubmissionState,
-  type FormValue
+  type FormValue,
+  type RepeatItemState,
+  type RepeatListState
 } from '~/src/server/plugins/engine/types.js'
 
 export class FormComponent extends ComponentBase {
@@ -197,4 +199,27 @@ export function isFormState(value?: unknown): value is FormState {
 
   // Skip empty objects
   return !!Object.values(value).length
+}
+
+/**
+ * Check for repeat list state
+ */
+export function isRepeatState(value?: unknown): value is RepeatListState {
+  if (!Array.isArray(value)) {
+    return false
+  }
+
+  // Skip checks when empty
+  if (!value.length) {
+    return true
+  }
+
+  return value.every(isRepeatValue)
+}
+
+/**
+ * Check for repeat list value
+ */
+export function isRepeatValue(value?: unknown): value is RepeatItemState {
+  return isFormState(value) && typeof value.itemId === 'string'
 }

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -133,26 +133,26 @@ export class RepeatPageController extends QuestionPageController {
    * @param request - the hapi request
    */
   private async setRepeatAppData(request: FormRequest | FormRequestPayload) {
-    const list = await this.getList(request)
-    const { itemId } = request.params
-    const itemIndex = list.findIndex((item) => item.itemId === itemId)
+    const { app, params } = request
+    const { itemId } = params
 
-    request.app.repeat = {
-      list,
-      item:
-        itemIndex > -1
-          ? { value: list[itemIndex], index: itemIndex }
-          : undefined
-    }
-
-    return request.app.repeat
-  }
-
-  private async getList(request: FormRequest | FormRequestPayload) {
     const { cacheService } = request.services([])
     const state = await cacheService.getState(request)
 
-    return this.getListFromState(state)
+    const list = this.getListFromState(state)
+    const value = this.getItemFromList(list, itemId)
+    const index = value ? list.indexOf(value) : -1
+
+    app.repeat = {
+      list,
+      item: value ? { value, index } : undefined
+    }
+
+    return app.repeat
+  }
+
+  getItemFromList(list: RepeatListState, itemId?: string) {
+    return list.find((item) => item.itemId === itemId)
   }
 
   getListFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -89,7 +89,7 @@ export type FormValue =
   | Item['value']
   | Item['value'][]
   | FileState[]
-  | RepeatState[]
+  | RepeatListState
   | undefined
 
 export type FormState = Partial<Record<string, FormStateValue>>
@@ -225,9 +225,11 @@ export interface TempFileState {
   files: FileState[]
 }
 
-export interface RepeatState extends FormPayload {
+export interface RepeatItemState extends FormPayload {
   itemId: string
 }
+
+export type RepeatListState = RepeatItemState[]
 
 export interface CheckAnswers {
   title?: ComponentText

--- a/src/typings/hapi/index.d.ts
+++ b/src/typings/hapi/index.d.ts
@@ -7,7 +7,8 @@ import { type Logger } from 'pino'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FileState,
-  type RepeatState
+  type RepeatItemState,
+  type RepeatListState
 } from '~/src/server/plugins/engine/types.js'
 import { type CacheService } from '~/src/server/services/index.js'
 
@@ -30,9 +31,9 @@ declare module '@hapi/hapi' {
     files?: FileState[]
     formAction?: string
     repeat?: {
-      list: RepeatState[]
+      list: RepeatListState
       item?: {
-        value: RepeatState
+        value: RepeatItemState
         index: number
       }
     }

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -7,6 +7,7 @@ import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/server/index.js'
+import { isRepeatState } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { submit } from '~/src/server/plugins/engine/services/formSubmissionService.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import { FormAction } from '~/src/server/routes/types.js'
@@ -57,21 +58,18 @@ async function createRepeatItem(
     `${basePath}/pizza-order/summary?itemId=${itemId}`
   )
 
-  const repeatName = repeatPage.repeat.options.name
-
   // Extract the session cookie
   const request = res1.request
   const { cacheService } = request.services([])
-  const state = await cacheService.getState(request)
-  const listState = state[repeatName]
 
-  if (!Array.isArray(listState) || listState.length !== expectedItemCount) {
+  const { name } = repeatPage.repeat.options
+  const state = await cacheService.getState(request)
+
+  if (!isRepeatState(state[name]) || state[name].length !== expectedItemCount) {
     throw new Error('Unexpected list state')
   }
 
-  const item = listState
-    .filter((value) => typeof value === 'object' && 'itemId' in value)
-    .at(-1)
+  const item = state[name].at(-1)
 
   if (!item) {
     throw new Error('No item state found')


### PR DESCRIPTION
This PR adds new helpers for repeater state to complement our existing ones:

* ✅ `isFormValue()`
* ✅ `isFormState()`
* ❌ `isRepeatValue()`
* ❌ `isRepeatState()`

I've split these out so I can use them in form context