### PR TITLE
Allow preview URL direct access using `?force`

### DIFF
--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -28,6 +28,7 @@ import {
   type FormSubmissionState,
   type FormValidationResult
 } from '~/src/server/plugins/engine/types.js'
+import { type FormQuery } from '~/src/server/routes/types.js'
 
 export class ComponentCollection {
   page?: PageControllerClass
@@ -232,7 +233,11 @@ export class ComponentCollection {
     return list
   }
 
-  getViewModel(payload: FormPayload, errors?: FormSubmissionError[]) {
+  getViewModel(
+    payload: FormPayload,
+    errors?: FormSubmissionError[],
+    query: FormQuery = {}
+  ) {
     const { components } = this
 
     const result: ComponentViewModel[] = components.map((component) => {
@@ -240,7 +245,7 @@ export class ComponentCollection {
 
       const model =
         component instanceof FormComponent
-          ? component.getViewModel(payload, errors)
+          ? component.getViewModel(payload, errors, query)
           : component.getViewModel()
 
       return { type, isFormComponent, model }

--- a/src/server/plugins/engine/components/FileUploadField.test.ts
+++ b/src/server/plugins/engine/components/FileUploadField.test.ts
@@ -407,6 +407,68 @@ describe('FileUploadField', () => {
         )
       })
 
+      it('sets Nunjucks component defaults (preview URL direct access)', () => {
+        const viewModel = field.getViewModel(
+          getFormData(validState),
+          undefined,
+
+          // Preview URL '?force'
+          { force: '' }
+        )
+
+        expect(viewModel).toEqual(
+          expect.objectContaining({
+            label: { text: def.title },
+            name: 'file', // hardcoded to 'file' for CDP
+            id: 'myComponent',
+            value: '', // input type=file can't have a default value
+            upload: {
+              count: 3,
+              pendingCount: 0,
+              successfulCount: 3,
+              summaryList: {
+                classes: 'govuk-summary-list--long-key',
+                rows: [
+                  {
+                    key: {
+                      html: expect.stringContaining('SampleJPGImage_30mbmb.jpg')
+                    },
+                    value: {
+                      html: expect.stringContaining('Uploaded')
+                    },
+                    actions: {
+                      items: []
+                    }
+                  },
+                  {
+                    key: {
+                      html: expect.stringContaining('error-messages.txt')
+                    },
+                    value: {
+                      html: expect.stringContaining('Uploaded')
+                    },
+                    actions: {
+                      items: []
+                    }
+                  },
+                  {
+                    key: {
+                      html: expect.stringContaining('SampleJPGImage_20mbmb.jpg')
+                    },
+                    value: {
+                      html: expect.stringContaining('Uploaded')
+                    },
+                    actions: {
+                      items: []
+                    }
+                  }
+                ]
+              }
+            }
+          })
+        )
+      })
+
       it('sets Nunjucks component defaults with temp valid state', () => {
         const viewModel = field.getViewModel(getFormData(validTempState))
 

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -201,11 +201,16 @@ export class FormModel {
    * Form context for the current page
    */
   getFormContext(request: FormContextRequest, state: FormState): FormContext {
+    const { query } = request
+
     const page = getPage(this, request)
 
     // Determine form paths
     const currentPath = page.path
     const startPath = page.getStartPath()
+
+    // Preview URL direct access is allowed
+    const isForceAccess = 'force' in query
 
     let context: FormContext = {
       evaluationState: {},
@@ -213,7 +218,8 @@ export class FormModel {
       relevantPages: [],
       payload: page.getFormDataFromState(request, state),
       state,
-      paths: []
+      paths: [],
+      isForceAccess
     }
 
     // Validate current page

--- a/src/server/plugins/engine/models/SummaryViewModel.test.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.test.ts
@@ -1,9 +1,11 @@
-import { type PageSummary } from '@defra/forms-model'
-
 import {
   FormModel,
   SummaryViewModel
 } from '~/src/server/plugins/engine/models/index.js'
+import {
+  createPage,
+  type PageControllerClass
+} from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import {
   type FormContext,
   type FormContextRequest,
@@ -19,7 +21,7 @@ describe('SummaryViewModel', () => {
 
   let model: FormModel
   let state: FormState
-  let pageDef: PageSummary
+  let page: PageControllerClass
   let pageUrl: URL
   let request: FormContextRequest
   let context: FormContext
@@ -46,7 +48,7 @@ describe('SummaryViewModel', () => {
       ]
     }
 
-    pageDef = definition.pages[2]
+    page = createPage(model, definition.pages[2])
     pageUrl = new URL('http://example.com/repeat/pizza-order/summary')
 
     request = {
@@ -62,7 +64,7 @@ describe('SummaryViewModel', () => {
     }
 
     context = model.getFormContext(request, state)
-    summaryViewModel = new SummaryViewModel(model, pageDef, request, context)
+    summaryViewModel = new SummaryViewModel(request, page, context)
   })
 
   describe('Check answers', () => {
@@ -134,7 +136,7 @@ describe('SummaryViewModel', () => {
     it('should add summary list for each section (preview URL direct access)', () => {
       request.query.force = '' // Preview URL '?force'
       context = model.getFormContext(request, state)
-      summaryViewModel = new SummaryViewModel(model, pageDef, request, context)
+      summaryViewModel = new SummaryViewModel(request, page, context)
 
       expect(summaryViewModel.checkAnswers).toHaveLength(2)
 

--- a/src/server/plugins/engine/models/SummaryViewModel.test.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.test.ts
@@ -20,7 +20,6 @@ describe('SummaryViewModel', () => {
   const itemId2 = 'xyz-987'
 
   let model: FormModel
-  let state: FormState
   let page: PageControllerClass
   let pageUrl: URL
   let request: FormContextRequest
@@ -31,22 +30,6 @@ describe('SummaryViewModel', () => {
     model = new FormModel(definition, {
       basePath: 'test'
     })
-
-    state = {
-      orderType: 'delivery',
-      pizza: [
-        {
-          toppings: 'Ham',
-          quantity: 2,
-          itemId: itemId1
-        },
-        {
-          toppings: 'Pepperoni',
-          quantity: 1,
-          itemId: itemId2
-        }
-      ]
-    }
 
     page = createPage(model, definition.pages[2])
     pageUrl = new URL('http://example.com/repeat/pizza-order/summary')
@@ -62,12 +45,59 @@ describe('SummaryViewModel', () => {
       query: {},
       app: { model }
     }
-
-    context = model.getFormContext(request, state)
-    summaryViewModel = new SummaryViewModel(request, page, context)
   })
 
-  describe('Check answers', () => {
+  describe.each([
+    {
+      description: '0 items',
+      state: {
+        orderType: 'collection',
+        pizza: []
+      } satisfies FormState,
+      keys: ['How would you like to receive your pizza?', 'Pizzas'],
+      values: ['Collection', 'Not supplied']
+    },
+    {
+      description: '1 item',
+      state: {
+        orderType: 'delivery',
+        pizza: [
+          {
+            toppings: 'Ham',
+            quantity: 2,
+            itemId: itemId1
+          }
+        ]
+      } satisfies FormState,
+      keys: ['How would you like to receive your pizza?', 'Pizza added'],
+      values: ['Delivery', 'You added 1 Pizza']
+    },
+    {
+      description: '2 items',
+      state: {
+        orderType: 'delivery',
+        pizza: [
+          {
+            toppings: 'Ham',
+            quantity: 2,
+            itemId: itemId1
+          },
+          {
+            toppings: 'Pepperoni',
+            quantity: 1,
+            itemId: itemId2
+          }
+        ]
+      } satisfies FormState,
+      keys: ['How would you like to receive your pizza?', 'Pizzas added'],
+      values: ['Delivery', 'You added 2 Pizzas']
+    }
+  ])('Check answers ($description)', ({ state, keys, values }) => {
+    beforeEach(() => {
+      context = model.getFormContext(request, state)
+      summaryViewModel = new SummaryViewModel(request, page, context)
+    })
+
     it('should add title for each section', () => {
       const [checkAnswers1, checkAnswers2] = summaryViewModel.checkAnswers
 
@@ -91,11 +121,11 @@ describe('SummaryViewModel', () => {
       expect(summaryList1).toHaveProperty('rows', [
         {
           key: {
-            text: 'How would you like to receive your pizza?'
+            text: keys[0]
           },
           value: {
             classes: 'app-prose-scope',
-            html: 'Delivery'
+            html: values[0]
           },
           actions: {
             items: [
@@ -103,7 +133,7 @@ describe('SummaryViewModel', () => {
                 classes: 'govuk-link--no-visited-state',
                 href: `${basePath}/delivery-or-collection?returnUrl=${encodeURIComponent(`${basePath}/summary`)}`,
                 text: 'Change',
-                visuallyHiddenText: 'How would you like to receive your pizza?'
+                visuallyHiddenText: keys[0]
               }
             ]
           }
@@ -113,11 +143,11 @@ describe('SummaryViewModel', () => {
       expect(summaryList2).toHaveProperty('rows', [
         {
           key: {
-            text: 'Pizzas added'
+            text: keys[1]
           },
           value: {
             classes: 'app-prose-scope',
-            html: 'You added 2 Pizzas'
+            html: values[1]
           },
           actions: {
             items: [
@@ -148,11 +178,11 @@ describe('SummaryViewModel', () => {
       expect(summaryList1).toHaveProperty('rows', [
         {
           key: {
-            text: 'How would you like to receive your pizza?'
+            text: keys[0]
           },
           value: {
             classes: 'app-prose-scope',
-            html: 'Delivery'
+            html: values[0]
           },
           actions: {
             items: []
@@ -163,11 +193,11 @@ describe('SummaryViewModel', () => {
       expect(summaryList2).toHaveProperty('rows', [
         {
           key: {
-            text: 'Pizzas added'
+            text: keys[1]
           },
           value: {
             classes: 'app-prose-scope',
-            html: 'You added 2 Pizzas'
+            html: values[1]
           },
           actions: {
             items: []

--- a/src/server/plugins/engine/models/SummaryViewModel.test.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.test.ts
@@ -1,10 +1,13 @@
+import { type PageSummary } from '@defra/forms-model'
+
 import {
   FormModel,
   SummaryViewModel
 } from '~/src/server/plugins/engine/models/index.js'
 import {
   type FormContext,
-  type FormContextRequest
+  type FormContextRequest,
+  type FormState
 } from '~/src/server/plugins/engine/types.js'
 import definition from '~/test/form/definitions/repeat-mixed.js'
 
@@ -14,15 +17,20 @@ describe('SummaryViewModel', () => {
   const itemId1 = 'abc-123'
   const itemId2 = 'xyz-987'
 
+  let model: FormModel
+  let state: FormState
+  let pageDef: PageSummary
+  let pageUrl: URL
+  let request: FormContextRequest
   let context: FormContext
   let summaryViewModel: SummaryViewModel
 
   beforeEach(() => {
-    const model = new FormModel(definition, {
+    model = new FormModel(definition, {
       basePath: 'test'
     })
 
-    const state = {
+    state = {
       orderType: 'delivery',
       pizza: [
         {
@@ -38,10 +46,10 @@ describe('SummaryViewModel', () => {
       ]
     }
 
-    const pageDef = definition.pages[2]
-    const pageUrl = new URL('http://example.com/repeat/pizza-order/summary')
+    pageDef = definition.pages[2]
+    pageUrl = new URL('http://example.com/repeat/pizza-order/summary')
 
-    const request = {
+    request = {
       method: 'get',
       url: pageUrl,
       path: pageUrl.pathname,
@@ -51,7 +59,7 @@ describe('SummaryViewModel', () => {
       },
       query: {},
       app: { model }
-    } satisfies FormContextRequest
+    }
 
     context = model.getFormContext(request, state)
     summaryViewModel = new SummaryViewModel(model, pageDef, request, context)
@@ -118,6 +126,49 @@ describe('SummaryViewModel', () => {
                 visuallyHiddenText: 'Pizza'
               }
             ]
+          }
+        }
+      ])
+    })
+
+    it('should add summary list for each section (preview URL direct access)', () => {
+      request.query.force = '' // Preview URL '?force'
+      context = model.getFormContext(request, state)
+      summaryViewModel = new SummaryViewModel(model, pageDef, request, context)
+
+      expect(summaryViewModel.checkAnswers).toHaveLength(2)
+
+      const [checkAnswers1, checkAnswers2] = summaryViewModel.checkAnswers
+
+      const { summaryList: summaryList1 } = checkAnswers1
+      const { summaryList: summaryList2 } = checkAnswers2
+
+      expect(summaryList1).toHaveProperty('rows', [
+        {
+          key: {
+            text: 'How would you like to receive your pizza?'
+          },
+          value: {
+            classes: 'app-prose-scope',
+            html: 'Delivery'
+          },
+          actions: {
+            items: []
+          }
+        }
+      ])
+
+      expect(summaryList2).toHaveProperty('rows', [
+        {
+          key: {
+            text: 'Pizzas added'
+          },
+          value: {
+            classes: 'app-prose-scope',
+            html: 'You added 2 Pizzas'
+          },
+          actions: {
+            items: []
           }
         }
       ])

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -22,6 +22,7 @@ import {
   type FormContextRequest,
   type FormState,
   type FormSubmissionError,
+  type SummaryListAction,
   type SummaryListRow
 } from '~/src/server/plugins/engine/types.js'
 
@@ -53,6 +54,7 @@ export class SummaryViewModel {
     context: FormContext
   ) {
     const { basePath, def, sections } = model
+    const { isForceAccess } = context
 
     this.pageTitle = pageDef.title
     this.serviceUrl = `/${basePath}`
@@ -70,9 +72,21 @@ export class SummaryViewModel {
 
     // Format check answers
     this.checkAnswers = this.details.map((detail): CheckAnswers => {
-      const { items, title } = detail
+      const { title } = detail
 
-      const rows = items.map((item): SummaryListRow => {
+      const rows = detail.items.map((item): SummaryListRow => {
+        const items: SummaryListAction[] = []
+
+        // Remove summary list actions from previews
+        if (!isForceAccess) {
+          items.push({
+            href: item.href,
+            text: 'Change',
+            classes: 'govuk-link--no-visited-state',
+            visuallyHiddenText: item.label
+          })
+        }
+
         return {
           key: {
             text: item.title
@@ -82,14 +96,7 @@ export class SummaryViewModel {
             html: item.value || 'Not supplied'
           },
           actions: {
-            items: [
-              {
-                href: item.href,
-                text: 'Change',
-                classes: 'govuk-link--no-visited-state',
-                visuallyHiddenText: item.label
-              }
-            ]
+            items
           }
         }
       })

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -174,7 +174,7 @@ function ItemRepeat(
     name,
     label: title,
     title: values.length ? `${unit} added` : unit,
-    value: `You added ${values.length} ${unit}`,
+    value: values.length ? `You added ${values.length} ${unit}` : '',
     href: getPageHref(page, options.path, {
       returnUrl: getPageHref(page, page.getSummaryPath())
     }),

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -1,4 +1,4 @@
-import { type PageSummary, type Section } from '@defra/forms-model'
+import { type Section } from '@defra/forms-model'
 
 import {
   getAnswer,
@@ -6,7 +6,6 @@ import {
 } from '~/src/server/plugins/engine/components/helpers.js'
 import { type BackLink } from '~/src/server/plugins/engine/components/types.js'
 import { getError, getPageHref } from '~/src/server/plugins/engine/helpers.js'
-import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   type Detail,
   type DetailItem,
@@ -31,6 +30,7 @@ export class SummaryViewModel {
    * Responsible for parsing state values to the govuk-frontend summary list template
    */
 
+  page: PageControllerClass
   pageTitle: string
   declaration?: string
   details: Detail[]
@@ -48,15 +48,16 @@ export class SummaryViewModel {
   }
 
   constructor(
-    model: FormModel,
-    pageDef: PageSummary,
     request: FormContextRequest,
+    page: PageControllerClass,
     context: FormContext
   ) {
+    const { model } = page
     const { basePath, def, sections } = model
     const { isForceAccess } = context
 
-    this.pageTitle = pageDef.title
+    this.page = page
+    this.pageTitle = page.title
     this.serviceUrl = `/${basePath}`
     this.name = def.name
     this.declaration = def.declaration

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -41,6 +41,7 @@ import {
   crumbSchema,
   paramsSchema
 } from '~/src/server/schemas/index.js'
+import { merge } from '~/src/server/services/cacheService.js'
 
 export class QuestionPageController extends PageController {
   collection: ComponentCollection
@@ -243,6 +244,13 @@ export class QuestionPageController extends PageController {
   }
 
   async getState(request: FormRequest | FormRequestPayload) {
+    const { query } = request
+
+    // Skip get for preview URL direct access
+    if ('force' in query) {
+      return {}
+    }
+
     const { cacheService } = request.services([])
     return cacheService.getState(request)
   }
@@ -251,6 +259,13 @@ export class QuestionPageController extends PageController {
     request: FormRequest | FormRequestPayload,
     state: FormSubmissionState
   ) {
+    const { query } = request
+
+    // Skip set for preview URL direct access
+    if ('force' in query) {
+      return state
+    }
+
     const { cacheService } = request.services([])
     return cacheService.setState(request, state)
   }
@@ -260,8 +275,18 @@ export class QuestionPageController extends PageController {
     state: FormSubmissionState,
     update: object
   ) {
+    const { query } = request
+
+    // Merge state before set
+    const updated = merge(state, update)
+
+    // Skip set for preview URL direct access
+    if ('force' in query) {
+      return updated
+    }
+
     const { cacheService } = request.services([])
-    return cacheService.mergeState(request, state, update)
+    return cacheService.setState(request, updated)
   }
 
   makeGetRouteHandler() {

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -321,23 +321,25 @@ export class QuestionPageController extends PageController {
       })
 
       viewModel.notificationEmailWarning =
-        await this.buildMissingEmailWarningModel(request)
+        await this.buildMissingEmailWarningModel(request, context)
 
       return h.view(viewName, viewModel)
     }
   }
 
   async buildMissingEmailWarningModel(
-    request: FormRequest
+    request: FormRequest,
+    context: FormContext
   ): Promise<FormPageViewModel['notificationEmailWarning']> {
     const { path } = this
     const { params } = request
+    const { isForceAccess } = context
 
     const startPath = this.getStartPath()
     const summaryPath = this.getSummaryPath()
 
     // Warn the user if the form has no notification email set only on start page and summary page
-    if ([startPath, summaryPath].includes(path)) {
+    if ([startPath, summaryPath].includes(path) && !isForceAccess) {
       const { notificationEmail } = await getFormMetadata(params.slug)
 
       if (!notificationEmail) {

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -425,13 +425,13 @@ export class QuestionPageController extends PageController {
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
       const { collection, viewName } = this
-      const { state } = context
+      const { isForceAccess, state } = context
 
       /**
        * If there are any errors, render the page with the parsed errors
        * @todo Refactor to match POST REDIRECT GET pattern
        */
-      if (context.errors) {
+      if (context.errors || isForceAccess) {
         const viewModel = this.getViewModel(request, context)
         viewModel.errors = collection.getErrors(viewModel.errors)
 

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -94,11 +94,12 @@ export class QuestionPageController extends PageController {
     context: FormContext
   ): FormPageViewModel {
     const { collection, viewModel } = this
+    const { query } = request
     const { payload, errors } = context
 
     let { pageTitle, showTitle } = viewModel
 
-    const components = collection.getViewModel(payload, errors)
+    const components = collection.getViewModel(payload, errors, query)
     const formComponents = components.filter(
       ({ isFormComponent }) => isFormComponent
     )

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -163,7 +163,8 @@ export class RepeatPageController extends QuestionPageController {
       if (!itemId) {
         const summaryPath = this.getSummaryPath(request)
         const nextPath = redirectPath(`${path}/${randomUUID()}`, {
-          returnUrl: query.returnUrl
+          returnUrl: query.returnUrl,
+          force: query.force
         })
 
         // Only redirect to new item when list is empty

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -368,7 +368,7 @@ export class RepeatPageController extends QuestionPageController {
   ): RepeaterSummaryPageViewModel {
     const { collection, href, repeat } = this
     const { query } = request
-    const { errors } = context
+    const { isForceAccess, errors } = context
 
     const { title } = repeat.options
 
@@ -385,26 +385,29 @@ export class RepeatPageController extends QuestionPageController {
       const summaryPath = this.getSummaryPath(request)
 
       list.forEach((item, index) => {
-        const items: SummaryListAction[] = [
-          {
+        const items: SummaryListAction[] = []
+
+        // Remove summary list actions from previews
+        if (!isForceAccess) {
+          items.push({
             href: redirectPath(`${href}/${item.itemId}`, {
               returnUrl: query.returnUrl ?? this.getHref(summaryPath)
             }),
             text: 'Change',
             classes: 'govuk-link--no-visited-state',
             visuallyHiddenText: `item ${index + 1}`
-          }
-        ]
-
-        if (count > 1) {
-          items.push({
-            href: redirectPath(`${href}/${item.itemId}/confirm-delete`, {
-              returnUrl: query.returnUrl
-            }),
-            text: 'Remove',
-            classes: 'govuk-link--no-visited-state',
-            visuallyHiddenText: `item ${index + 1}`
           })
+
+          if (count > 1) {
+            items.push({
+              href: redirectPath(`${href}/${item.itemId}/confirm-delete`, {
+                returnUrl: query.returnUrl
+              }),
+              text: 'Remove',
+              classes: 'govuk-link--no-visited-state',
+              visuallyHiddenText: `item ${index + 1}`
+            })
+          }
         }
 
         const itemDisplayText = collection.fields.length

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -62,12 +62,7 @@ export class SummaryPageController extends QuestionPageController {
     request: FormContextRequest,
     context: FormContext
   ): SummaryViewModel {
-    const viewModel = new SummaryViewModel(
-      this.model,
-      this.pageDef,
-      request,
-      context
-    )
+    const viewModel = new SummaryViewModel(request, this, context)
 
     // We already figure these out in the base page controller. Take them and apply them to our page-specific model.
     // This is a stop-gap until we can add proper inheritance in place.

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -92,7 +92,7 @@ export class SummaryPageController extends QuestionPageController {
       const viewModel = this.getSummaryViewModel(request, context)
 
       viewModel.notificationEmailWarning =
-        await this.buildMissingEmailWarningModel(request)
+        await this.buildMissingEmailWarningModel(request, context)
 
       return h.view(viewName, viewModel)
     }

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -1,4 +1,4 @@
-import { slugSchema } from '@defra/forms-model'
+import { hasFormComponents, slugSchema } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import {
   type Plugin,
@@ -17,7 +17,8 @@ import {
   getPage,
   getStartPath,
   normalisePath,
-  proceed
+  proceed,
+  redirectPath
 } from '~/src/server/plugins/engine/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { FileUploadPageController } from '~/src/server/plugins/engine/pageControllers/FileUploadPageController.js'
@@ -205,9 +206,19 @@ export const plugin = {
       request: FormRequestPayload,
       h: Pick<ResponseToolkit, 'redirect' | 'view'>
     ) => {
-      return redirectOrMakeHandler(request, h, (page, context) =>
-        page.makePostRouteHandler()(request, context, h)
-      )
+      const { query } = request
+
+      return redirectOrMakeHandler(request, h, (page, context) => {
+        const { pageDef } = page
+        const { isForceAccess } = context
+
+        // Redirect to GET for preview URL direct access
+        if (isForceAccess && !hasFormComponents(pageDef)) {
+          return proceed(request, h, redirectPath(page.href, query))
+        }
+
+        return page.makePostRouteHandler()(request, context, h)
+      })
     }
 
     const dispatchRouteOptions: RouteOptions<FormRequestRefs> = {
@@ -401,7 +412,9 @@ export const plugin = {
       const { params } = request
 
       return redirectOrMakeHandler(request, h, (page, context) => {
-        if (!(page instanceof RepeatPageController)) {
+        const { isForceAccess } = context
+
+        if (isForceAccess || !(page instanceof RepeatPageController)) {
           throw Boom.notFound(`No repeater page found for /${params.path}`)
         }
 
@@ -514,7 +527,10 @@ export const plugin = {
       const { params } = request
 
       return redirectOrMakeHandler(request, h, (page, context) => {
+        const { isForceAccess } = context
+
         if (
+          isForceAccess ||
           !(
             page instanceof RepeatPageController ||
             page instanceof FileUploadPageController

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -170,11 +170,8 @@ export const plugin = {
       const relevantPath = page.getRelevantPath(request, context)
       const summaryPath = page.getSummaryPath()
 
-      // Allow preview URL direct access
-      const { isPreview } = checkFormStatus(request.path)
-
       // Return handler for relevant pages or preview URL direct access
-      if (relevantPath.startsWith(page.path) || isPreview) {
+      if (relevantPath.startsWith(page.path) || context.isForceAccess) {
         return makeHandler(page, context)
       }
 

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -124,6 +124,9 @@ export interface FormContext {
    * Visited paths evaluated from form state
    */
   paths: string[]
+
+  // Preview URL direct access is allowed
+  isForceAccess: boolean
 }
 
 export type FormContextRequest = (

--- a/src/server/plugins/engine/views/file-upload.html
+++ b/src/server/plugins/engine/views/file-upload.html
@@ -7,7 +7,7 @@
 {% block form %}
   {{ componentList(componentsBefore) }}
 
-  <form method="post" novalidate {%- if formAction %} action="{{ formAction }}" enctype="multipart/form-data" {%- endif %}>
+  <form method="post" {%- if formAction and not context.isForceAccess %} action="{{ formAction }}" enctype="multipart/form-data" {%- endif %} novalidate>
     {{ govukFileUpload(formComponent.model) }}
 
     {% if formAction %}

--- a/src/server/plugins/engine/views/index.html
+++ b/src/server/plugins/engine/views/index.html
@@ -33,7 +33,7 @@
     </div>
   </div>
 
-  {% if config.cdpEnvironment == 'local' and context | length %}
+  {% if config.cdpEnvironment == 'local' and context | length and not context.isForceAccess %}
     {% include "partials/debug.html" %}
   {% endif %}
 {% endblock %}

--- a/src/server/plugins/engine/views/item-delete.html
+++ b/src/server/plugins/engine/views/item-delete.html
@@ -50,7 +50,7 @@
     </div>
   </div>
 
-  {% if config.cdpEnvironment == 'local' and context | length %}
+  {% if config.cdpEnvironment == 'local' and context | length and not context.isForceAccess %}
     {% include "partials/debug.html" %}
   {% endif %}
 {% endblock %}

--- a/src/server/plugins/engine/views/partials/preview-banner.html
+++ b/src/server/plugins/engine/views/partials/preview-banner.html
@@ -1,7 +1,22 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner -%}
 
+{% set hasPreviousPages = context.relevantPages | length > 1 -%}
+
 {% call govukNotificationBanner() %}
-  <p class="govuk-notification-banner__heading">
-    This is a preview of a {{previewMode}} form. Do not enter personal information.
-  </p>
+  {% if not context.isForceAccess %}
+    <p class="govuk-notification-banner__heading">
+      This is a preview of a {{ previewMode }} form. Do not enter personal information.
+    </p>
+  {% else %}
+    <p class="govuk-notification-banner__heading {{- " govuk-!-margin-bottom-1" if hasPreviousPages }}">
+      This is a preview of a {{ previewMode }} form page.
+    </p>
+
+    {% if hasPreviousPages %}
+      <p class="govuk-body">
+        It depends on answers from earlier pages in the form. In the live
+        version, users will need to complete those questions first.
+      </p>
+    {% endif %}
+  {% endif %}
 {% endcall %}

--- a/src/server/plugins/engine/views/partials/preview-banner.test.js
+++ b/src/server/plugins/engine/views/partials/preview-banner.test.js
@@ -11,32 +11,112 @@ describe('Preview banner partial', () => {
     }
   ])('Status: $status', ({ status }) => {
     let $component = /** @type {HTMLElement | null} */ (null)
-    let $paragraph = /** @type {HTMLElement | null} */ (null)
+    let $paragraphs = /** @type {HTMLElement[]} */ ([])
 
-    beforeEach(() => {
-      const { container } = renderView('partials/preview-banner.html', {
-        context: { previewMode: status }
+    describe('Form preview', () => {
+      beforeEach(() => {
+        const { container } = renderView('partials/preview-banner.html', {
+          context: {
+            previewMode: status,
+            context: {
+              isForceAccess: false,
+              relevantPages: [{ title: 'Page 1' }]
+            }
+          }
+        })
+
+        $component = container.getByRole('region')
+        $paragraphs = container.getAllByRole('paragraph')
       })
 
-      $component = container.getByRole('region')
-      $paragraph = container.getByRole('paragraph')
+      it('should render contents', () => {
+        expect($component).toBeInTheDocument()
+        expect($component).toContainElement($paragraphs[0])
+        expect($component).toHaveClass('govuk-notification-banner')
+
+        expect($paragraphs).toHaveLength(1)
+        expect($paragraphs[0]).toHaveClass('govuk-notification-banner__heading')
+      })
+
+      it('should have accessible name', () => {
+        expect($component).toHaveAccessibleName('Important')
+      })
+
+      it('should have text content', () => {
+        expect($paragraphs[0]).toHaveTextContent(
+          `This is a preview of a ${status} form. Do not enter personal information.`
+        )
+      })
     })
 
-    it('should render contents', () => {
-      expect($component).toBeInTheDocument()
-      expect($component).toContainElement($paragraph)
-      expect($component).toHaveClass('govuk-notification-banner')
-      expect($paragraph).toHaveClass('govuk-notification-banner__heading')
+    describe('Preview URL direct access', () => {
+      beforeEach(() => {
+        const { container } = renderView('partials/preview-banner.html', {
+          context: {
+            previewMode: status,
+            context: {
+              isForceAccess: true,
+              relevantPages: [{ title: 'Page 1' }]
+            }
+          }
+        })
+
+        $component = container.getByRole('region')
+        $paragraphs = container.getAllByRole('paragraph')
+      })
+
+      it('should have text content', () => {
+        expect($paragraphs[0]).toHaveTextContent(
+          `This is a preview of a ${status} form page.`
+        )
+
+        expect($paragraphs[1]).toBeUndefined()
+      })
     })
 
-    it('should have accessible name', () => {
-      expect($component).toHaveAccessibleName('Important')
-    })
+    describe('Preview URL direct access (with previous pages)', () => {
+      beforeEach(() => {
+        const { container } = renderView('partials/preview-banner.html', {
+          context: {
+            previewMode: status,
+            context: {
+              isForceAccess: true,
+              relevantPages: [
+                { title: 'Page 1' },
+                { title: 'Page 2' },
+                { title: 'Page 3' }
+              ]
+            }
+          }
+        })
 
-    it('should have text content', () => {
-      expect($component).toHaveTextContent(
-        `This is a preview of a ${status} form. Do not enter personal information.`
-      )
+        $component = container.getByRole('region')
+        $paragraphs = container.getAllByRole('paragraph')
+      })
+
+      it('should render contents', () => {
+        expect($component).toBeInTheDocument()
+        expect($component).toContainElement($paragraphs[0])
+        expect($component).toHaveClass('govuk-notification-banner')
+
+        expect($paragraphs).toHaveLength(2)
+        expect($paragraphs[0]).toHaveClass('govuk-notification-banner__heading')
+        expect($paragraphs[1]).toHaveClass('govuk-body')
+      })
+
+      it('should have accessible name', () => {
+        expect($component).toHaveAccessibleName('Important')
+      })
+
+      it('should have text content', () => {
+        expect($paragraphs[0]).toHaveTextContent(
+          `This is a preview of a ${status} form page.`
+        )
+
+        expect($paragraphs[1]).toHaveTextContent(
+          'It depends on answers from earlier pages in the form. In the live version, users will need to complete those questions first.'
+        )
+      })
     })
   })
 })

--- a/src/server/plugins/engine/views/repeat-list-summary.html
+++ b/src/server/plugins/engine/views/repeat-list-summary.html
@@ -47,7 +47,7 @@
     </div>
   </div>
 
-  {% if config.cdpEnvironment == 'local' and context | length %}
+  {% if config.cdpEnvironment == 'local' and context | length and not context.isForceAccess %}
     {% include "partials/debug.html" %}
   {% endif %}
 {% endblock %}

--- a/src/server/routes/types.ts
+++ b/src/server/routes/types.ts
@@ -3,6 +3,14 @@ import { type ReqRefDefaults, type Request } from '@hapi/hapi'
 import { type FormPayload } from '~/src/server/plugins/engine/types.js'
 
 export interface FormQuery extends Partial<Record<string, string>> {
+  /**
+   * Allow preview URL direct access without relevant page checks
+   */
+  force?: string
+
+  /**
+   * Redirect location after 'continue' form action
+   */
   returnUrl?: string
 }
 

--- a/src/server/services/cacheService.ts
+++ b/src/server/services/cacheService.ts
@@ -50,14 +50,6 @@ export class CacheService {
     return this.getState(request)
   }
 
-  async mergeState(
-    request: FormRequest | FormRequestPayload,
-    state: FormSubmissionState,
-    update: object
-  ) {
-    return this.setState(request, merge(state, update))
-  }
-
   async getConfirmationState(
     request: FormRequest | FormRequestPayload
   ): Promise<{ confirmed?: true }> {

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -193,5 +193,7 @@
     ]
   } if slug %}
 
-  {{ govukFooter({ meta: meta }) }}
+  {% if not context.isForceAccess %}
+    {{ govukFooter({ meta: meta }) }}
+  {% endif %}
 {% endblock %}

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -120,11 +120,11 @@
   {% endif %}
 
   {{ govukHeader({
-    homepageUrl: "https://www.gov.uk",
+    homepageUrl: currentPath if context.isForceAccess else "https://www.gov.uk",
     containerClasses: "govuk-width-container",
     productName: productName | safe | trim,
     serviceName: name if name else config.serviceName,
-    serviceUrl: serviceUrl
+    serviceUrl: currentPath if context.isForceAccess else serviceUrl
   }) }}
 {% endblock %}
 
@@ -134,7 +134,7 @@
 
   {% if phaseTag %}
     {% set feedbackLinkHtml -%}
-      <a href="{{ feedbackLink }}" class="govuk-link" target="_blank" rel="noopener noreferrer">
+      <a href="{{ currentPath if context.isForceAccess else feedbackLink }}" class="govuk-link" {%- if not context.isForceAccess %} target="_blank" rel="noopener noreferrer" {%- endif %}>
         {%- if "mailto:" in feedbackLink -%}
           give your feedback by email
         {%- else -%}

--- a/src/server/views/summary.html
+++ b/src/server/views/summary.html
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  {% if config.cdpEnvironment == 'local' and context | length %}
+  {% if config.cdpEnvironment == 'local' and context | length and not context.isForceAccess %}
     {% include "partials/debug.html" %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
This PR allows direct access to preview pages using the `?force` query

This completes [bug #482470](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/482470) in readiness for [story #475713](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/475713)

<br>

<img width="1275" alt="Preview URL direct access from designer to runner" src="https://github.com/user-attachments/assets/689297e3-a51c-41ad-ba7f-c6971178ffde" />
