### PR TITLE
Prevent last repeater item from being removed

### DIFF
--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -290,10 +290,14 @@ export class RepeatPageController extends QuestionPageController {
     ) => {
       const { viewModel } = this
 
-      const { item } = await this.setRepeatAppData(request)
+      const { item, list } = await this.setRepeatAppData(request)
 
-      if (!item) {
-        return notFound('List item to delete not found')
+      if (!item || list.length === 1) {
+        return notFound(
+          item
+            ? 'Last list item cannot be removed'
+            : 'List item to remove not found'
+        )
       }
 
       const state = await super.getState(request)
@@ -340,19 +344,25 @@ export class RepeatPageController extends QuestionPageController {
       const { repeat } = this
       const { confirm } = this.getFormData(request)
 
+      const { item, list } = await this.setRepeatAppData(request)
+
+      if (!item || list.length === 1) {
+        return notFound(
+          item
+            ? 'Last list item cannot be removed'
+            : 'List item to remove not found'
+        )
+      }
+
+      // Remove the item from the list
       if (confirm) {
-        const { item, list } = await this.setRepeatAppData(request)
+        list.splice(item.index, 1)
 
-        if (item) {
-          // Remove the item from the list
-          list.splice(item.index, 1)
-
-          const update = {
-            [repeat.options.name]: list
-          }
-
-          await this.setState(request, update)
+        const update = {
+          [repeat.options.name]: list
         }
+
+        await this.setState(request, update)
       }
 
       return this.proceed(request, h)

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -210,8 +210,20 @@ describe('Repeat GET tests', () => {
     )
   })
 
-  test('GET /pizza-order/{id}/confirm-delete returns 200', async () => {
+  test('GET /pizza-order/{id}/confirm-delete with 1 item returns 404', async () => {
     const { item, headers } = await createRepeatItem(server, repeatPage)
+
+    const res = await server.inject({
+      url: `${basePath}/pizza-order/${item.itemId}/confirm-delete`,
+      headers
+    })
+
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
+  })
+
+  test('GET /pizza-order/{id}/confirm-delete with 2 items returns 200', async () => {
+    const { item, headers } = await createRepeatItem(server, repeatPage)
+    await createRepeatItem(server, repeatPage, 2, headers)
 
     const res = await server.inject({
       url: `${basePath}/pizza-order/${item.itemId}/confirm-delete`,
@@ -229,7 +241,7 @@ describe('Repeat GET tests', () => {
     expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
   })
 
-  test('GET /pizza-order/summary with items returns 200', async () => {
+  test('GET /pizza-order/summary with 2 items returns 200', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
     await createRepeatItem(server, repeatPage, 2, headers)
 
@@ -293,8 +305,24 @@ describe('Repeat POST tests', () => {
     expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/summary?/)
   })
 
-  test('POST /pizza-order/{id}/confirm-delete returns 303', async () => {
+  test('POST /pizza-order/{id}/confirm-delete with 1 item returns 404', async () => {
     const { item, headers } = await createRepeatItem(server, repeatPage)
+
+    const res = await server.inject({
+      url: `${basePath}/pizza-order/${item.itemId}/confirm-delete`,
+      method: 'POST',
+      headers,
+      payload: {
+        confirm: true
+      }
+    })
+
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
+  })
+
+  test('POST /pizza-order/{id}/confirm-delete with 2 items returns 303', async () => {
+    const { item, headers } = await createRepeatItem(server, repeatPage)
+    await createRepeatItem(server, repeatPage, 2, headers)
 
     const res = await server.inject({
       url: `${basePath}/pizza-order/${item.itemId}/confirm-delete`,


### PR DESCRIPTION
This PR renders the 404 Not Found page when attempting to remove the last repeater item

* `/pizza-order/{id}/confirm-delete` via **GET**
* `/pizza-order/{id}/confirm-delete` via **POST**

The last repeater item isn't rendered with a "Remove" link but this was possible (manually) via the route

Fixes [bug #490106](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490106)
