### PR TITLE
Check for maximum repeater state on continue

### DIFF
--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -284,11 +284,16 @@ export class FormModel {
     const { isPreview } = checkFormStatus(request.path)
 
     // Add paths for navigation
-    for (const { collection, path } of context.relevantPages) {
+    for (const { keys, path } of context.relevantPages) {
       paths.push(path)
 
-      // Stop at current page or with errors
-      if (!isPreview && collection.getErrors(errors)) {
+      // Stop at page with errors
+      if (
+        !isPreview &&
+        errors?.some(({ name, path }) => {
+          return keys.includes(name) || keys.some((key) => path.includes(key))
+        })
+      ) {
         break
       }
     }

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -53,7 +53,8 @@ export class RepeatPageController extends QuestionPageController {
   }
 
   get keys() {
-    return [this.repeat.options.name]
+    const { repeat } = this
+    return [repeat.options.name, ...super.keys]
   }
 
   getItemId(request?: FormContextRequest) {


### PR DESCRIPTION
This PR includes 2x changes to fix [bug #490108](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490108)

1. **Fix state validation to include non-field error keys**
We currently filter out the `stateSchema` repeater key

2. **Check for maximum repeater state on continue**
We now check for maximum repeater items on continue (not just add another)

<img width="690" alt="Maximum repeater items" src="https://github.com/user-attachments/assets/f3cdcf12-d671-442b-a560-8f71f6860fdc" />

☝️ The ability to add more than the maximum items will be addressed in [bug #490107](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490107)