### PR TITLE
Check for minimum repeater state on continue

### DIFF
--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -217,8 +217,15 @@ export class RepeatPageController extends QuestionPageController {
       request: FormRequest,
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
+      const { path } = this
+
       const state = await super.getState(request)
       const list = this.getListFromState(state)
+
+      if (!list.length) {
+        const nextPath = `${path}/${randomUUID()}${request.url.search}`
+        return super.proceed(request, h, nextPath)
+      }
 
       const { progress = [] } = state
       await this.updateProgress(progress, request)
@@ -240,6 +247,11 @@ export class RepeatPageController extends QuestionPageController {
 
       const state = await super.getState(request)
       const list = this.getListFromState(state)
+
+      if (!list.length) {
+        const nextPath = `${path}/${randomUUID()}${request.url.search}`
+        return super.proceed(request, h, nextPath)
+      }
 
       const { action } = this.getFormData(request)
 

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -243,17 +243,26 @@ export class RepeatPageController extends QuestionPageController {
 
       const { action } = this.getFormData(request)
 
-      // Show error if repeat max limit reached
-      if (
+      const hasErrorMin =
+        action === FormAction.Continue && list.length < schema.min
+
+      const hasErrorMax =
         (action === FormAction.AddAnother && list.length >= schema.max) ||
         (action === FormAction.Continue && list.length > schema.max)
-      ) {
+
+      // Show error if repeat limits apply
+      if (hasErrorMin || hasErrorMax) {
+        const count = hasErrorMax ? schema.max : schema.min
+        const itemTitle = `${options.title}${count === 1 ? '' : 's'}`
+
         const errors: FormSubmissionError[] = [
           {
             path: [],
             href: '',
             name: '',
-            text: `You can only add up to ${schema.max} ${options.title}${schema.max === 1 ? '' : 's'}`
+            text: hasErrorMax
+              ? `You can only add up to ${count} ${itemTitle}`
+              : `You must add at least ${count} ${itemTitle}`
           }
         ]
 

--- a/test/form/definitions/repeat.js
+++ b/test/form/definitions/repeat.js
@@ -18,8 +18,8 @@ export default /** @satisfies {FormDefinition} */ ({
           title: 'Pizza'
         },
         schema: {
-          min: 1,
-          max: 2
+          min: 2,
+          max: 3
         }
       },
       section: 'food',

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -125,12 +125,13 @@ describe('Repeat GET tests', () => {
     expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/[0-9a-f-]+$/)
   })
 
-  test('GET /pizza-order/summary returns 200', async () => {
+  test('GET /pizza-order/summary returns 302 to add another', async () => {
     const res = await server.inject({
       url: `${basePath}/pizza-order/summary`
     })
 
-    expect(res.statusCode).toBe(StatusCodes.OK)
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
+    expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/[0-9a-f-]+$/)
   })
 
   test('GET /pizza-order/{id} returns 200', async () => {

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -226,9 +226,26 @@ describe('Repeat GET tests', () => {
     expect(res.statusCode).toBe(StatusCodes.OK)
   })
 
-  test('GET /pizza-order/{id} with 2 items returns 302 to repeater summary', async () => {
+  test('GET /pizza-order/{id} with 2 items returns 200', async () => {
     const { headers } = await createRepeatItem(server, repeatPage, 1)
     await createRepeatItem(server, repeatPage, 2, headers)
+
+    const itemId = '00000000-0000-0000-0000-000000000000'
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue(itemId)
+
+    const res = await server.inject({
+      url: `${basePath}/pizza-order/${itemId}`,
+      headers
+    })
+
+    expect(res.statusCode).toBe(StatusCodes.OK)
+  })
+
+  test('GET /pizza-order/{id} with 3 items returns 302 to repeater summary', async () => {
+    const { headers } = await createRepeatItem(server, repeatPage, 1)
+
+    await createRepeatItem(server, repeatPage, 2, headers)
+    await createRepeatItem(server, repeatPage, 3, headers)
 
     const itemId = '00000000-0000-0000-0000-000000000000'
     jest.spyOn(crypto, 'randomUUID').mockReturnValue(itemId)
@@ -273,6 +290,17 @@ describe('Repeat GET tests', () => {
     })
 
     expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
+  })
+
+  test('GET /pizza-order/summary with 1 item returns 200', async () => {
+    const { headers } = await createRepeatItem(server, repeatPage)
+
+    const res = await server.inject({
+      url: `${basePath}/pizza-order/summary`,
+      headers
+    })
+
+    expect(res.statusCode).toBe(StatusCodes.OK)
   })
 
   test('GET /pizza-order/summary with 2 items returns 200', async () => {
@@ -376,8 +404,8 @@ describe('Repeat POST tests', () => {
     jest.spyOn(crypto, 'randomUUID').mockReturnValue(itemId)
 
     const res = await server.inject({
-      method: 'POST',
       url: `${basePath}/pizza-order/summary`,
+      method: 'POST',
       payload: {
         action: FormAction.AddAnother
       }
@@ -387,7 +415,10 @@ describe('Repeat POST tests', () => {
     expect(res.headers.location).toBe(`${basePath}/pizza-order/${itemId}`)
   })
 
-  test('POST /pizza-order/summary CONTINUE returns 303', async () => {
+  test('POST /pizza-order/summary with 1 item ADD_ANOTHER returns 303', async () => {
+    const itemId = '00000000-0000-0000-0000-000000000000'
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue(itemId)
+
     const { headers } = await createRepeatItem(server, repeatPage)
 
     const res = await server.inject({
@@ -395,18 +426,40 @@ describe('Repeat POST tests', () => {
       method: 'POST',
       headers,
       payload: {
-        action: FormAction.Continue
+        action: FormAction.AddAnother
       }
     })
 
     expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
-    expect(res.headers.location).toBe(`${basePath}/summary`)
+    expect(res.headers.location).toBe(`${basePath}/pizza-order/${itemId}`)
   })
 
-  test('POST /pizza-order/summary ADD_ANOTHER returns 200 with errors over schema.max', async () => {
+  test('POST /pizza-order/summary with 2 items ADD_ANOTHER returns 303', async () => {
+    const itemId = '00000000-0000-0000-0000-000000000000'
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue(itemId)
+
+    const { headers } = await createRepeatItem(server, repeatPage)
+
+    await createRepeatItem(server, repeatPage, 1, headers)
+
+    const res = await server.inject({
+      url: `${basePath}/pizza-order/summary`,
+      method: 'POST',
+      headers,
+      payload: {
+        action: FormAction.AddAnother
+      }
+    })
+
+    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
+    expect(res.headers.location).toBe(`${basePath}/pizza-order/${itemId}`)
+  })
+
+  test('POST /pizza-order/summary with 3 items ADD_ANOTHER returns 200 with errors over schema.max', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
 
     await createRepeatItem(server, repeatPage, 2, headers)
+    await createRepeatItem(server, repeatPage, 3, headers)
 
     const { container, response } = await renderResponse(server, {
       url: `${basePath}/pizza-order/summary`,
@@ -428,13 +481,13 @@ describe('Repeat POST tests', () => {
     })
 
     expect($heading).toBeInTheDocument()
-    expect($errorItems[0]).toHaveTextContent('You can only add up to 2 Pizzas')
+    expect($errorItems[0]).toHaveTextContent('You can only add up to 3 Pizzas')
   })
 
-  test('POST /pizza-order/summary CONTINUE returns 303 to /summary', async () => {
+  test('POST /pizza-order/summary CONTINUE with 1 item returns 200 with errors under schema.min', async () => {
     const { headers } = await createRepeatItem(server, repeatPage)
 
-    const res = await server.inject({
+    const { container, response } = await renderResponse(server, {
       url: `${basePath}/pizza-order/summary`,
       method: 'POST',
       headers,
@@ -443,23 +496,18 @@ describe('Repeat POST tests', () => {
       }
     })
 
-    expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
-    expect(res.headers.location).toBe(`${basePath}/summary`)
-
-    const { container, response } = await renderResponse(server, {
-      url: `${basePath}/summary`,
-      headers
-    })
-
     expect(response.statusCode).toBe(StatusCodes.OK)
 
-    const $values = container
-      .getAllByRole('definition')
-      .filter(({ classList }) =>
-        classList.contains('govuk-summary-list__value')
-      )
+    const $errorSummary = container.getByRole('alert')
+    const $errorItems = within($errorSummary).getAllByRole('listitem')
 
-    expect($values[0]).toHaveTextContent('You added 1 Pizza')
+    const $heading = within($errorSummary).getByRole('heading', {
+      name: 'There is a problem',
+      level: 2
+    })
+
+    expect($heading).toBeInTheDocument()
+    expect($errorItems[0]).toHaveTextContent('You must add at least 2 Pizzas')
   })
 
   test('POST /pizza-order/summary with 2 items CONTINUE returns 303 to /summary', async () => {
@@ -496,8 +544,8 @@ describe('Repeat POST tests', () => {
 
     // POST the summary page
     await server.inject({
-      method: 'POST',
       url: `${basePath}/summary`,
+      method: 'POST',
       headers,
       payload: {
         action: FormAction.Send


### PR DESCRIPTION
This PR includes 2x changes to fix [bug #490112](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490112)

1. **Prevent zero repeater items reaching mini summary**
Redirects to add another instead of more "0 Pizzas added" etc

2. **Check for minimum repeater state on continue**
We now check for minimum repeater items on continue