### PR TITLE
fix/491565 mixing form and global static pages

### DIFF
--- a/src/server/plugins/router.ts
+++ b/src/server/plugins/router.ts
@@ -1,3 +1,4 @@
+import { slugSchema } from '@defra/forms-model'
 import Boom from '@hapi/boom'
 import { type ServerRegisterPluginObject } from '@hapi/hapi'
 import Joi from 'joi'
@@ -22,23 +23,29 @@ export default {
     register: (server) => {
       server.route(routes)
 
-      server.route<{ Params: { slug?: string } }>({
+      // Shared help routes params schema & options
+      const params = Joi.object()
+        .keys({
+          slug: slugSchema
+        })
+        .required()
+
+      const options = {
+        validate: {
+          params
+        }
+      }
+
+      server.route<{ Params: { slug: string } }>({
         method: 'get',
-        path: '/help/get-support/{slug?}',
+        path: '/help/get-support/{slug}',
         async handler(request, h) {
           const { slug } = request.params
-          const viewName = 'help/get-support'
-
-          // If there's no slug in the path,
-          // return the generic help page
-          if (!slug) {
-            return h.view(viewName)
-          }
-
           const form = await getFormMetadata(slug)
 
-          return h.view(viewName, { form })
-        }
+          return h.view('help/get-support', { form })
+        },
+        options
       })
 
       server.route<{ Params: { slug: string } }>({
@@ -49,22 +56,25 @@ export default {
           const form = await getFormMetadata(slug)
 
           return h.view('help/privacy-notice', { form })
-        }
+        },
+        options
       })
 
-      server.route({
+      server.route<{ Params: { slug: string } }>({
         method: 'get',
-        path: '/help/cookies',
+        path: '/help/cookies/{slug}',
         handler(_request, h) {
           return h.view('help/cookies', {
             googleAnalyticsContainerId: config
               .get('googleAnalyticsTrackingId')
               .replace(/^G-/, '')
           })
-        }
+        },
+        options
       })
 
       server.route<{
+        Params: { slug: string }
         Payload: {
           crumb?: string
           'cookies[analytics]'?: string
@@ -73,9 +83,10 @@ export default {
         Query: { returnUrl?: string }
       }>({
         method: 'post',
-        path: '/help/cookie-preferences',
+        path: '/help/cookie-preferences/{slug}',
         handler(request, h) {
-          const { payload, query } = request
+          const { params, payload, query } = request
+          const { slug } = params
           let { returnUrl } = query
 
           if (returnUrl && !isPathRelative(returnUrl)) {
@@ -110,7 +121,7 @@ export default {
 
           if (!returnUrl) {
             cookieConsent.dismissed = true // this page already has a confirmation message, don't show another
-            returnUrl = '/help/cookie-preferences'
+            returnUrl = `/help/cookie-preferences/${slug}`
           }
 
           const serialisedCookieConsent = serialiseCookieConsent(cookieConsent)
@@ -120,6 +131,7 @@ export default {
         },
         options: {
           validate: {
+            params,
             payload: Joi.object({
               crumb: crumbSchema,
               'cookies[analytics]': Joi.string().valid('yes', 'no').optional(),
@@ -140,10 +152,12 @@ export default {
         }
       })
 
-      server.route({
+      server.route<{ Params: { slug: string } }>({
         method: 'get',
-        path: '/help/cookie-preferences',
+        path: '/help/cookie-preferences/{slug}',
         handler(request, h) {
+          const { params } = request
+          const { slug } = params
           let cookieConsentDismissed = false
 
           if (typeof request.state.cookieConsent === 'string') {
@@ -159,20 +173,22 @@ export default {
           // the cookie banner
           const showConsentSuccess =
             cookieConsentDismissed &&
-            request.info.referrer.endsWith('/help/cookie-preferences')
+            request.info.referrer.endsWith(`/help/cookie-preferences/${slug}`)
 
           return h.view('help/cookie-preferences', {
             cookieConsentUpdated: showConsentSuccess
           })
-        }
+        },
+        options
       })
 
-      server.route({
+      server.route<{ Params: { slug: string } }>({
         method: 'get',
-        path: '/help/accessibility-statement',
+        path: '/help/accessibility-statement/{slug}',
         handler(_request, h) {
           return h.view('help/accessibility-statement')
-        }
+        },
+        options
       })
     }
   }

--- a/src/server/routes/index.test.ts
+++ b/src/server/routes/index.test.ts
@@ -3,7 +3,11 @@ import { StatusCodes } from 'http-status-codes'
 
 import { config } from '~/src/config/index.js'
 import { createServer } from '~/src/server/index.js'
+import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
+import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
+
+jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
 describe('Routes', () => {
   let server: Server
@@ -20,7 +24,7 @@ describe('Routes', () => {
   test('cookies page is served', async () => {
     const options = {
       method: 'GET',
-      url: '/help/cookies'
+      url: '/help/cookies/slug'
     }
 
     const { container } = await renderResponse(server, options)
@@ -42,7 +46,7 @@ describe('Routes', () => {
   test('accessibility statement page is served', async () => {
     const options = {
       method: 'GET',
-      url: '/help/accessibility-statement'
+      url: '/help/accessibility-statement/slug'
     }
 
     const { container } = await renderResponse(server, options)
@@ -57,9 +61,11 @@ describe('Routes', () => {
   })
 
   test('Help page is served', async () => {
+    jest.mocked(getFormMetadata).mockResolvedValue(fixtures.form.metadata)
+
     const options = {
       method: 'GET',
-      url: '/help/get-support'
+      url: '/help/get-support/slug'
     }
 
     const res = await server.inject(options)

--- a/src/server/views/help/cookie-preferences.html
+++ b/src/server/views/help/cookie-preferences.html
@@ -24,7 +24,7 @@
 
       <h2 class="govuk-heading-l">Change your cookie settings</h2>
 
-      <form action="/help/cookie-preferences" method="post" novalidate>
+      <form method="post" novalidate>
         <input type="hidden" name="crumb" value="{{ crumb }}">
 
         {{ govukRadios({

--- a/src/server/views/help/cookies.html
+++ b/src/server/views/help/cookies.html
@@ -65,7 +65,7 @@
     }) }}
 
     <h2 class="govuk-heading-m">Change your settings</h2>
-    <p class="govuk-body">You can <a class="govuk-link" href="/help/cookie-preferences">change which cookies you’re happy for us to use</a>.</p>
+    <p class="govuk-body">You can <a class="govuk-link" href="/help/cookie-preferences/{{ slug }}">change which cookies you’re happy for us to use</a>.</p>
   </div>
 </div>
 {% endblock %}

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -45,16 +45,16 @@
 {% endblock %}
 
 {% block header %}
-  {% if googleAnalyticsTrackingId %}
-    <form method="post" action="/help/cookie-preferences?returnUrl={{ currentPath | urlencode }}">
+  {% if googleAnalyticsTrackingId and slug %}
+    <form method="post" action="/help/cookie-preferences/{{ slug }}?returnUrl={{ currentPath | urlencode }}">
       <input type="hidden" name="crumb" value="{{ crumb }}">
 
     {% set acceptHtml %}
-      <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="/help/cookies">change your cookie settings</a> at any time.</p>
+      <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="/help/cookies/{{ slug }}">change your cookie settings</a> at any time.</p>
     {% endset %}
 
     {% set rejectedHtml %}
-      <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" href="/help/cookies">change your cookie settings</a> at any time.</p>
+      <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" href="/help/cookies/{{ slug }}">change your cookie settings</a> at any time.</p>
     {% endset %}
 
     {% if cookieConsent.analytics !== true and cookieConsent.analytics !== false and cookieConsent.dismissed !== true %}
@@ -84,7 +84,7 @@
               },
               {
                 text: "View cookies",
-                href: "/help/cookies"
+                href: "/help/cookies/" + slug
               }
             ]
           }
@@ -175,21 +175,21 @@
 {% endblock %}
 
 {% block footer %}
-    {{ govukFooter({
-        meta: {
-            items: [{
-                href: '/help/get-support' + ('/' + slug if slug),
-                text: 'Get help with this form'
-            }, {
-                href: '/help/privacy' + ('/' + slug if slug),
-                text: 'Privacy'
-            }, {
-                href: '/help/cookies',
-                text: 'Cookies'
-            }, {
-                href: '/help/accessibility-statement',
-                text: 'Accessibility Statement'
-            }]
-        }
-    }) }}
+  {% set meta = {
+    items: [{
+      href: '/help/get-support/' + slug,
+      text: 'Get help with this form'
+    }, {
+      href: '/help/privacy/' + slug,
+      text: 'Privacy'
+    }, {
+      href: '/help/cookies/' + slug,
+      text: 'Cookies'
+    }, {
+      href: '/help/accessibility-statement/' + slug,
+      text: 'Accessibility Statement'
+    }]
+  } if slug %}
+
+  {{ govukFooter({ meta: meta }) }}
 {% endblock %}

--- a/test/form/cookies.test.js
+++ b/test/form/cookies.test.js
@@ -60,7 +60,7 @@ describe(`Cookie banner and analytics`, () => {
     // set the cookie preferences
     const sessionInitialisationResponse = await server.inject({
       method: 'POST',
-      url: `/help/cookie-preferences?returnUrl=${encodeURIComponent('/mypage')}`,
+      url: `/help/cookie-preferences/basic?returnUrl=${encodeURIComponent('/mypage')}`,
       payload: {
         'cookies[analytics]': 'yes'
       }
@@ -112,7 +112,7 @@ describe(`Cookie banner and analytics`, () => {
     // set the cookie preferences
     const sessionInitialisationResponse = await server.inject({
       method: 'POST',
-      url: `/help/cookie-preferences?returnUrl=${encodeURIComponent('/mypage')}`,
+      url: `/help/cookie-preferences/basic?returnUrl=${encodeURIComponent('/mypage')}`,
       payload: {
         'cookies[analytics]': 'no'
       }
@@ -165,7 +165,7 @@ describe(`Cookie banner and analytics`, () => {
     // set the cookie preferences
     const sessionInitialisationResponse = await server.inject({
       method: 'POST',
-      url: `/help/cookie-preferences?returnUrl=${encodeURIComponent('/mypage')}`,
+      url: `/help/cookie-preferences/basic?returnUrl=${encodeURIComponent('/mypage')}`,
       payload: {
         'cookies[analytics]': 'yes',
         'cookies[dismissed]': 'yes'
@@ -218,14 +218,14 @@ describe(`Cookie preferences`, () => {
       // set the cookie preferences
       const sessionInitialisationResponse = await server.inject({
         method: 'POST',
-        url: `/help/cookie-preferences`,
+        url: `/help/cookie-preferences/basic`,
         payload: {
           'cookies[analytics]': value
         }
       })
 
       const headers = {
-        Referer: '/help/cookie-preferences',
+        Referer: '/help/cookie-preferences/basic',
         ...getCookieHeader(sessionInitialisationResponse, [
           'crumb',
           'session',
@@ -235,7 +235,7 @@ describe(`Cookie preferences`, () => {
 
       const { container } = await renderResponse(server, {
         method: 'GET',
-        url: '/help/cookie-preferences',
+        url: '/help/cookie-preferences/basic',
         headers
       })
 
@@ -261,7 +261,7 @@ describe(`Cookie preferences`, () => {
     // set the cookie preferences
     const sessionInitialisationResponse = await server.inject({
       method: 'POST',
-      url: `/help/cookie-preferences?returnUrl=${encodeURIComponent('/another-page')}`,
+      url: `/help/cookie-preferences/basic?returnUrl=${encodeURIComponent('/another-page')}`,
       payload: {
         'cookies[analytics]': 'yes'
       }
@@ -277,7 +277,7 @@ describe(`Cookie preferences`, () => {
 
     const { container } = await renderResponse(server, {
       method: 'GET',
-      url: '/help/cookie-preferences',
+      url: '/help/cookie-preferences/basic',
       headers
     })
 
@@ -299,7 +299,7 @@ describe(`Cookie preferences`, () => {
 
     const { container } = await renderResponse(server, {
       method: 'GET',
-      url: '/help/cookie-preferences'
+      url: '/help/cookie-preferences/basic'
     })
 
     const $input = container.getByRole('radio', {
@@ -315,7 +315,7 @@ describe(`Cookie preferences`, () => {
 
     const { response } = await renderResponse(server, {
       method: 'POST',
-      url: `/help/cookie-preferences?returnUrl=${encodeURIComponent('https://my-malicious-url.com')}`,
+      url: `/help/cookie-preferences/basic?returnUrl=${encodeURIComponent('https://my-malicious-url.com')}`,
       payload: {
         'cookies[analytics]': 'yes'
       }

--- a/test/form/cookies.test.js
+++ b/test/form/cookies.test.js
@@ -4,20 +4,28 @@ import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
 import { createServer } from '~/src/server/index.js'
+import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
+import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
+
+jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
 describe(`Cookie banner and analytics`, () => {
   /** @type {Server} */
   let server
+
+  beforeEach(() => {
+    jest.mocked(getFormMetadata).mockResolvedValue(fixtures.form.metadata)
+  })
 
   afterEach(async () => {
     await server.stop()
   })
 
   test.each([
-    '/basic/start', // form pages
-    '/' // non-form pages
+    '/basic/licence', // form pages
+    '/help/accessibility-statement/basic' // non-form pages
   ])('shows the cookie banner by default', async (path) => {
     server = await createServer({
       formFileName: 'basic.js',
@@ -46,9 +54,9 @@ describe(`Cookie banner and analytics`, () => {
 
   test.each([
     // form pages
-    '/basic/start',
+    '/basic/licence',
     // non-form pages
-    '/'
+    '/help/accessibility-statement/basic'
   ])('confirms when the user has accepted analytics cookies', async (path) => {
     server = await createServer({
       formFileName: 'basic.js',
@@ -98,9 +106,9 @@ describe(`Cookie banner and analytics`, () => {
 
   test.each([
     // form pages
-    '/basic/start',
+    '/basic/licence',
     // non-form pages
-    '/'
+    '/help/accessibility-statement/basic'
   ])('confirms when the user has rejected analytics cookies', async (path) => {
     server = await createServer({
       formFileName: 'basic.js',


### PR DESCRIPTION
Adds the slug to all help pages (get-support, privacy, cookies, accessibility-statement and cookies-preferences)