### PR TITLE
Fix missing `viewModel` defaults

### DIFF
--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -293,8 +293,14 @@ export class RepeatPageController extends QuestionPageController {
         return notFound('List item to delete not found')
       }
 
+      const state = await super.getState(request)
+
+      const { progress = [] } = state
+      await this.updateProgress(progress, request)
+
       return h.view(this.listDeleteViewName, {
         ...viewModel,
+        backLink: this.getBackLink(progress),
         field: {
           name: 'confirm',
           fieldset: {

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -300,7 +300,10 @@ export class RepeatPageController extends QuestionPageController {
 
       return h.view(this.listDeleteViewName, {
         ...viewModel,
+
         backLink: this.getBackLink(progress),
+        showTitle: false,
+
         field: {
           name: 'confirm',
           fieldset: {

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -285,6 +285,8 @@ export class RepeatPageController extends QuestionPageController {
       request: FormRequest,
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
+      const { viewModel } = this
+
       const { item } = await this.setRepeatAppData(request)
 
       if (!item) {
@@ -292,6 +294,7 @@ export class RepeatPageController extends QuestionPageController {
       }
 
       return h.view(this.listDeleteViewName, {
+        ...viewModel,
         field: {
           name: 'confirm',
           fieldset: {

--- a/src/server/plugins/engine/pageControllers/StatusPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StatusPageController.ts
@@ -19,7 +19,7 @@ export class StatusPageController extends QuestionPageController {
       request: FormRequest,
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
-      const { model, title, viewName } = this
+      const { viewModel, viewName } = this
 
       const { cacheService } = request.services([])
       const confirmationState = await cacheService.getConfirmationState(request)
@@ -34,10 +34,8 @@ export class StatusPageController extends QuestionPageController {
       const { submissionGuidance } = await getFormMetadata(slug)
 
       return h.view(viewName, {
-        pageTitle: title,
-        name: model.name,
-        submissionGuidance,
-        serviceUrl: this.getHref('/')
+        ...viewModel,
+        submissionGuidance
       })
     }
   }


### PR DESCRIPTION
This PR fixes missing `viewModel` defaults like the browser `<title>` and the form name

Fixes [bug #490119](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490119) including the missing back link

<img width="603" alt="Repeater remove default view model" src="https://github.com/user-attachments/assets/2a570030-cf32-43d8-bce1-7e393ea005e0" />
