### PR TITLE
Add file upload state helpers etc

### DIFF
--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -51,8 +51,7 @@ export class CheckboxesField extends SelectionControlField {
     const { items, name } = this
 
     // State checkbox values
-    const value = state[name]
-    const values = this.isValue(value) ? value : []
+    const values = this.getFormValue(state[name]) ?? []
 
     // Map (or discard) state values to item values
     const selected = items
@@ -60,6 +59,10 @@ export class CheckboxesField extends SelectionControlField {
       .map((item) => item.value)
 
     return selected.length ? selected : undefined
+  }
+
+  getFormValue(value?: FormStateValue | FormState) {
+    return this.isValue(value) ? value : undefined
   }
 
   getDisplayStringFromState(state: FormSubmissionState) {

--- a/src/server/plugins/engine/components/FileUploadField.test.ts
+++ b/src/server/plugins/engine/components/FileUploadField.test.ts
@@ -18,7 +18,7 @@ import { validationOptions as opts } from '~/src/server/plugins/engine/pageContr
 import {
   FileStatus,
   UploadStatus,
-  type FileState
+  type UploadState
 } from '~/src/server/plugins/engine/types.js'
 import definition from '~/test/form/definitions/file-upload-basic.js'
 import { getFormData, getFormState } from '~/test/helpers/component-helpers.js'
@@ -26,7 +26,7 @@ import { getFormData, getFormState } from '~/test/helpers/component-helpers.js'
 describe('FileUploadField', () => {
   let model: FormModel
 
-  const validTempState: FileState[] = [
+  const validTempState: UploadState = [
     {
       uploadId: '3075efea-e5de-476f-a0bf-9ae7ef56ca69',
       status: {
@@ -85,7 +85,7 @@ describe('FileUploadField', () => {
     }
   ]
 
-  const validState: FileState[] = [
+  const validState: UploadState = [
     {
       uploadId: '3075efea-e5de-476f-a0bf-9ae7ef56ca69',
       status: {

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -1,7 +1,10 @@
 import { type FileUploadFieldComponent } from '@defra/forms-model'
 import joi, { type ArraySchema } from 'joi'
 
-import { FormComponent } from '~/src/server/plugins/engine/components/FormComponent.js'
+import {
+  FormComponent,
+  isUploadState
+} from '~/src/server/plugins/engine/components/FormComponent.js'
 import { filesize } from '~/src/server/plugins/engine/helpers.js'
 import {
   FileStatus,
@@ -17,6 +20,7 @@ import {
   type SummaryList,
   type SummaryListRow,
   type UploadState,
+  type UploadStatusFileResponse,
   type UploadStatusResponse
 } from '~/src/server/plugins/engine/types.js'
 import { render } from '~/src/server/plugins/nunjucks/index.js'
@@ -51,7 +55,7 @@ export const metadataSchema = joi
   .required()
 
 export const tempStatusSchema = joi
-  .object<UploadState>({
+  .object<UploadStatusFileResponse>({
     uploadStatus: joi
       .string()
       .valid(UploadStatus.ready, UploadStatus.pending)
@@ -256,24 +260,7 @@ export class FileUploadField extends FormComponent {
     }
   }
 
-  isValue(value?: FormStateValue | FormState): value is FileState[] {
-    return FileUploadField.isFileUploads(value)
-  }
-
-  static isFileUploads(
-    value?: FormStateValue | FormState
-  ): value is FileState[] {
-    if (!Array.isArray(value)) {
-      return false
-    }
-
-    // Skip checks when empty
-    if (!value.length) {
-      return true
-    }
-
-    return value.every(
-      (value) => typeof value === 'object' && 'uploadId' in value
-    )
+  isValue(value?: FormStateValue | FormState): value is UploadState {
+    return isUploadState(value)
   }
 }

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -138,7 +138,11 @@ export class FileUploadField extends FormComponent {
   }
 
   getFormValueFromState(state: FormSubmissionState) {
-    const value = super.getFormValueFromState(state)
+    const { name } = this
+    return this.getFormValue(state[name])
+  }
+
+  getFormValue(value?: FormStateValue | FormState) {
     return this.isValue(value) ? value : undefined
   }
 
@@ -163,7 +167,7 @@ export class FileUploadField extends FormComponent {
     const viewModel = super.getViewModel(payload, errors)
     const { attributes, id, value } = viewModel
 
-    const files = this.isValue(value) ? value : []
+    const files = this.getFormValue(value) ?? []
     const count = files.length
 
     let pendingCount = 0

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -3,6 +3,7 @@ import { type FormComponentsDef, type Item } from '@defra/forms-model'
 import { ComponentBase } from '~/src/server/plugins/engine/components/ComponentBase.js'
 import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
 import {
+  type FileState,
   type FormPayload,
   type FormState,
   type FormStateValue,
@@ -10,7 +11,8 @@ import {
   type FormSubmissionState,
   type FormValue,
   type RepeatItemState,
-  type RepeatListState
+  type RepeatListState,
+  type UploadState
 } from '~/src/server/plugins/engine/types.js'
 
 export class FormComponent extends ComponentBase {
@@ -222,4 +224,27 @@ export function isRepeatState(value?: unknown): value is RepeatListState {
  */
 export function isRepeatValue(value?: unknown): value is RepeatItemState {
   return isFormState(value) && typeof value.itemId === 'string'
+}
+
+/**
+ * Check for upload state
+ */
+export function isUploadState(value?: unknown): value is UploadState {
+  if (!Array.isArray(value)) {
+    return false
+  }
+
+  // Skip checks when empty
+  if (!value.length) {
+    return true
+  }
+
+  return value.every(isUploadValue)
+}
+
+/**
+ * Check for upload state value
+ */
+export function isUploadValue(value?: unknown): value is FileState {
+  return isFormState(value) && typeof value.uploadId === 'string'
 }

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -51,10 +51,8 @@ export class FormComponent extends ComponentBase {
       return collection.getFormDataFromState(state)
     }
 
-    const value = state[name]
-
     return {
-      [name]: this.isValue(value) ? value : undefined
+      [name]: this.getFormValue(state[name])
     }
   }
 
@@ -65,7 +63,10 @@ export class FormComponent extends ComponentBase {
       return collection.getFormValueFromState(state)
     }
 
-    const value = state[name]
+    return this.getFormValue(state[name])
+  }
+
+  getFormValue(value?: FormStateValue | FormState) {
     return this.isValue(value) ? value : undefined
   }
 
@@ -76,10 +77,8 @@ export class FormComponent extends ComponentBase {
       return collection.getStateFromValidForm(payload)
     }
 
-    const value = payload[name]
-
     return {
-      [name]: this.isValue(value) ? value : null
+      [name]: this.getFormValue(payload[name]) ?? null
     }
   }
 

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -78,7 +78,11 @@ export class NumberField extends FormComponent {
   }
 
   getFormValueFromState(state: FormSubmissionState) {
-    const value = super.getFormValueFromState(state)
+    const { name } = this
+    return this.getFormValue(state[name])
+  }
+
+  getFormValue(value?: FormStateValue | FormState) {
     return this.isValue(value) ? value : undefined
   }
 

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -78,7 +78,11 @@ export class TextField extends FormComponent {
   }
 
   getFormValueFromState(state: FormSubmissionState) {
-    const value = super.getFormValueFromState(state)
+    const { name } = this
+    return this.getFormValue(state[name])
+  }
+
+  getFormValue(value?: FormStateValue | FormState) {
     return this.isValue(value) ? value : undefined
   }
 

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -28,7 +28,7 @@ import {
   type FormPayload,
   type FormSubmissionError,
   type TempFileState,
-  type UploadState,
+  type UploadStatusFileResponse,
   type UploadStatusResponse
 } from '~/src/server/plugins/engine/types.js'
 import {
@@ -38,7 +38,7 @@ import {
 
 const MAX_UPLOADS = 25
 
-function prepareStatus(status: UploadState) {
+function prepareStatus(status: UploadStatusFileResponse) {
   const file = status.form.file
   const isPending = file.fileStatus === FileStatus.pending
 
@@ -402,7 +402,7 @@ export class FileUploadPageController extends QuestionPageController {
         const result = results[index]
 
         if (result.status === 'fulfilled') {
-          const validateResult: ValidationResult<UploadState> =
+          const validateResult: ValidationResult<UploadStatusFileResponse> =
             tempStatusSchema.validate(result.value, { stripUnknown: true })
 
           if (!validateResult.error) {

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -27,6 +27,7 @@ import {
   type FormContextRequest,
   type FormPayload,
   type FormSubmissionError,
+  type FormSubmissionState,
   type TempFileState,
   type UploadStatusFileResponse,
   type UploadStatusResponse
@@ -264,10 +265,11 @@ export class FileUploadPageController extends QuestionPageController {
 
   getViewModel(
     request: FormContextRequest,
+    state: FormSubmissionState,
     payload: FormPayload,
     errors?: FormSubmissionError[]
   ): FileUploadPageViewModel {
-    const viewModel = super.getViewModel(request, payload, errors)
+    const viewModel = super.getViewModel(request, state, payload, errors)
 
     const name = this.fileUploadComponent.name
     const components = viewModel.components

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -165,8 +165,8 @@ describe('QuestionPageController', () => {
     let viewModel2: FormPageViewModel
 
     beforeEach(() => {
-      viewModel1 = controller1.getViewModel(requestPage1, {})
-      viewModel2 = controller2.getViewModel(requestPage2, {})
+      viewModel1 = controller1.getViewModel(requestPage1, {}, {})
+      viewModel2 = controller2.getViewModel(requestPage2, {}, {})
     })
 
     it('hides the page title for single form component pages', () => {

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -27,6 +27,7 @@ import {
   type FormContextRequest,
   type FormPageViewModel,
   type FormPayload,
+  type FormState,
   type FormSubmissionError,
   type FormSubmissionPayload,
   type FormSubmissionState
@@ -201,7 +202,11 @@ export class QuestionPageController extends PageController {
     }
   }
 
-  getStateFromValidForm(request: FormContextRequest, payload: FormPayload) {
+  getStateFromValidForm(
+    request: FormContextRequest,
+    state: FormSubmissionState,
+    payload: FormPayload
+  ): FormState {
     return this.collection.getStateFromValidForm(payload)
   }
 
@@ -396,7 +401,7 @@ export class QuestionPageController extends PageController {
       // Convert and save sanitised payload to state
       state = await this.setState(
         request,
-        this.getStateFromValidForm(request, payload)
+        this.getStateFromValidForm(request, state, payload)
       )
 
       return this.proceed(

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -80,11 +80,13 @@ export class QuestionPageController extends PageController {
   /**
    * Used for mapping form payloads and errors to govuk-frontend's template api, so a page can be rendered
    * @param request - the hapi request
+   * @param state - the form state
    * @param payload - contains a user's form payload
    * @param [errors] - validation errors that may have occurred
    */
   getViewModel(
     request: FormContextRequest,
+    state: FormSubmissionState,
     payload: FormPayload,
     errors?: FormSubmissionError[]
   ): FormPageViewModel {
@@ -247,7 +249,7 @@ export class QuestionPageController extends PageController {
       }
 
       const payload = this.getFormDataFromState(request, context.state)
-      const viewModel = this.getViewModel(request, payload)
+      const viewModel = this.getViewModel(request, context.state, payload)
 
       /**
        * Content components can be hidden based on a condition. If the condition evaluates to true, it is safe to be kept, otherwise discard it
@@ -389,7 +391,12 @@ export class QuestionPageController extends PageController {
        */
       if (errors) {
         const { progress = [] } = context.state
-        const viewModel = this.getViewModel(request, payload, errors)
+        const viewModel = this.getViewModel(
+          request,
+          context.state,
+          payload,
+          errors
+        )
 
         viewModel.context = context
         viewModel.errors = collection.getErrors(viewModel.errors)

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -192,7 +192,10 @@ export class QuestionPageController extends PageController {
   /**
    * Gets the form payload (from state) for this page only
    */
-  getFormDataFromState(state: FormSubmissionState): FormPayload {
+  getFormDataFromState(
+    request: FormContextRequest | undefined,
+    state: FormSubmissionState
+  ): FormPayload {
     return {
       ...this.collection.getFormDataFromState(state)
     }
@@ -238,7 +241,7 @@ export class QuestionPageController extends PageController {
         return this.proceed(request, h, relevantPath)
       }
 
-      const payload = this.getFormDataFromState(context.state)
+      const payload = this.getFormDataFromState(request, context.state)
       const viewModel = this.getViewModel(request, payload)
 
       /**

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -362,10 +362,11 @@ export class RepeatPageController extends QuestionPageController {
 
   getViewModel(
     request: FormContextRequest,
+    state: FormSubmissionState,
     payload: FormPayload,
     errors?: FormSubmissionError[]
   ): FormPageViewModel {
-    const viewModel = super.getViewModel(request, payload, errors)
+    const viewModel = super.getViewModel(request, state, payload, errors)
 
     const { list, item } = this.getRepeatAppData(request)
 

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -74,8 +74,9 @@ export class RepeatPageController extends QuestionPageController {
   }
 
   getStateFromValidForm(
-    request: FormRequestPayload,
-    payload: FormRequestPayload['payload']
+    request: FormContextRequest,
+    state: FormSubmissionState,
+    payload: FormPayload
   ) {
     const itemId = this.getItemId(request)
 
@@ -84,7 +85,7 @@ export class RepeatPageController extends QuestionPageController {
     }
 
     const { item, list } = this.getRepeatAppData(request)
-    const itemState = super.getStateFromValidForm(request, payload)
+    const itemState = super.getStateFromValidForm(request, state, payload)
 
     const updated: RepeatItemState = { ...itemState, itemId }
     const newList = [...list]

--- a/src/server/plugins/engine/pageControllers/StartPageController.ts
+++ b/src/server/plugins/engine/pageControllers/StartPageController.ts
@@ -1,7 +1,8 @@
 import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
   type FormPayload,
-  type FormSubmissionError
+  type FormSubmissionError,
+  type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
 
@@ -14,11 +15,12 @@ export class StartPageController extends QuestionPageController {
 
   getViewModel(
     request: FormRequest,
+    state: FormSubmissionState,
     payload: FormPayload,
     errors?: FormSubmissionError[]
   ) {
     return {
-      ...super.getViewModel(request, payload, errors),
+      ...super.getViewModel(request, state, payload, errors),
       isStartPage: true
     }
   }

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -88,7 +88,7 @@ export type FormPayload = {
 export type FormValue =
   | Item['value']
   | Item['value'][]
-  | FileState[]
+  | UploadState
   | RepeatListState
   | undefined
 
@@ -172,6 +172,8 @@ export enum FileStatus {
   pending = 'pending'
 }
 
+export type UploadState = FileState[]
+
 export type FileUpload = {
   fileId: string
   filename: string
@@ -210,19 +212,19 @@ export type UploadStatusResponse =
       numberOfRejectedFiles: 0
     }
 
-export type UploadState = Exclude<
+export type UploadStatusFileResponse = Exclude<
   UploadStatusResponse,
   { uploadStatus: UploadStatus.initiated }
 >
 
 export interface FileState {
   uploadId: string
-  status: UploadState
+  status: UploadStatusFileResponse
 }
 
 export interface TempFileState {
   upload?: UploadInitiateResponse
-  files: FileState[]
+  files: UploadState
 }
 
 export interface RepeatItemState extends FormPayload {

--- a/src/server/plugins/engine/views/partials/debug.html
+++ b/src/server/plugins/engine/views/partials/debug.html
@@ -22,7 +22,7 @@
       </p>
 
       {{ appDebug({
-        content: question.getFormDataFromState(context.state)
+        content: question.getFormDataFromState(undefined, context.state)
       }) }}
     {% else %}
       {{ appDebug({

--- a/src/typings/hapi/index.d.ts
+++ b/src/typings/hapi/index.d.ts
@@ -6,9 +6,9 @@ import { type Logger } from 'pino'
 
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
-  type FileState,
   type RepeatItemState,
-  type RepeatListState
+  type RepeatListState,
+  type UploadState
 } from '~/src/server/plugins/engine/types.js'
 import {
   type FormRequest,
@@ -41,7 +41,7 @@ declare module '@hapi/hapi' {
 
   interface RequestApplicationState {
     model?: FormModel
-    files?: FileState[]
+    files?: UploadState
     formAction?: string
     repeat?: {
       list: RepeatListState


### PR DESCRIPTION
This PR follows https://github.com/DEFRA/forms-runner/pull/603 and adds new helpers for repeater state to complement our existing ones:

* ✅ `isFormValue()`
* ✅ `isFormState()`
* ✅ `isRepeatValue()`
* ✅ `isRepeatState()`
* ❌ `isUploadValue()`
* ❌ `isUploadState()`

### State and payload page controller methods

I've also refactored our page methods to prevent unnecessary Redis state reads etc, such as:

* **Add field method `getFormValue()` to handle `state[name]` etc**
  State value access allow file uploads to be filtered (initialised, pending etc) directly from state in future

* **Pass request to `getFormDataFromState()` when converting state**
  Request access provides existing `itemId` or `uploadId` values where previously unavailable

* **Pass state to `getStateFromValidForm()` when converting payload**
  State access provides existing file upload or repeater data where previously unavailable
  
These changes will be utilised in PR https://github.com/DEFRA/forms-runner/pull/599