### PR TITLE
Find file upload field using collection

### DIFF
--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -18,8 +18,8 @@ import {
 import {
   FileStatus,
   UploadStatus,
+  type FeaturedFormPageViewModel,
   type FileState,
-  type FileUploadPageViewModel,
   type FormContextRequest,
   type FormPayload,
   type FormSubmissionError,
@@ -267,25 +267,26 @@ export class FileUploadPageController extends QuestionPageController {
     state: FormSubmissionState,
     payload: FormPayload,
     errors?: FormSubmissionError[]
-  ): FileUploadPageViewModel {
+  ): FeaturedFormPageViewModel {
     const { fileUpload } = this
 
     const viewModel = super.getViewModel(request, state, payload, errors)
     const { components } = viewModel
 
-    const [fileUploadComponent] = components.filter(
+    // Featured form component
+    const [formComponent] = components.filter(
       ({ model }) => model.id === fileUpload.name
     )
 
-    const index = components.indexOf(fileUploadComponent)
+    const index = components.indexOf(formComponent)
 
     return {
       ...viewModel,
       formAction: request.app.formAction,
-      fileUploadComponent,
+      formComponent,
 
       // Split out components before/after
-      preUploadComponents: components.slice(0, index),
+      componentsBefore: components.slice(0, index),
       components: components.slice(index)
     }
   }

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -278,13 +278,13 @@ export interface FormPageViewModel extends PageViewModelBase {
   }
 }
 
-export interface FileUploadPageViewModel extends FormPageViewModel {
+export interface FeaturedFormPageViewModel extends FormPageViewModel {
   formAction?: string
-  fileUploadComponent: ComponentViewModel
-  preUploadComponents: ComponentViewModel[]
+  formComponent: ComponentViewModel
+  componentsBefore: ComponentViewModel[]
 }
 
 export type PageViewModel =
   | PageViewModelBase
   | FormPageViewModel
-  | FileUploadPageViewModel
+  | FeaturedFormPageViewModel

--- a/src/server/plugins/engine/views/components/fileuploadfield.html
+++ b/src/server/plugins/engine/views/components/fileuploadfield.html
@@ -1,8 +1,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
 
 {% macro FileUploadField(component) %}
-  {% set model = component.model %}
-  {% set upload = model.upload %}
+  {% set upload = component.model.upload %}
 
   <h2 class="govuk-heading-m">Uploaded files</h2>
   {% if upload.count %}

--- a/src/server/plugins/engine/views/file-upload.html
+++ b/src/server/plugins/engine/views/file-upload.html
@@ -7,7 +7,7 @@
 {% block form %}
   {{ componentList(componentsBefore) }}
 
-  <form method="post" enctype="multipart/form-data" autocomplete="off" novalidate action="{{ formAction }}">
+  <form method="post" novalidate {%- if formAction %} action="{{ formAction }}" enctype="multipart/form-data" {%- endif %}>
     {{ govukFileUpload(formComponent.model) }}
 
     {% if formAction %}

--- a/src/server/plugins/engine/views/file-upload.html
+++ b/src/server/plugins/engine/views/file-upload.html
@@ -1,15 +1,14 @@
-{% extends 'index.html' %}
+{% extends "index.html" %}
 
-{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% set model = fileUploadComponent.model %}
-
 {% block form %}
-  {{ componentList(preUploadComponents) }}
+  {{ componentList(componentsBefore) }}
+
   <form method="post" enctype="multipart/form-data" autocomplete="off" novalidate action="{{ formAction }}">
-    {{ govukFileUpload(model) }}
+    {{ govukFileUpload(formComponent.model) }}
 
     {% if formAction %}
       {{ govukButton({
@@ -24,5 +23,6 @@
       }) }}
     {% endif %}
   </form>
-  {{super()}}
+
+  {{ super() }}
 {% endblock %}

--- a/src/server/views/summary.html
+++ b/src/server/views/summary.html
@@ -28,7 +28,7 @@
         {{ govukSummaryList(section.summaryList) }}
       {% endfor %}
 
-      <form method="post" autocomplete="off" novalidate>
+      <form method="post" novalidate>
         <input type="hidden" name="crumb" value="{{ crumb }}">
         <input type="hidden" name="action" value="send">
 


### PR DESCRIPTION
Bit of a tech debt PR

Uses the page collection to locate the file upload field and prefers general purpose view model names:

* `fileUploadComponent` → `formComponent`
* `preUploadComponents` → `componentsBefore`

Means we can use `collection.fields.indexOf()` when finding featured (file upload) form components etc