### PR TITLE
Add crumb globally

### DIFF
--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -248,11 +248,7 @@ export const plugin = {
 
     const postRouteOptions: RouteOptions<FormRequestPayloadRefs> = {
       payload: {
-        parse: true,
-        failAction: (request, h) => {
-          request.server.plugins.crumb.generate?.(request, h)
-          return h.continue
-        }
+        parse: true
       },
       pre: [{ method: loadFormPreHandler }]
     }

--- a/src/server/plugins/nunjucks/context.js
+++ b/src/server/plugins/nunjucks/context.js
@@ -30,16 +30,14 @@ export function context(request) {
 
   const { params, path, state } = request ?? {}
 
-  let crumb
+  /** @type {CookieConsent | undefined} */
   let cookieConsent
 
   if (typeof state?.cookieConsent === 'string') {
     cookieConsent = parseCookieConsent(state.cookieConsent)
   }
 
-  if (request) {
-    crumb = request.server.plugins.crumb.generate?.(request)
-  }
+  const crumb = request?.server.plugins.crumb.generate?.(request)
 
   const isPreviewMode = path?.startsWith(PREVIEW_PATH_PREFIX)
 
@@ -67,5 +65,6 @@ export function context(request) {
 }
 
 /**
+ * @import { CookieConsent } from '~/src/common/types.js'
  * @import { FormRequest, FormRequestPayload } from '~/src/server/routes/types.js'
  */

--- a/src/server/plugins/nunjucks/context.js
+++ b/src/server/plugins/nunjucks/context.js
@@ -30,10 +30,15 @@ export function context(request) {
 
   const { params, path, state } = request ?? {}
 
+  let crumb
   let cookieConsent
 
   if (typeof state?.cookieConsent === 'string') {
     cookieConsent = parseCookieConsent(state.cookieConsent)
+  }
+
+  if (request) {
+    crumb = request.server.plugins.crumb.generate?.(request)
   }
 
   const isPreviewMode = path?.startsWith(PREVIEW_PATH_PREFIX)
@@ -50,6 +55,7 @@ export function context(request) {
     serviceVersion: config.get('serviceVersion'),
     slug: params?.slug,
     cookieConsent,
+    crumb,
     googleAnalyticsTrackingId: config.get('googleAnalyticsTrackingId'),
     cspNonce: request?.plugins.blankie?.nonces?.script,
     currentPath: request ? `${request.path}${request.url.search}` : undefined,

--- a/src/server/views/help/cookie-preferences.html
+++ b/src/server/views/help/cookie-preferences.html
@@ -25,6 +25,8 @@
       <h2 class="govuk-heading-l">Change your cookie settings</h2>
 
       <form action="/help/cookie-preferences" method="post" novalidate>
+        <input type="hidden" name="crumb" value="{{ crumb }}">
+
         {{ govukRadios({
           name: "cookies[analytics]",
           fieldset: {

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -47,6 +47,8 @@
 {% block header %}
   {% if googleAnalyticsTrackingId %}
     <form method="post" action="/help/cookie-preferences?returnUrl={{ currentPath | urlencode }}">
+      <input type="hidden" name="crumb" value="{{ crumb }}">
+
     {% set acceptHtml %}
       <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="/help/cookies">change your cookie settings</a> at any time.</p>
     {% endset %}

--- a/src/typings/hapi/index.d.ts
+++ b/src/typings/hapi/index.d.ts
@@ -10,6 +10,10 @@ import {
   type RepeatItemState,
   type RepeatListState
 } from '~/src/server/plugins/engine/types.js'
+import {
+  type FormRequest,
+  type FormRequestPayload
+} from '~/src/server/routes/types.js'
 import { type CacheService } from '~/src/server/services/index.js'
 
 declare module '@hapi/hapi' {
@@ -17,7 +21,7 @@ declare module '@hapi/hapi' {
   // props from plugins which doesn't export @types
   interface PluginProperties {
     crumb: {
-      generate?: (request: Request) => void
+      generate?: (request: Request | FormRequest | FormRequestPayload) => void
     }
   }
 

--- a/src/typings/hapi/index.d.ts
+++ b/src/typings/hapi/index.d.ts
@@ -17,7 +17,7 @@ declare module '@hapi/hapi' {
   // props from plugins which doesn't export @types
   interface PluginProperties {
     crumb: {
-      generate?: (request: Request, h: ResponseToolkit) => void
+      generate?: (request: Request) => void
     }
   }
 


### PR DESCRIPTION
Supports the recent GA changes https://github.com/DEFRA/forms-runner/pull/571 by allowing `crumb` to be accessed on all pages. Previously, only form engine pages generated crumb and so the cookie preferences form would fail in a live environment if submitted from a non-form page.