### PR TITLE
Exit pages: Repeater + state adjustments

### DIFF
--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -73,6 +73,33 @@ export class RepeatPageController extends QuestionPageController {
     return params
   }
 
+  getFormDataFromState(
+    request: FormContextRequest | undefined,
+    state: FormSubmissionState
+  ) {
+    const { repeat } = this
+
+    const params = this.getFormParams(request)
+    const list = this.getListFromState(state)
+    const itemId = this.getItemId(request)
+
+    // Create payload with repeater list state
+    if (!itemId) {
+      return {
+        ...params,
+        [repeat.options.name]: list
+      }
+    }
+
+    // Create payload with repeater item state
+    const item = this.getItemFromList(list, itemId)
+
+    return {
+      ...params,
+      ...item
+    }
+  }
+
   getStateFromValidForm(
     request: FormContextRequest,
     state: FormSubmissionState,
@@ -84,9 +111,10 @@ export class RepeatPageController extends QuestionPageController {
       throw badRequest('No item ID found')
     }
 
-    const { item, list } = this.getRepeatAppData(request)
-    const itemState = super.getStateFromValidForm(request, state, payload)
+    const list = this.getListFromState(state)
+    const item = this.getItemFromList(list, itemId)
 
+    const itemState = super.getStateFromValidForm(request, state, payload)
     const updated: RepeatItemState = { ...itemState, itemId }
     const newList = [...list]
 
@@ -95,25 +123,12 @@ export class RepeatPageController extends QuestionPageController {
       newList.push(updated)
     } else {
       // Update an existing item
-      newList[item.index] = updated
+      newList[list.indexOf(item)] = updated
     }
 
     return {
       [this.repeat.options.name]: newList
     }
-  }
-
-  async getState(request: FormRequest | FormRequestPayload) {
-    const state = await super.getState(request)
-    const { item } = this.getRepeatAppData(request)
-
-    // When editing an existing item, get the item from
-    // the array list and set its values onto the state
-    if (item) {
-      return { ...state, ...item.value }
-    }
-
-    return state
   }
 
   proceed(
@@ -122,44 +137,6 @@ export class RepeatPageController extends QuestionPageController {
   ) {
     const nextPath = this.getSummaryPath(request)
     return super.proceed(request, h, nextPath)
-  }
-
-  /**
-   * Gets the repeat data from `request.app`
-   * @param request - the hapi request
-   */
-  private getRepeatAppData(request: FormContextRequest) {
-    const repeat = request.app.repeat
-
-    if (!repeat) {
-      throw badRequest('No repeat data found on the request')
-    }
-
-    return repeat
-  }
-
-  /**
-   * Get the repeat list array from state and add it to `request.app`.
-   * If editing an existing item, the item and index will also be added.
-   * @param request - the hapi request
-   * @param list - the repeat list state
-   */
-  private setRepeatAppData(
-    request: FormRequest | FormRequestPayload,
-    list: RepeatListState
-  ) {
-    const { app } = request
-
-    const itemId = this.getItemId(request)
-    const value = this.getItemFromList(list, itemId)
-    const index = value ? list.indexOf(value) : -1
-
-    app.repeat = {
-      list,
-      item: value ? { value, index } : undefined
-    }
-
-    return app.repeat
   }
 
   getItemFromList(list: RepeatListState, itemId?: string) {
@@ -182,7 +159,7 @@ export class RepeatPageController extends QuestionPageController {
 
       const itemId = this.getItemId(request)
 
-      const state = await super.getState(request)
+      const state = await this.getState(request)
       const list = this.getListFromState(state)
 
       if (!itemId) {
@@ -193,23 +170,7 @@ export class RepeatPageController extends QuestionPageController {
         return super.proceed(request, h, list.length ? summaryPath : nextPath)
       }
 
-      this.setRepeatAppData(request, list)
-
       return super.makeGetRouteHandler()(request, h)
-    }
-  }
-
-  makePostRouteHandler() {
-    return async (
-      request: FormRequestPayload,
-      h: Pick<ResponseToolkit, 'redirect' | 'view'>
-    ) => {
-      const state = await super.getState(request)
-      const list = this.getListFromState(state)
-
-      this.setRepeatAppData(request, list)
-
-      return super.makePostRouteHandler()(request, h)
     }
   }
 
@@ -220,7 +181,7 @@ export class RepeatPageController extends QuestionPageController {
     ) => {
       const { path } = this
 
-      const state = await super.getState(request)
+      const state = await this.getState(request)
       const list = this.getListFromState(state)
 
       if (!list.length) {
@@ -245,7 +206,7 @@ export class RepeatPageController extends QuestionPageController {
       const { model, path, repeat } = this
       const { schema, options } = repeat
 
-      const state = await super.getState(request)
+      const state = await this.getState(request)
       const list = this.getListFromState(state)
 
       if (!list.length) {
@@ -313,10 +274,11 @@ export class RepeatPageController extends QuestionPageController {
     ) => {
       const { viewModel } = this
 
-      const state = await super.getState(request)
+      const state = await this.getState(request)
       const list = this.getListFromState(state)
 
-      const { item } = this.setRepeatAppData(request, list)
+      const itemId = this.getItemId(request)
+      const item = this.getItemFromList(list, itemId)
 
       if (!item || list.length === 1) {
         return notFound(
@@ -327,7 +289,7 @@ export class RepeatPageController extends QuestionPageController {
       }
 
       const { title } = this.repeat.options
-      const itemTitle = `${title} ${item.index + 1}`
+      const itemTitle = `${title} ${list.indexOf(item) + 1}`
 
       const { progress = [] } = await this.updateProgress(request, state)
 
@@ -370,10 +332,11 @@ export class RepeatPageController extends QuestionPageController {
       const { repeat } = this
       const { confirm } = this.getFormParams(request)
 
-      const state = await super.getState(request)
+      const state = await this.getState(request)
       const list = this.getListFromState(state)
 
-      const { item } = this.setRepeatAppData(request, list)
+      const itemId = this.getItemId(request)
+      const item = this.getItemFromList(list, itemId)
 
       if (!item || list.length === 1) {
         return notFound(
@@ -385,7 +348,7 @@ export class RepeatPageController extends QuestionPageController {
 
       // Remove the item from the list
       if (confirm) {
-        list.splice(item.index, 1)
+        list.splice(list.indexOf(item), 1)
 
         const update = {
           [repeat.options.name]: list
@@ -404,11 +367,13 @@ export class RepeatPageController extends QuestionPageController {
     payload: FormPayload,
     errors?: FormSubmissionError[]
   ): FormPageViewModel {
+    const list = this.getListFromState(state)
+
+    const itemId = this.getItemId(request)
+    const item = this.getItemFromList(list, itemId)
+
     const viewModel = super.getViewModel(request, state, payload, errors)
-
-    const { list, item } = this.getRepeatAppData(request)
-
-    const itemNumber = item ? item.index + 1 : list.length + 1
+    const itemNumber = item ? list.indexOf(item) + 1 : list.length + 1
     const repeatCaption = `${this.repeat.options.title} ${itemNumber}`
 
     return {

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -6,6 +6,7 @@ import { type ResponseToolkit } from '@hapi/hapi'
 import Joi from 'joi'
 
 import { isRepeatState } from '~/src/server/plugins/engine/components/FormComponent.js'
+import { redirectPath } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
@@ -156,6 +157,7 @@ export class RepeatPageController extends QuestionPageController {
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { path } = this
+      const { query } = request
 
       const itemId = this.getItemId(request)
 
@@ -164,7 +166,9 @@ export class RepeatPageController extends QuestionPageController {
 
       if (!itemId) {
         const summaryPath = this.getSummaryPath(request)
-        const nextPath = `${path}/${randomUUID()}${request.url.search}`
+        const nextPath = redirectPath(`${path}/${randomUUID()}`, {
+          returnUrl: query.returnUrl
+        })
 
         // Only redirect to new item when list is empty
         return super.proceed(request, h, list.length ? summaryPath : nextPath)
@@ -180,12 +184,16 @@ export class RepeatPageController extends QuestionPageController {
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { path } = this
+      const { query } = request
 
       const state = await this.getState(request)
       const list = this.getListFromState(state)
 
       if (!list.length) {
-        const nextPath = `${path}/${randomUUID()}${request.url.search}`
+        const nextPath = redirectPath(`${path}/${randomUUID()}`, {
+          returnUrl: query.returnUrl
+        })
+
         return super.proceed(request, h, nextPath)
       }
 
@@ -204,13 +212,17 @@ export class RepeatPageController extends QuestionPageController {
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { model, path, repeat } = this
+      const { query } = request
       const { schema, options } = repeat
 
       const state = await this.getState(request)
       const list = this.getListFromState(state)
 
       if (!list.length) {
-        const nextPath = `${path}/${randomUUID()}${request.url.search}`
+        const nextPath = redirectPath(`${path}/${randomUUID()}`, {
+          returnUrl: query.returnUrl
+        })
+
         return super.proceed(request, h, nextPath)
       }
 
@@ -248,7 +260,10 @@ export class RepeatPageController extends QuestionPageController {
       }
 
       if (action === FormAction.AddAnother) {
-        const nextPath = `${path}/${randomUUID()}${request.url.search}`
+        const nextPath = redirectPath(`${path}/${randomUUID()}`, {
+          returnUrl: query.returnUrl
+        })
+
         return super.proceed(request, h, nextPath)
       } else if (action === FormAction.Continue) {
         return super.proceed(
@@ -401,6 +416,7 @@ export class RepeatPageController extends QuestionPageController {
     backLink?: string
   } {
     const { collection, href, repeat, section } = this
+    const { query } = request
 
     const { title } = repeat.options
     const sectionTitle = section?.hideTitle !== true ? section?.title : ''
@@ -418,7 +434,9 @@ export class RepeatPageController extends QuestionPageController {
       list.forEach((item, index) => {
         const items: SummaryListAction[] = [
           {
-            href: `${href}/${item.itemId}${request.url.search}`,
+            href: redirectPath(`${href}/${item.itemId}`, {
+              returnUrl: query.returnUrl
+            }),
             text: 'Change',
             classes: 'govuk-link--no-visited-state',
             visuallyHiddenText: `item ${index + 1}`
@@ -427,7 +445,9 @@ export class RepeatPageController extends QuestionPageController {
 
         if (count > 1) {
           items.push({
-            href: `${href}/${item.itemId}/confirm-delete${request.url.search}`,
+            href: redirectPath(`${href}/${item.itemId}/confirm-delete`, {
+              returnUrl: query.returnUrl
+            }),
             text: 'Remove',
             classes: 'govuk-link--no-visited-state',
             visuallyHiddenText: `item ${index + 1}`

--- a/src/typings/hapi/index.d.ts
+++ b/src/typings/hapi/index.d.ts
@@ -6,10 +6,6 @@ import { type Logger } from 'pino'
 
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
-  type RepeatItemState,
-  type RepeatListState
-} from '~/src/server/plugins/engine/types.js'
-import {
   type FormRequest,
   type FormRequestPayload
 } from '~/src/server/routes/types.js'
@@ -40,13 +36,6 @@ declare module '@hapi/hapi' {
 
   interface RequestApplicationState {
     model?: FormModel
-    repeat?: {
-      list: RepeatListState
-      item?: {
-        value: RepeatItemState
-        index: number
-      }
-    }
   }
 
   interface Server {


### PR DESCRIPTION
This PR includes changes for the ["exit page bug" #482470](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/482470)

* Restore state validation on POST
* Only redirect to new repeater item when list is empty
* Fix missing back link when showing mini summary errors