### PR TITLE
Fix missing repeater summary view model props

### DIFF
--- a/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.test.ts
@@ -2,103 +2,228 @@ import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { RepeatPageController } from '~/src/server/plugins/engine/pageControllers/RepeatPageController.js'
 import {
   type FormContextRequest,
-  type FormSubmissionError
+  type FormPageViewModel,
+  type FormSubmissionError,
+  type RepeatListState,
+  type RepeaterSummaryPageViewModel
 } from '~/src/server/plugins/engine/types.js'
 import definition from '~/test/form/definitions/repeat.js'
 
 describe('RepeatPageController', () => {
+  const itemId1 = 'abc-123'
+  const itemId2 = 'xyz-987'
+
+  let pageUrl: URL
+  let pageItemUrl: URL
+  let pageSummaryUrl: URL
+
   let model: FormModel
   let controller: RepeatPageController
+  let requestPage: FormContextRequest
+  let requestPageItem: FormContextRequest
+  let requestPageSummary: FormContextRequest
 
   beforeEach(() => {
     const { pages } = definition
+
+    pageUrl = new URL('/repeat/pizza-order', 'http://example.com')
+
+    pageItemUrl = new URL(
+      `${pageUrl.pathname}/${itemId1}?itemId=${itemId2}`,
+      'http://example.com'
+    )
+
+    pageSummaryUrl = new URL(
+      `${pageUrl.pathname}/summary?itemId=${itemId2}`,
+      'http://example.com'
+    )
 
     model = new FormModel(definition, {
       basePath: 'test'
     })
 
     controller = new RepeatPageController(model, pages[0])
+
+    requestPage = {
+      method: 'get',
+      url: pageUrl,
+      path: pageUrl.pathname,
+      params: {
+        path: 'pizza-order',
+        slug: 'repeat'
+      },
+      query: {},
+      app: { model }
+    }
+
+    requestPageItem = {
+      method: 'get',
+      url: pageItemUrl,
+      path: pageItemUrl.pathname,
+      params: {
+        path: 'pizza-order',
+        slug: 'repeat',
+        itemId: itemId1
+      },
+      query: {
+        itemId: itemId2
+      },
+      app: { model }
+    }
+
+    requestPageSummary = {
+      method: 'get',
+      url: pageSummaryUrl,
+      path: pageSummaryUrl.pathname,
+      params: {
+        path: 'pizza-order',
+        slug: 'repeat'
+      },
+      query: {
+        itemId: itemId2
+      },
+      app: { model }
+    }
+  })
+
+  describe('Properties', () => {
+    it('returns summary view name', () => {
+      expect(controller).toHaveProperty(
+        'listSummaryViewName',
+        'repeat-list-summary'
+      )
+    })
+
+    it('returns delete view name', () => {
+      expect(controller).toHaveProperty('listDeleteViewName', 'item-delete')
+    })
+
+    it('returns repeater config', () => {
+      expect(controller).toHaveProperty('repeat', {
+        options: {
+          name: 'pizza',
+          title: 'Pizza'
+        },
+        schema: {
+          max: 3,
+          min: 2
+        }
+      })
+    })
   })
 
   describe('Path methods', () => {
     describe('Summary path', () => {
-      let request: FormContextRequest
-
-      const itemId1 = 'abc-123'
-      const itemId2 = 'xyz-987'
-
       it('returns path to summary page', () => {
         expect(controller.getSummaryPath()).toBe('/summary')
       })
 
       it('returns path to repeater summary page', () => {
-        const pageUrl = new URL('http://example.com/repeat/pizza-order')
-
-        request = {
-          method: 'get',
-          url: pageUrl,
-          path: pageUrl.pathname,
-          params: {
-            path: 'pizza-order',
-            slug: 'repeat'
-          },
-          query: {},
-          app: { model }
-        }
-
-        expect(controller.getSummaryPath(request)).toBe('/pizza-order/summary')
+        expect(controller.getSummaryPath(requestPage)).toBe(
+          '/pizza-order/summary'
+        )
       })
 
       it('adds item ID query when in params', () => {
-        const pageUrl = new URL(
-          `/repeat/pizza-order/${itemId1}?itemId=${itemId2}`,
-          'http://example.com'
-        )
-
-        request = {
-          method: 'get',
-          url: pageUrl,
-          path: pageUrl.pathname,
-          params: {
-            path: 'pizza-order',
-            slug: 'repeat',
-            itemId: itemId1
-          },
-          query: {
-            itemId: itemId2
-          },
-          app: { model }
-        }
-
-        expect(controller.getSummaryPath(request)).toBe(
+        expect(controller.getSummaryPath(requestPageItem)).toBe(
           `/pizza-order/summary?itemId=${itemId1}`
         )
       })
 
       it('removes item ID query when not in params', () => {
-        const pageUrl = new URL(
-          `/repeat/pizza-order?itemId=${itemId2}`,
-          'http://example.com'
+        expect(controller.getSummaryPath(requestPageSummary)).toBe(
+          '/pizza-order/summary'
         )
-
-        request = {
-          method: 'get',
-          url: pageUrl,
-          path: pageUrl.pathname,
-          params: {
-            path: 'pizza-order',
-            slug: 'repeat'
-          },
-          query: {
-            itemId: itemId2
-          },
-          app: { model }
-        }
-
-        expect(controller.getSummaryPath(request)).toBe('/pizza-order/summary')
       })
     })
   })
+
+  describe('Item view model', () => {
+    let viewModel: FormPageViewModel
+
+    beforeEach(() => {
+      viewModel = controller.getViewModel(requestPageItem, {}, {})
+    })
+
+    it('updates section title with repeater title and count', () => {
+      expect(viewModel).toHaveProperty('sectionTitle', 'Food: Pizza 1')
+    })
+  })
+
+  describe.each([
+    {
+      description: 'No items',
+      list: [] satisfies RepeatListState,
+      viewModel: {
+        pageTitle: 'You have added 0 Pizzas',
+        showTitle: true,
+        sectionTitle: 'Food'
+      }
+    },
+    {
+      description: '1 item',
+      list: [
+        {
+          itemId: itemId1,
+          toppings: 'Ham',
+          quantity: 2
+        }
+      ] satisfies RepeatListState,
+      viewModel: {
+        pageTitle: 'You have added 1 Pizza',
+        showTitle: true,
+        sectionTitle: 'Food'
+      }
+    },
+    {
+      description: '2 items',
+      list: [
+        {
+          itemId: itemId1,
+          toppings: 'Ham',
+          quantity: 2
+        },
+        {
+          itemId: itemId2,
+          toppings: 'Cheese',
+          quantity: 1
+        }
+      ] satisfies RepeatListState,
+      viewModel: {
+        pageTitle: 'You have added 2 Pizzas',
+        showTitle: true,
+        sectionTitle: 'Food'
+      }
+    }
+  ])(
+    'List summary view model ($description)',
+    ({ list, viewModel: expected }) => {
+      let viewModel: RepeaterSummaryPageViewModel
+
+      beforeEach(() => {
+        viewModel = controller.getListSummaryViewModel(requestPageSummary, list)
+      })
+
+      it('should customise page title', () => {
+        expect(viewModel).toHaveProperty('pageTitle', expected.pageTitle)
+        expect(viewModel).toHaveProperty('showTitle', expected.showTitle)
+      })
+
+      it('should extend default view model', () => {
+        const defaults = controller.viewModel
+
+        expect(viewModel).toHaveProperty('name', defaults.name)
+        expect(viewModel).toHaveProperty('page', defaults.page)
+        expect(viewModel).toHaveProperty('sectionTitle', expected.sectionTitle)
+        expect(viewModel).toHaveProperty('isStartPage', defaults.isStartPage)
+        expect(viewModel).toHaveProperty('serviceUrl', defaults.serviceUrl)
+        expect(viewModel).toHaveProperty('feedbackLink', defaults.feedbackLink)
+
+        // Unless overridden
+        expect(viewModel).not.toHaveProperty('pageTitle', defaults.pageTitle)
+      })
+    }
+  )
 
   describe('Form validation', () => {
     it('includes title text and errors', () => {

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -9,7 +9,6 @@ import { isRepeatState } from '~/src/server/plugins/engine/components/FormCompon
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
 import {
-  type CheckAnswers,
   type FormContextRequest,
   type FormPageViewModel,
   type FormPayload,
@@ -18,6 +17,7 @@ import {
   type ItemDeletePageViewModel,
   type RepeatItemState,
   type RepeatListState,
+  type RepeaterSummaryPageViewModel,
   type SummaryList,
   type SummaryListAction
 } from '~/src/server/plugins/engine/types.js'
@@ -371,21 +371,10 @@ export class RepeatPageController extends QuestionPageController {
     request: FormContextRequest,
     list: RepeatListState,
     errors?: FormSubmissionError[]
-  ): {
-    name: string | undefined
-    pageTitle: string
-    sectionTitle: string | undefined
-    showTitle: boolean
-    serviceUrl: string
-    errors?: FormSubmissionError[]
-    checkAnswers: CheckAnswers[]
-    repeatTitle: string
-    backLink?: string
-  } {
-    const { collection, href, repeat, section } = this
+  ): RepeaterSummaryPageViewModel {
+    const { collection, href, repeat } = this
 
     const { title } = repeat.options
-    const sectionTitle = section?.hideTitle !== true ? section?.title : ''
 
     const summaryList: SummaryList = {
       classes: 'govuk-summary-list--long-actions',
@@ -435,14 +424,12 @@ export class RepeatPageController extends QuestionPageController {
     }
 
     return {
-      name: this.name,
+      ...this.viewModel,
+      repeatTitle: title,
       pageTitle: `You have added ${count} ${title}${count === 1 ? '' : 's'}`,
-      sectionTitle,
       showTitle: true,
       errors,
-      serviceUrl: this.getHref('/'),
-      checkAnswers: [{ summaryList }],
-      repeatTitle: title
+      checkAnswers: [{ summaryList }]
     }
   }
 

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -264,7 +264,6 @@ export interface PageViewModelBase {
   feedbackLink?: string
   serviceUrl: string
   phaseTag?: string
-  googleAnalyticsTrackingId?: string
 }
 
 export interface ItemDeletePageViewModel extends PageViewModelBase {

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -283,6 +283,12 @@ export interface FormPageViewModel extends PageViewModelBase {
   }
 }
 
+export interface RepeaterSummaryPageViewModel extends PageViewModelBase {
+  errors?: FormSubmissionError[]
+  checkAnswers: CheckAnswers[]
+  repeatTitle: string
+}
+
 export interface FeaturedFormPageViewModel extends FormPageViewModel {
   formAction?: string
   formComponent: ComponentViewModel
@@ -293,4 +299,5 @@ export type PageViewModel =
   | PageViewModelBase
   | ItemDeletePageViewModel
   | FormPageViewModel
+  | RepeaterSummaryPageViewModel
   | FeaturedFormPageViewModel


### PR DESCRIPTION
I’ve found more view model props we need to add to the repeater summary page in [bug #490109](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490109)

## View model missing props

```
page: PageController
isStartPage: boolean
feedbackLink?: string
phaseTag?: string
```

Low impact, but in the UI you’ll see the phase banner and feedback link revert back to their defaults for this page only

<img width="691" alt="Missing view model props" src="https://github.com/user-attachments/assets/aa40ee2d-4839-4ac6-b0f9-bf7de8921040" />
