### PR TITLE
Use Joi to validate form params object

### DIFF
--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -90,16 +90,19 @@ export class FileUploadPageController extends QuestionPageController {
     this.viewName = 'file-upload'
   }
 
-  getFormData(request?: FormContextRequest) {
+  getFormDataFromState(
+    request: FormContextRequest | undefined,
+    state: FormSubmissionState
+  ) {
     const { fileUpload } = this
 
-    const formData = super.getFormData(request)
+    const payload = super.getFormDataFromState(request, state)
     const files = request?.app.files ?? []
 
     // Append the files to the payload
-    formData[fileUpload.name] = files.length ? files : undefined
+    payload[fileUpload.name] = files.length ? files : undefined
 
-    return formData
+    return payload
   }
 
   async getState(request: FormRequest | FormRequestPayload) {

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -199,7 +199,7 @@ export class FileUploadPageController extends QuestionPageController {
       const state = await this.getState(request)
       const uploadState = state.upload?.[path] ?? { files: [] }
 
-      const { confirm } = this.getFormData(request)
+      const { confirm } = this.getFormParams(request)
 
       // Check for any removed files in the POST payload
       if (confirm) {

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -186,13 +186,6 @@ export class QuestionPageController extends PageController {
   }
 
   /**
-   * Gets the form payload (from request) for this page only
-   */
-  getFormData(request?: FormContextRequest): FormSubmissionPayload {
-    return request?.payload ?? {}
-  }
-
-  /**
    * Gets the form payload (from state) for this page only
    */
   getFormDataFromState(
@@ -201,16 +194,23 @@ export class QuestionPageController extends PageController {
   ): FormPayload {
     const { collection } = this
 
-    // Form data from request
-    const formData = this.getFormData(request)
+    // Form params from request
+    const params = this.getFormParams(request)
 
     // Form payload from state
     const payload = collection.getFormDataFromState(state)
 
     return {
-      ...formData,
+      ...params,
       ...payload
     }
+  }
+
+  /**
+   * Gets form params (from payload) for this page only
+   */
+  getFormParams(request?: FormContextRequest): FormSubmissionPayload {
+    return request?.payload ?? {}
   }
 
   getStateFromValidForm(

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -199,8 +199,17 @@ export class QuestionPageController extends PageController {
     request: FormContextRequest | undefined,
     state: FormSubmissionState
   ): FormPayload {
+    const { collection } = this
+
+    // Form data from request
+    const formData = this.getFormData(request)
+
+    // Form payload from state
+    const payload = collection.getFormDataFromState(state)
+
     return {
-      ...this.collection.getFormDataFromState(state)
+      ...formData,
+      ...payload
     }
   }
 
@@ -383,7 +392,7 @@ export class QuestionPageController extends PageController {
       })
 
       // Sanitised payload after validation
-      const { value: payload, errors } = this.validate(request)
+      const { value: payload, errors } = this.validate(request, context.state)
 
       /**
        * If there are any errors, render the page with the parsed errors
@@ -426,11 +435,11 @@ export class QuestionPageController extends PageController {
     }
   }
 
-  validate(request: FormRequestPayload) {
+  validate(request: FormRequestPayload, state: FormSubmissionState) {
     const { collection } = this
 
-    const formData = this.getFormData(request)
-    return collection.validate(formData)
+    const payload = this.getFormDataFromState(request, state)
+    return collection.validate({ ...payload, ...request.payload })
   }
 
   proceed(

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -26,10 +26,10 @@ import {
   type FormContextProgress,
   type FormContextRequest,
   type FormPageViewModel,
+  type FormParams,
   type FormPayload,
   type FormState,
   type FormSubmissionError,
-  type FormSubmissionPayload,
   type FormSubmissionState
 } from '~/src/server/plugins/engine/types.js'
 import {
@@ -38,7 +38,11 @@ import {
   type FormRequestPayloadRefs,
   type FormRequestRefs
 } from '~/src/server/routes/types.js'
-import { actionSchema, crumbSchema } from '~/src/server/schemas/index.js'
+import {
+  actionSchema,
+  crumbSchema,
+  paramsSchema
+} from '~/src/server/schemas/index.js'
 
 export class QuestionPageController extends PageController {
   collection: ComponentCollection
@@ -209,8 +213,15 @@ export class QuestionPageController extends PageController {
   /**
    * Gets form params (from payload) for this page only
    */
-  getFormParams(request?: FormContextRequest): FormSubmissionPayload {
-    return request?.payload ?? {}
+  getFormParams(request?: FormContextRequest): FormParams {
+    const { payload } = request ?? {}
+
+    const result = paramsSchema.validate(payload, {
+      abortEarly: false,
+      stripUnknown: true
+    })
+
+    return result.value as FormParams
   }
 
   getStateFromValidForm(

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -58,19 +58,19 @@ export class RepeatPageController extends QuestionPageController {
   }
 
   getItemId(request?: FormContextRequest) {
-    const { itemId } = this.getFormData(request)
+    const { itemId } = this.getFormParams(request)
     return itemId ?? request?.params.itemId
   }
 
-  getFormData(request?: FormContextRequest) {
-    const formData = super.getFormData(request)
+  getFormParams(request?: FormContextRequest) {
+    const params = super.getFormParams(request)
 
     // Apply an itemId to the form payload
     if (request?.payload) {
-      formData.itemId = request.params.itemId ?? randomUUID()
+      params.itemId = request.params.itemId ?? randomUUID()
     }
 
-    return formData
+    return params
   }
 
   getStateFromValidForm(
@@ -252,7 +252,7 @@ export class RepeatPageController extends QuestionPageController {
         return super.proceed(request, h, nextPath)
       }
 
-      const { action } = this.getFormData(request)
+      const { action } = this.getFormParams(request)
 
       const hasErrorMin =
         action === FormAction.Continue && list.length < schema.min
@@ -364,7 +364,7 @@ export class RepeatPageController extends QuestionPageController {
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { repeat } = this
-      const { confirm } = this.getFormData(request)
+      const { confirm } = this.getFormParams(request)
 
       const { item, list } = await this.setRepeatAppData(request)
 

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -71,19 +71,18 @@ export interface FormSubmissionError
   text: string // e.g: 'Date field must be a real date'
 }
 
+export interface FormParams {
+  action?: FormAction
+  confirm?: true
+  crumb?: string
+  itemId?: string
+}
+
 /**
  * Form POST for question pages
  * (after Joi has converted value types)
  */
-export type FormSubmissionPayload = {
-  action?: FormAction
-  confirm?: boolean
-  crumb?: string
-} & FormPayload
-
-export type FormPayload = {
-  itemId?: string
-} & Partial<Record<string, FormValue>>
+export type FormPayload = FormParams & Partial<Record<string, FormValue>>
 
 export type FormValue =
   | Item['value']
@@ -145,7 +144,7 @@ export type FormContextRequest = (
     }
   | {
       method: 'post'
-      payload: FormSubmissionPayload
+      payload: FormPayload
     }
   | {
       method: FormRequest['method']

--- a/src/server/routes/types.ts
+++ b/src/server/routes/types.ts
@@ -1,6 +1,6 @@
 import { type ReqRefDefaults, type Request } from '@hapi/hapi'
 
-import { type FormSubmissionPayload } from '~/src/server/plugins/engine/types.js'
+import { type FormPayload } from '~/src/server/plugins/engine/types.js'
 
 export interface FormQuery extends Partial<Record<string, string>> {
   returnUrl?: string
@@ -20,7 +20,7 @@ export interface FormRequestRefs
 }
 
 export interface FormRequestPayloadRefs extends FormRequestRefs {
-  Payload: FormSubmissionPayload
+  Payload: FormPayload
 }
 
 export type FormRequest = Request<FormRequestRefs>

--- a/src/server/schemas/index.ts
+++ b/src/server/schemas/index.ts
@@ -1,12 +1,13 @@
 import Joi from 'joi'
 
+import { type FormParams } from '~/src/server/plugins/engine/types.js'
 import { FormAction, FormStatus } from '~/src/server/routes/types.js'
 
-export const stateSchema = Joi.string()
+export const stateSchema = Joi.string<FormStatus>()
   .valid(FormStatus.Draft, FormStatus.Live)
   .required()
 
-export const actionSchema = Joi.string()
+export const actionSchema = Joi.string<FormAction>()
   .valid(
     FormAction.Continue,
     FormAction.Delete,
@@ -19,4 +20,14 @@ export const actionSchema = Joi.string()
 export const pathSchema = Joi.string().required()
 export const itemIdSchema = Joi.string().uuid().required()
 export const crumbSchema = Joi.string().optional().allow('')
-export const confirmSchema = Joi.boolean().default(false)
+export const confirmSchema = Joi.boolean().empty(false)
+
+export const paramsSchema = Joi.object<FormParams>()
+  .keys({
+    action: actionSchema,
+    confirm: confirmSchema,
+    crumb: crumbSchema,
+    itemId: itemIdSchema.optional()
+  })
+  .default({})
+  .optional()


### PR DESCRIPTION
This PR renames page `getFormData()` to `getFormParams()` and adds Joi validation

For clarity, this prevents confusion with `getFormDataFromState()`

```patch
- const { confirm } = this.getFormData(request)
+ const { confirm } = this.getFormParams(request)
  
  // Check for any removed files in the POST payload
  if (confirm) {
```