### PR TITLE
Exit pages: Return to summary after relevant page redirect

### DIFF
--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -28,6 +28,7 @@ export function proceed(
   nextUrl: string
 ) {
   const { method, payload, query } = request
+  const { returnUrl } = query
 
   const isReturnAllowed =
     payload && 'action' in payload
@@ -36,9 +37,9 @@ export function proceed(
 
   // Redirect to return location (optional)
   const response =
-    isReturnAllowed && query.returnUrl?.startsWith('/')
-      ? h.redirect(query.returnUrl)
-      : h.redirect(nextUrl)
+    isReturnAllowed && returnUrl?.startsWith('/')
+      ? h.redirect(returnUrl)
+      : h.redirect(redirectPath(nextUrl, { returnUrl }))
 
   // Redirect POST to GET to avoid resubmission
   return method === 'post'

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -61,7 +61,7 @@ export function encodeUrl(link?: string) {
 }
 
 /**
- * Redirect to page
+ * Get page href
  */
 export function getPageHref(
   page: PageControllerClass,
@@ -69,7 +69,7 @@ export function getPageHref(
 ): string
 
 /**
- * Redirect to page by path
+ * Get page href by path
  */
 export function getPageHref(
   page: PageControllerClass,
@@ -86,24 +86,39 @@ export function getPageHref(
   const query = typeof pathOrQuery === 'object' ? pathOrQuery : queryOnly
 
   if (!path.startsWith('/')) {
-    throw Error('Only relative URLs are allowed')
+    throw Error(`Only relative URLs are allowed: ${path}`)
   }
+
+  // Return path with page href as base
+  return redirectPath(page.getHref(path), query)
+}
+
+/**
+ * Get redirect path with optional query params
+ */
+export function redirectPath(nextUrl: string, query: FormQuery = {}) {
+  const isRelativePath = nextUrl.startsWith('/')
 
   // Filter string query params only
   const params = Object.entries(query).filter(
     (query): query is [string, string] => typeof query[1] === 'string'
   )
 
-  // Build URL using page href as base
-  const href = page.getHref(path)
-  const url = new URL(href, 'http://example.com')
+  // Build URL with relative path support
+  const url = isRelativePath
+    ? new URL(nextUrl, 'http://example.com')
+    : new URL(nextUrl)
 
   // Append query params
   for (const [name, value] of params) {
     url.searchParams.set(name, value)
   }
 
-  return `${url.pathname}${url.search}`
+  if (isRelativePath) {
+    return `${url.pathname}${url.search}`
+  }
+
+  return url.href
 }
 
 export function normalisePath(path = '') {

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -15,7 +15,9 @@ import {
 } from '~/src/server/plugins/engine/components/helpers.js'
 import {
   checkEmailAddressForLiveFormSubmission,
-  checkFormStatus
+  checkFormStatus,
+  findPage,
+  getPageHref
 } from '~/src/server/plugins/engine/helpers.js'
 import {
   SummaryViewModel,
@@ -90,10 +92,17 @@ export class SummaryPageController extends QuestionPageController {
 
       const state = await this.getState(request)
       const context = model.getFormContext(request, state)
+      const relevantPath = this.getRelevantPath(context)
 
       // Redirect back to last relevant page
-      if (!context.paths.includes(path)) {
-        return this.proceed(request, h, this.getRelevantPath(context))
+      if (relevantPath !== path) {
+        const redirectTo = findPage(model, relevantPath)
+
+        if (redirectTo?.next.length) {
+          request.query.returnUrl = getPageHref(this, this.getSummaryPath())
+        }
+
+        return this.proceed(request, h, relevantPath)
       }
 
       const viewModel = this.getSummaryViewModel(request, context)

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -435,7 +435,9 @@ describe('Form journey', () => {
 
       // Redirect back to start
       expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-      expect(response.headers.location).toBe(`${basePath}/licence`)
+      expect(response.headers.location).toBe(
+        `${basePath}/licence?returnUrl=%2Fbasic%2Fsummary`
+      )
     })
   })
 })


### PR DESCRIPTION
This PR ensures "Change answer" redirects always come back to the summary page

Even when a changed answer adds many new pages to the journey to complete first

Part of the ["exit page bug" #482470](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/482470) fixes