### PR TITLE
Update confirm delete page, remove file sizes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,6 +28,12 @@ module.exports = {
       plugins: ['@typescript-eslint', 'import', 'jsdoc', 'n', 'promise'],
       rules: {
         'no-console': 'error',
+        'no-irregular-whitespace': [
+          'error',
+          {
+            skipTemplates: true
+          }
+        ],
 
         // Check type imports are identified
         '@typescript-eslint/consistent-type-imports': [

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -5,7 +5,6 @@ import {
   FormComponent,
   isUploadState
 } from '~/src/server/plugins/engine/components/FormComponent.js'
-import { filesize } from '~/src/server/plugins/engine/helpers.js'
 import {
   FileStatus,
   UploadStatus,
@@ -192,12 +191,7 @@ export class FileUploadField extends FormComponent {
 
       const valueHtml = render
         .view('components/fileuploadfield-value.html', {
-          context: {
-            params: {
-              size: filesize(file.contentLength),
-              tag
-            }
-          }
+          context: { params: { tag } }
         })
         .trim()
 

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -158,17 +158,6 @@ export function getStartPath(model?: FormModel) {
   return startPath ? `/${startPath}` : ControllerPath.Start
 }
 
-export const filesize = (bytes: number) => {
-  let i = -1
-  const byteUnits = [' kB', ' MB', ' GB', ' TB', 'PB', 'EB', 'ZB', 'YB']
-  do {
-    bytes = bytes / 1000
-    i++
-  } while (bytes > 1000)
-
-  return Math.max(bytes, 0.1).toFixed(1) + byteUnits[i]
-}
-
 export function checkFormStatus(path: string) {
   const isPreview = path.toLowerCase().startsWith(PREVIEW_PATH_PREFIX)
 

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -24,6 +24,7 @@ import {
   type FormPayload,
   type FormSubmissionError,
   type FormSubmissionState,
+  type ItemDeletePageViewModel,
   type UploadInitiateResponse,
   type UploadStatusFileResponse,
   type UploadStatusResponse
@@ -170,39 +171,20 @@ export class FileUploadPageController extends QuestionPageController {
         return Boom.notFound('File to delete not found')
       }
 
-      const { filename: itemTitle } = fileToRemove.status.form.file
+      const { filename } = fileToRemove.status.form.file
 
       state = await this.updateProgress(request, state)
       const { progress = [] } = state
 
       return h.view(this.fileDeleteViewName, {
         ...viewModel,
-
         backLink: this.getBackLink(progress),
-        showTitle: false,
-
-        field: {
-          name: 'confirm',
-          fieldset: {
-            legend: {
-              text: `Are you sure you want to remove ${itemTitle} from this form?`,
-              isPageHeading: true,
-              classes: 'govuk-fieldset__legend--l'
-            }
-          },
-          items: [
-            {
-              value: true,
-              text: `Yes, remove ${itemTitle}`
-            },
-            {
-              value: false,
-              text: 'No'
-            }
-          ],
-          value: true
-        }
-      })
+        pageTitle: `Are you sure you want to remove this file?`,
+        itemTitle: filename,
+        confirmation: { text: 'You cannot recover removed files.' },
+        buttonConfirm: { text: 'Remove file' },
+        buttonCancel: { text: 'Cancel' }
+      } satisfies ItemDeletePageViewModel)
     }
   }
 

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -15,6 +15,7 @@ import {
   type FormPayload,
   type FormSubmissionError,
   type FormSubmissionState,
+  type ItemDeletePageViewModel,
   type RepeatItemState,
   type RepeatListState,
   type SummaryList,
@@ -290,39 +291,18 @@ export class RepeatPageController extends QuestionPageController {
       }
 
       const { title } = this.repeat.options
-      const itemTitle = `${title} ${list.indexOf(item) + 1}`
 
       state = await this.updateProgress(request, state)
       const { progress = [] } = state
 
       return h.view(this.listDeleteViewName, {
         ...viewModel,
-
         backLink: this.getBackLink(progress),
-        showTitle: false,
-
-        field: {
-          name: 'confirm',
-          fieldset: {
-            legend: {
-              text: `Are you sure you want to remove ${itemTitle} from this form?`,
-              isPageHeading: true,
-              classes: 'govuk-fieldset__legend--l'
-            }
-          },
-          items: [
-            {
-              value: true,
-              text: `Yes, remove ${itemTitle}`
-            },
-            {
-              value: false,
-              text: 'No'
-            }
-          ],
-          value: true
-        }
-      })
+        pageTitle: `Are you sure you want to remove this ${title}?`,
+        itemTitle: `${title} ${list.indexOf(item) + 1}`,
+        buttonConfirm: { text: `Remove ${title}` },
+        buttonCancel: { text: 'Cancel' }
+      } satisfies ItemDeletePageViewModel)
     }
   }
 

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -267,6 +267,13 @@ export interface PageViewModelBase {
   googleAnalyticsTrackingId?: string
 }
 
+export interface ItemDeletePageViewModel extends PageViewModelBase {
+  itemTitle: string
+  confirmation?: ComponentText
+  buttonConfirm: ComponentText
+  buttonCancel: ComponentText
+}
+
 export interface FormPageViewModel extends PageViewModelBase {
   components: ComponentViewModel[]
   context?: FormContext
@@ -285,5 +292,6 @@ export interface FeaturedFormPageViewModel extends FormPageViewModel {
 
 export type PageViewModel =
   | PageViewModelBase
+  | ItemDeletePageViewModel
   | FormPageViewModel
   | FeaturedFormPageViewModel

--- a/src/server/plugins/engine/views/components/fileuploadfield-value.html
+++ b/src/server/plugins/engine/views/components/fileuploadfield-value.html
@@ -1,3 +1,3 @@
 {% from "govuk/components/tag/macro.njk" import govukTag -%}
 
-{{ params.size }} {{ govukTag(params.tag) }}
+{{ govukTag(params.tag) }}

--- a/src/server/plugins/engine/views/item-delete.html
+++ b/src/server/plugins/engine/views/item-delete.html
@@ -20,16 +20,32 @@
 
       {% include "partials/heading.html" %}
 
+      {% if confirmation %}
+        <p class="govuk-body govuk-!-margin-bottom-6">
+          {{ confirmation.html | safe if confirmation.html else confirmation.text }}
+        </p>
+      {% endif %}
+
       <form method="post" novalidate>
         <input type="hidden" name="crumb" value="{{ crumb }}">
         <input type="hidden" name="action" value="delete">
 
-        {{ govukRadios(field) }}
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: buttonConfirm.text,
+            html: buttonConfirm.html,
+            name: "confirm",
+            value: "true",
+            classes: "govuk-button--warning",
+            preventDoubleClick: true
+          }) }}
 
-        {{ govukButton({
-          text: "Continue",
-          preventDoubleClick: true
-        }) }}
+          {{ govukButton({
+            text: buttonCancel.text,
+            html: buttonCancel.html,
+            classes: "govuk-button--secondary"
+          }) }}
+        </div>
       </form>
     </div>
   </div>

--- a/src/server/plugins/engine/views/partials/heading.html
+++ b/src/server/plugins/engine/views/partials/heading.html
@@ -1,8 +1,16 @@
-{% if sectionTitle and (sectionTitle !== pageTitle) %}
-  <h2 class="govuk-caption-l govuk-!-margin-top-0" id="section-title">{{sectionTitle}}</h2>
+{% if sectionTitle and (sectionTitle !== pageTitle) or itemTitle %}
+  <h2 class="govuk-caption-l govuk-!-margin-top-0" id="section-title">
+    {% if sectionTitle and itemTitle %}
+      {{- sectionTitle }}: {{ itemTitle -}}
+    {% elif not sectionTitle %}
+      {{- itemTitle -}}
+    {% else %}
+      {{- sectionTitle -}}
+    {% endif %}
+  </h2>
 {% endif %}
 {% if showTitle %}
   <h1 class="govuk-heading-l">
-    {{pageTitle}}
+    {{ pageTitle }}
   </h1>
 {% endif %}


### PR DESCRIPTION
This PR includes design feedback for https://github.com/DEFRA/forms-runner/pull/619 to align with **forms-designer**

Reviewed by Dan and Alex as part of [bug #490120](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490120)

# Uploaded file sizes

Uploaded file sizes have been removed but [see design history](https://defra-forms-design-history-18deac2f53ea.herokuapp.com/private-beta-round3-4/) for more information

## Before

<img width="670" alt="File summary before" src="https://github.com/user-attachments/assets/198616d9-a2be-4d2f-8843-a4eff743054d" />

## After

<img width="671" alt="File summary after" src="https://github.com/user-attachments/assets/bf1a1259-2881-4b16-962d-74dd7530e65b" />

# Warning buttons

Confirmation radios have been replaced with [**warning buttons** for destructive actions](https://design-system.service.gov.uk/components/button/#warning-buttons)

<img width="579" alt="File upload confirm remove" src="https://github.com/user-attachments/assets/98fc446a-f4fb-4ea3-9d57-e9a8c6d2319e" />

<img width="585" alt="Repeater confirm remove" src="https://github.com/user-attachments/assets/9fd01455-ee1e-48df-b7ba-679d2a861ca9" />