### PR TITLE
Always access page state using page methods

### DIFF
--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -211,12 +211,9 @@ export class QuestionPageController extends PageController {
     return cacheService.getState(request)
   }
 
-  async setState(
-    request: FormRequest | FormRequestPayload,
-    state: FormSubmissionState
-  ) {
+  async setState(request: FormRequest | FormRequestPayload, value: object) {
     const { cacheService } = request.services([])
-    return cacheService.mergeState(request, state)
+    return cacheService.mergeState(request, value)
   }
 
   makeGetRouteHandler() {
@@ -333,8 +330,6 @@ export class QuestionPageController extends PageController {
    * Progress is stored in the state.
    */
   async updateProgress(progress: string[], request: FormRequest) {
-    const { cacheService } = request.services([])
-
     const lastVisited = progress.at(-1)
     const currentPath = `${request.path.substring(1)}${request.url.search}`
 
@@ -354,7 +349,7 @@ export class QuestionPageController extends PageController {
       }
     }
 
-    await cacheService.mergeState(request, { progress })
+    await this.setState(request, { progress })
   }
 
   /**

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -309,8 +309,6 @@ export class RepeatPageController extends QuestionPageController {
         const { item, list } = await this.setRepeatAppData(request)
 
         if (item) {
-          const { cacheService } = request.services([])
-
           // Remove the item from the list
           list.splice(item.index, 1)
 
@@ -318,7 +316,7 @@ export class RepeatPageController extends QuestionPageController {
             [repeat.options.name]: list
           }
 
-          await cacheService.mergeState(request, update)
+          await this.setState(request, update)
         }
       }
 

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -277,7 +277,6 @@ export interface FormPageViewModel extends PageViewModelBase {
 }
 
 export interface FileUploadPageViewModel extends FormPageViewModel {
-  path: string
   formAction?: string
   fileUploadComponent: ComponentViewModel
   preUploadComponents: ComponentViewModel[]

--- a/src/server/plugins/engine/views/components/fileuploadfield.html
+++ b/src/server/plugins/engine/views/components/fileuploadfield.html
@@ -10,7 +10,7 @@
     <p class="govuk-body">{{upload.successfulCount}} of {{upload.count}} files uploaded</p>
     <p class="govuk-body">
       {% if upload.pendingCount %}
-        <a href="{{ path }}" class="govuk-link govuk-link--no-visited-state">Refresh page to update file upload progress</a>
+        <a href="{{ page.href }}" class="govuk-link govuk-link--no-visited-state">Refresh page to update file upload progress</a>
       {% endif %}
     </p>
     {% if upload.summary | length %}

--- a/src/server/services/cacheService.ts
+++ b/src/server/services/cacheService.ts
@@ -3,10 +3,7 @@ import { merge } from '@hapi/hoek'
 
 import { config } from '~/src/config/index.js'
 import { type createServer } from '~/src/server/index.js'
-import {
-  type FormSubmissionState,
-  type TempFileState
-} from '~/src/server/plugins/engine/types.js'
+import { type FormSubmissionState } from '~/src/server/plugins/engine/types.js'
 import {
   type FormRequest,
   type FormRequestPayload
@@ -69,25 +66,6 @@ export class CacheService {
     const ttl = config.get('confirmationSessionTimeout')
 
     return this.cache.set(key, confirmationState, ttl)
-  }
-
-  async getUploadState(request: FormRequest | FormRequestPayload) {
-    const state = await this.getState(request)
-    const uploadState = state.upload ?? {}
-    const path = request.path
-
-    return uploadState[path] ?? { files: [] }
-  }
-
-  async mergeUploadState(
-    request: FormRequest | FormRequestPayload,
-    uploadState: TempFileState
-  ) {
-    const path = request.path
-
-    await this.mergeState(request, {
-      upload: { [path]: uploadState }
-    })
   }
 
   async clearState(request: FormRequest | FormRequestPayload) {

--- a/test/form/persist-files.test.js
+++ b/test/form/persist-files.test.js
@@ -91,10 +91,7 @@ describe('Submission journey test', () => {
   })
 
   test('GET /file-upload-component returns 200', async () => {
-    jest.spyOn(CacheService.prototype, 'getUploadState').mockResolvedValueOnce({
-      upload: undefined,
-      files: []
-    })
+    jest.spyOn(CacheService.prototype, 'getState').mockResolvedValueOnce({})
 
     jest.mocked(uploadService.initiateUpload).mockResolvedValueOnce({
       uploadId: '123-546-789',
@@ -111,14 +108,19 @@ describe('Submission journey test', () => {
   })
 
   test('POST /file-upload-component returns 303', async () => {
-    jest.spyOn(CacheService.prototype, 'getUploadState').mockResolvedValueOnce(
-      /** @type {TempFileState} */ ({
+    jest.spyOn(CacheService.prototype, 'getState').mockResolvedValueOnce(
+      // @ts-expect-error - Allow upload property mismatch with `FormState`
+      /** @type {FormSubmissionState} */ ({
         upload: {
-          uploadId: '123-546-788',
-          uploadUrl: 'http://localhost:7337/upload-and-scan/123-546-788',
-          statusUrl: 'http://localhost:7337/status/123-546-788'
-        },
-        files: [readyFile, readyFile2]
+          '/file-upload-component': {
+            files: [readyFile, readyFile2],
+            upload: {
+              uploadId: '123-546-788',
+              uploadUrl: 'http://localhost:7337/upload-and-scan/123-546-788',
+              statusUrl: 'http://localhost:7337/status/123-546-788'
+            }
+          }
+        }
       })
     )
 
@@ -223,5 +225,5 @@ describe('Submission journey test', () => {
 
 /**
  * @import { Server } from '@hapi/hapi'
- * @import { FileState, TempFileState } from '~/src/server/plugins/engine/types.js'
+ * @import { FileState, FormSubmissionState } from '~/src/server/plugins/engine/types.js'
  */


### PR DESCRIPTION
This PR follows on from https://github.com/DEFRA/forms-runner/pull/617

It allows us to share existing `state` rather than hitting Redis again


```patch
+ const { path } = this
  const state = await this.getState(request)
  
- const { cacheService } = request.services([])
- const uploadState = await cacheService.getUploadState(request)
+ const uploadState = state.upload?.[path] ?? { files: [] }
```