### PR TITLE
Add support for release branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - 'releases/**'
+
     paths:
       - '.browserslistrc'
       - 'babel.config.*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,10 @@ on:
       - '!**/*.test.*'
 
   workflow_dispatch:
+    inputs:
+      version:
+        description: Version number (optional)
+        required: false
 
 concurrency:
   group: publish
@@ -42,3 +46,4 @@ jobs:
         uses: DEFRA/cdp-build-action/build@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ github.event.inputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ permissions:
 
 env:
   AWS_REGION: eu-west-2
-  AWS_ACCOUNT_ID: "094954420758"
+  AWS_ACCOUNT_ID: '094954420758'
 
 jobs:
   build:


### PR DESCRIPTION
This PR updates our [**Publish** GitHub Action](https://github.com/DEFRA/forms-runner/actions/workflows/publish.yml) to support releases from `release/**` branches

Closes feature [ticket #490606](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490606)