### PR TITLE
Only redirect to new repeater item when list is empty

### DIFF
--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -91,11 +91,11 @@ export class FileUploadPageController extends QuestionPageController {
     this.viewName = 'file-upload'
   }
 
-  getFormData(request: FormContextRequest) {
+  getFormData(request?: FormContextRequest) {
     const formData = super.getFormData(request)
 
     const name = this.getComponentName()
-    const files = request.app.files ?? []
+    const files = request?.app.files ?? []
 
     // Append the files to the payload
     formData[name] = files.length ? files : undefined

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -185,8 +185,8 @@ export class QuestionPageController extends PageController {
   /**
    * Gets the form payload (from request) for this page only
    */
-  getFormData(request: FormContextRequest): FormSubmissionPayload {
-    return request.payload ?? {}
+  getFormData(request?: FormContextRequest): FormSubmissionPayload {
+    return request?.payload ?? {}
   }
 
   /**

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -261,7 +261,8 @@ export class RepeatPageController extends QuestionPageController {
           return h.view(this.listSummaryViewName, viewModel)
         }
 
-        return super.proceed(request, h, `${path}${request.url.search}`)
+        const nextPath = `${path}/${randomUUID()}${request.url.search}`
+        return super.proceed(request, h, nextPath)
       } else if (action === FormAction.Continue) {
         return super.proceed(
           request,

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -56,11 +56,13 @@ export class RepeatPageController extends QuestionPageController {
     return [this.repeat.options.name]
   }
 
-  getFormData(request: FormContextRequest) {
+  getFormData(request?: FormContextRequest) {
     const formData = super.getFormData(request)
 
     // Apply an itemId to the form payload
-    formData.itemId = request.params.itemId ?? randomUUID()
+    if (request?.payload) {
+      formData.itemId = request.params.itemId ?? randomUUID()
+    }
 
     return formData
   }

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -182,8 +182,14 @@ export class RepeatPageController extends QuestionPageController {
       const itemId = this.getItemId(request)
 
       if (!itemId) {
+        const state = await super.getState(request)
+        const list = this.getListFromState(state)
+
+        const summaryPath = this.getSummaryPath(request)
         const nextPath = `${path}/${randomUUID()}${request.url.search}`
-        return super.proceed(request, h, nextPath)
+
+        // Only redirect to new item when list is empty
+        return super.proceed(request, h, list.length ? summaryPath : nextPath)
       }
 
       await this.setRepeatAppData(request)

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto'
+import crypto from 'node:crypto'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -34,7 +34,7 @@ async function createRepeatItem(
   repeatPage,
   expectedItemCount = 1,
   headers,
-  itemId = randomUUID()
+  itemId = crypto.randomUUID()
 ) {
   // Issue a GET request to the item
   // page to add to the progress stack
@@ -310,6 +310,9 @@ describe('Repeat POST tests', () => {
   })
 
   test('POST /pizza-order/summary ADD_ANOTHER returns 303', async () => {
+    const itemId = '00000000-0000-0000-0000-000000000000'
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue(itemId)
+
     const res = await server.inject({
       method: 'POST',
       url: `${basePath}/pizza-order/summary`,
@@ -319,7 +322,7 @@ describe('Repeat POST tests', () => {
     })
 
     expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
-    expect(res.headers.location).toBe(`${basePath}/pizza-order`)
+    expect(res.headers.location).toBe(`${basePath}/pizza-order/${itemId}`)
   })
 
   test('POST /pizza-order/summary CONTINUE returns 303', async () => {


### PR DESCRIPTION
This PR updates the handling of the repeater page

Fixes [bug #490111](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490111)

**Before**
When visiting a repeater page, we redirect to the new item page

**After**
When visiting a repeater page:

* Empty repeater state is redirecting to the new item page
* Populated repeater state is redirected to the mini summary page with "Add another" or "Continue"