### PR TITLE
Use Nunjucks `{{ config.serviceName }}` etc like forms-designer

### DIFF
--- a/src/server/plugins/engine/pageControllers/PageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.test.ts
@@ -54,14 +54,9 @@ describe('PageController', () => {
       })
     })
 
-    it('returns feedback link (from config)', () => {
-      expect(controller1).toHaveProperty(
-        'feedbackLink',
-        'https://test.defra.gov.uk/'
-      )
-    })
-
     it('returns feedback link (from form definition)', () => {
+      expect(controller1).toHaveProperty('feedbackLink', undefined)
+
       const emailAddress = 'test@feedback.cat'
 
       model.def.feedback = {

--- a/src/server/plugins/engine/pageControllers/PageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.test.ts
@@ -74,11 +74,9 @@ describe('PageController', () => {
       )
     })
 
-    it('returns phase tag (from config)', () => {
-      expect(controller1).toHaveProperty('phaseTag', 'beta')
-    })
-
     it('returns phase tag (from form definition)', () => {
+      expect(controller1).toHaveProperty('phaseTag', undefined)
+
       model.def.phaseBanner = {
         phase: 'alpha'
       }

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -11,7 +11,6 @@ import {
   type RouteOptions
 } from '@hapi/hapi'
 
-import { config } from '~/src/config/index.js'
 import { type ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import {
   encodeUrl,
@@ -109,13 +108,9 @@ export class PageController {
     const { def } = this
 
     // setting the feedbackLink to undefined here for feedback forms prevents the feedback link from being shown
-    let feedbackLink = def.feedback?.emailAddress
+    const feedbackLink = def.feedback?.emailAddress
       ? `mailto:${def.feedback.emailAddress}`
       : def.feedback?.url
-
-    if (!feedbackLink) {
-      feedbackLink = config.get('feedbackLink')
-    }
 
     return encodeUrl(feedbackLink)
   }

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -122,7 +122,7 @@ export class PageController {
 
   get phaseTag() {
     const { def } = this
-    return def.phaseBanner?.phase ?? config.get('phaseTag')
+    return def.phaseBanner?.phase
   }
 
   getHref(path: string) {

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -9,6 +9,7 @@ import {
 } from '~/src/server/plugins/engine/components/types.js'
 import { type PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
+import { type ViewContext } from '~/src/server/plugins/nunjucks/types.js'
 import { type FormAction, type FormRequest } from '~/src/server/routes/types.js'
 
 /**
@@ -241,7 +242,7 @@ export type SummaryListAction = ComponentText & {
   visuallyHiddenText: string
 }
 
-export interface PageViewModelBase {
+export interface PageViewModelBase extends Partial<ViewContext> {
   page: PageController
   name?: string
   pageTitle: string

--- a/src/server/plugins/engine/views/index.html
+++ b/src/server/plugins/engine/views/index.html
@@ -33,7 +33,7 @@
     </div>
   </div>
 
-  {% if cdpEnvironment == 'local' and context | length %}
+  {% if config.cdpEnvironment == 'local' and context | length %}
     {% include "partials/debug.html" %}
   {% endif %}
 {% endblock %}

--- a/src/server/plugins/engine/views/item-delete.html
+++ b/src/server/plugins/engine/views/item-delete.html
@@ -50,7 +50,7 @@
     </div>
   </div>
 
-  {% if cdpEnvironment == 'local' and context | length %}
+  {% if config.cdpEnvironment == 'local' and context | length %}
     {% include "partials/debug.html" %}
   {% endif %}
 {% endblock %}

--- a/src/server/plugins/engine/views/repeat-list-summary.html
+++ b/src/server/plugins/engine/views/repeat-list-summary.html
@@ -47,7 +47,7 @@
     </div>
   </div>
 
-  {% if cdpEnvironment == 'local' and context | length %}
+  {% if config.cdpEnvironment == 'local' and context | length %}
     {% include "partials/debug.html" %}
   {% endif %}
 {% endblock %}

--- a/src/server/plugins/nunjucks/context.js
+++ b/src/server/plugins/nunjucks/context.js
@@ -47,7 +47,7 @@ export function context(request) {
   const isResponseOK =
     !Boom.isBoom(response) && response?.statusCode === StatusCodes.OK
 
-  return {
+  return /** @type {ViewContext} */ ({
     appVersion: pkg.version,
     assetPath: '/assets',
     config: {
@@ -69,10 +69,11 @@ export function context(request) {
     getAssetPath: (asset = '') => {
       return `/${webpackManifest?.[asset] ?? asset}`
     }
-  }
+  })
 }
 
 /**
  * @import { CookieConsent } from '~/src/common/types.js'
+ * @import { ViewContext } from '~/src/server/plugins/nunjucks/types.js'
  * @import { FormRequest, FormRequestPayload } from '~/src/server/routes/types.js'
  */

--- a/src/server/plugins/nunjucks/context.js
+++ b/src/server/plugins/nunjucks/context.js
@@ -40,8 +40,6 @@ export function context(request) {
     cookieConsent = parseCookieConsent(state.cookieConsent)
   }
 
-  const crumb = request?.server.plugins.crumb.generate?.(request)
-
   const isPreviewMode = path?.startsWith(PREVIEW_PATH_PREFIX)
 
   // Only add the slug in to the context if the response is OK.
@@ -52,19 +50,21 @@ export function context(request) {
   return {
     appVersion: pkg.version,
     assetPath: '/assets',
-    cdpEnvironment: config.get('cdpEnvironment'),
-    feedbackLink: encodeUrl(config.get('feedbackLink')),
-    phaseTag: config.get('phaseTag'),
-    previewMode: isPreviewMode ? params?.state : undefined,
-    serviceBannerText: config.get('serviceBannerText'),
-    serviceName: config.get('serviceName'),
-    serviceVersion: config.get('serviceVersion'),
-    slug: isResponseOK ? params?.slug : undefined,
+    config: {
+      cdpEnvironment: config.get('cdpEnvironment'),
+      feedbackLink: encodeUrl(config.get('feedbackLink')),
+      googleAnalyticsTrackingId: config.get('googleAnalyticsTrackingId'),
+      phaseTag: config.get('phaseTag'),
+      serviceBannerText: config.get('serviceBannerText'),
+      serviceName: config.get('serviceName'),
+      serviceVersion: config.get('serviceVersion')
+    },
     cookieConsent,
-    crumb,
-    googleAnalyticsTrackingId: config.get('googleAnalyticsTrackingId'),
+    crumb: request?.server.plugins.crumb.generate?.(request),
     cspNonce: request?.plugins.blankie?.nonces?.script,
     currentPath: request ? `${request.path}${request.url.search}` : undefined,
+    previewMode: isPreviewMode ? params?.state : undefined,
+    slug: isResponseOK ? params?.slug : undefined,
 
     getAssetPath: (asset = '') => {
       return `/${webpackManifest?.[asset] ?? asset}`

--- a/src/server/plugins/nunjucks/context.test.js
+++ b/src/server/plugins/nunjucks/context.test.js
@@ -1,6 +1,7 @@
 import { tmpdir } from 'node:os'
 
 import { config } from '~/src/config/index.js'
+import { encodeUrl } from '~/src/server/plugins/engine/helpers.js'
 import { context } from '~/src/server/plugins/nunjucks/context.js'
 
 describe('Nunjucks context', () => {
@@ -58,10 +59,13 @@ describe('Nunjucks context', () => {
     it('should include environment, phase tag and service info', () => {
       const ctx = context(null)
 
-      expect(ctx).toEqual(
+      expect(ctx.config).toEqual(
         expect.objectContaining({
           cdpEnvironment: config.get('cdpEnvironment'),
+          feedbackLink: encodeUrl(config.get('feedbackLink')),
+          googleAnalyticsTrackingId: config.get('googleAnalyticsTrackingId'),
           phaseTag: config.get('phaseTag'),
+          serviceBannerText: config.get('serviceBannerText'),
           serviceName: config.get('serviceName'),
           serviceVersion: config.get('serviceVersion')
         })

--- a/src/server/plugins/nunjucks/types.js
+++ b/src/server/plugins/nunjucks/types.js
@@ -8,3 +8,26 @@
  * @typedef {object} RenderOptions
  * @property {object} [context] - Nunjucks render context
  */
+
+/**
+ * @typedef {object} ViewContext - Nunjucks view context
+ * @property {string} appVersion - Application version
+ * @property {string} assetPath - Asset path
+ * @property {Partial<Config>} config - Application config properties
+ * @property {CookieConsent} [cookieConsent] - Cookie consent preferences
+ * @property {string} [crumb] - Cross-Site Request Forgery (CSRF) token
+ * @property {string} [cspNonce] - Content Security Policy (CSP) nonce
+ * @property {string} [currentPath] - Current path
+ * @property {string} [previewMode] - Preview mode
+ * @property {string} [slug] - Form slug
+ * @property {(asset?: string) => string} getAssetPath - Asset path resolver
+ */
+
+/**
+ * @typedef {ReturnType<typeof config['getProperties']>} Config - Application config properties
+ */
+
+/**
+ * @import { CookieConsent } from '~/src/common/types.js'
+ * @import { config } from '~/src/config/index.js'
+ */

--- a/src/server/views/help/privacy-notice.html
+++ b/src/server/views/help/privacy-notice.html
@@ -1,36 +1,36 @@
 {% extends "layout.html" %}
 
-{% set pageTitle = serviceName + " privacy notice" %}
+{% set pageTitle = config.serviceName + " privacy notice" %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">{{ serviceName }} privacy notice</h1>
-      <p class="govuk-body">The {{ form.title }} form was created using ‘{{ serviceName }}’. This service is owned and operated by the Department for Environment, Food & Rural Affairs (Defra).</p>
+      <h1 class="govuk-heading-l">{{ config.serviceName }} privacy notice</h1>
+      <p class="govuk-body">The {{ form.title }} form was created using ‘{{ config.serviceName }}’. This service is owned and operated by the Department for Environment, Food & Rural Affairs (Defra).</p>
 
       <h2 class="govuk-heading-m">Who collects your personal data</h2>
-      <p class="govuk-body">The organisation that created the {{ form.title }} form using ‘{{ serviceName }}’ is the data controller of personal data they collect. If the data controller is outside the Defra legal entity, then Defra is the data processor.</p>
+      <p class="govuk-body">The organisation that created the {{ form.title }} form using ‘{{ config.serviceName }}’ is the data controller of personal data they collect. If the data controller is outside the Defra legal entity, then Defra is the data processor.</p>
       <p class="govuk-body">Read the <a href="{{ form.privacyNoticeUrl }}" class="govuk-link">specific privacy notice for the {{ form.title }} form</a>.</p>
-      <p class="govuk-body">Defra also collects some data as a data controller. This privacy notice explains what personal data Defra collects and processes as a data controller through forms made with ‘{{ serviceName }}’.</p>
+      <p class="govuk-body">Defra also collects some data as a data controller. This privacy notice explains what personal data Defra collects and processes as a data controller through forms made with ‘{{ config.serviceName }}’.</p>
       <p class="govuk-body">If you need further information about how Defra uses your personal data, email <a href="mailto:defraforms@defra.gov.uk" class="govuk-link">defraforms@defra.gov.uk</a>.</p>
       <p class="govuk-body">If you want information and your associated rights you can email: <a href="mailto:data.protection@defra.gov.uk" class="govuk-link">data.protection@defra.gov.uk</a>.</p>
       <p class="govuk-body">The data protection officer for Defra is responsible for checking that Defra complies with legislation. You can contact them at <a href="mailto:DefraGroupDataProtectionOfficer@defra.gov.uk" class="govuk-link">Defra<wbr>Group<wbr>Data<wbr>Protection<wbr>Officer@defra.gov.uk</a>.</p>
 
       <h2 class="govuk-heading-m">Data we collect from you and what we do with it</h2>
-      <p class="govuk-body">If you give your consent, we use Google Analytics cookies to collect information about how you use ‘{{ serviceName }}’. Read the <a href="https://support.google.com/analytics/topic/2919631" class="govuk-link">data privacy and security policy for Google Analytics</a>.</p>
+      <p class="govuk-body">If you give your consent, we use Google Analytics cookies to collect information about how you use ‘{{ config.serviceName }}’. Read the <a href="https://support.google.com/analytics/topic/2919631" class="govuk-link">data privacy and security policy for Google Analytics</a>.</p>
       <p class="govuk-body">Google Analytics processes information about:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>your IP address</li>
-        <li>the pages you visit on ‘{{ serviceName }}’</li>
-        <li>how long you spend on each ‘{{ serviceName }}’ page</li>
+        <li>the pages you visit on ‘{{ config.serviceName }}’</li>
+        <li>how long you spend on each ‘{{ config.serviceName }}’ page</li>
         <li>how you got to the site</li>
         <li>what you select while you’re visiting the site</li>
       </ul>
       <p class="govuk-body">Defra will make sure you cannot be directly identified by Google Analytics data. We do this by using <a href="https://support.google.com/analytics/answer/2763052" class="govuk-link">Google Analytics’ IP address anonymisation</a> feature and by removing any other personal data from the titles or URLs of the pages you visit.</p>
       <p class="govuk-body">Defra will not combine analytics information with other data sets in a way that would directly identify who you are.</p>
       <p class="govuk-body">We use system logs to collect information about the usage of forms. The logs are stored in Amazon Web Services based in London.</p>
-      <p class="govuk-body">We use the system logs and Google Analytics data to create anonymised reports about the performance of forms that use ‘{{ serviceName }}’. We use this data to improve forms, for example, if we discover a high number of drops offs at a certain point within a form. We may share this information with the data controller of the form.</p>
-      <p class="govuk-body">If you email us feedback about a form that uses ‘{{ serviceName }}’, we’ll send your email address and any other personal information you choose to include in your email to the data controller for review. The data controller may use your personal information to reply to your query to update a form based on your feedback where it is appropriate.</p>
+      <p class="govuk-body">We use the system logs and Google Analytics data to create anonymised reports about the performance of forms that use ‘{{ config.serviceName }}’. We use this data to improve forms, for example, if we discover a high number of drops offs at a certain point within a form. We may share this information with the data controller of the form.</p>
+      <p class="govuk-body">If you email us feedback about a form that uses ‘{{ config.serviceName }}’, we’ll send your email address and any other personal information you choose to include in your email to the data controller for review. The data controller may use your personal information to reply to your query to update a form based on your feedback where it is appropriate.</p>
 
       <h2 class="govuk-heading-m">Lawful basis for processing your personal data</h2>
       <p class="govuk-body">The lawful basis for processing your personal data is your consent.</p>

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -11,19 +11,19 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner -%}
 
 {% set productName %}
-  {% if cdpEnvironment !== "prod" %}
-    {{ appTagEnv({ env: cdpEnvironment }) }}
+  {% if config.cdpEnvironment !== "prod" %}
+    {{ appTagEnv({ env: config.cdpEnvironment }) }}
   {% endif %}
 {% endset %}
 
 {% block head %}
   <meta name="application-name" content="@defra/forms-runner" {{- govukAttributes({
     "data-environment": {
-      value: cdpEnvironment,
+      value: config.cdpEnvironment,
       optional: true
     },
     "data-version": {
-      value: serviceVersion,
+      value: config.serviceVersion,
       optional: true
     }
   }) }}>
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block pageTitle -%}
-  {{ "Error: " if errors | length }}{{ pageTitle }} - {{ name if name else serviceName }} - GOV.UK
+  {{ "Error: " if errors | length }}{{ pageTitle }} - {{ name if name else config.serviceName }} - GOV.UK
 {%- endblock %}
 
 {% block skipLink %}
@@ -45,8 +45,8 @@
 {% endblock %}
 
 {% block header %}
-  {% if googleAnalyticsTrackingId and slug %}
-    <form method="post" action="/help/cookie-preferences/{{ slug }}?returnUrl={{ currentPath | urlencode }}">
+  {% if config.googleAnalyticsTrackingId and slug %}
+    <form method="post" action="/help/cookie-preferences?returnUrl={{ currentPath | urlencode }}">
       <input type="hidden" name="crumb" value="{{ crumb }}">
 
     {% set acceptHtml %}
@@ -64,10 +64,10 @@
       {% endset %}
 
       {{ govukCookieBanner({
-        ariaLabel: "Cookies on " + serviceName,
+        ariaLabel: "Cookies on " + config.serviceName,
         messages: [
           {
-            headingText: serviceName,
+            headingText: config.serviceName,
             html: html,
             actions: [
               {
@@ -92,7 +92,7 @@
       }) }}
     {% elif cookieConsent.dismissed === false %}
       {{ govukCookieBanner({
-        ariaLabel: "Cookies on " + serviceName,
+        ariaLabel: "Cookies on " + config.serviceName,
         messages: [
           {
             html: acceptHtml if cookieConsent.analytics === true else rejectedHtml,
@@ -112,10 +112,10 @@
     </form>
   {% endif %}
 
-  {% if serviceBannerText | length %}
+  {% if config.serviceBannerText | length %}
     {{ appServiceBanner({
       title: "Service status",
-      text: serviceBannerText
+      text: config.serviceBannerText
     }) }}
   {% endif %}
 
@@ -123,7 +123,7 @@
     homepageUrl: "https://www.gov.uk",
     containerClasses: "govuk-width-container",
     productName: productName | safe | trim,
-    serviceName: name if name else serviceName,
+    serviceName: name if name else config.serviceName,
     serviceUrl: serviceUrl
   }) }}
 {% endblock %}
@@ -157,13 +157,13 @@
 {% block bodyEnd %}
   <script type="module" nonce="{{ cspNonce }}" src="{{ getAssetPath("application.js") }}"></script>
 
-  {% if googleAnalyticsTrackingId and cookieConsent.analytics === true %}
-  <script id="ga-tag-js-main" nonce="{{ cspNonce }}" src="https://www.googletagmanager.com/gtag/js?id={{ googleAnalyticsTrackingId }}" defer></script>
+  {% if config.googleAnalyticsTrackingId and cookieConsent.analytics === true %}
+  <script id="ga-tag-js-main" nonce="{{ cspNonce }}" src="https://www.googletagmanager.com/gtag/js?id={{ config.googleAnalyticsTrackingId }}" defer></script>
   <script id="ga-tag-js-init" nonce="{{ cspNonce }}">
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', '{{ googleAnalyticsTrackingId }}');
+    gtag('config', '{{ config.googleAnalyticsTrackingId }}');
   </script>
 {% endif %}
 {% endblock %}

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -129,33 +129,30 @@
 {% endblock %}
 
 {% block beforeContent %}
-    {% if phaseTag %}
-        {% if 'mailto:' in feedbackLink %}
-            {{ govukPhaseBanner({
-                tag: {
-                    text: phaseTag | capitalize
-                },
-                html: 'This is a new service. Help us improve it and <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="' + feedbackLink | escape + '">give your feedback by email</a>.'
-            }) }}
-        {% else %}
-            {{ govukPhaseBanner({
-                tag: {
-                    text: phaseTag | capitalize
-                },
-                html: 'This is a new service. Help us improve it and <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="' + feedbackLink | escape + '">give your feedback (opens in new tab)</a>.'
-            }) }}
-        {% endif %}
-    {% endif %}
-    {% if backLink %}
-      {{ govukBackLink(backLink) }}
-    {% endif %}
-{% endblock %}
+  {% if phaseTag %}
+    {% set feedbackLinkHtml -%}
+      <a href="{{ feedbackLink }}" class="govuk-link" target="_blank" rel="noopener noreferrer">
+        {%- if "mailto:" in feedbackLink -%}
+          give your feedback by email
+        {%- else -%}
+          give your feedback (opens in new tab)
+        {%- endif -%}
+      </a>
+    {%- endset %}
 
+    {{ govukPhaseBanner({
+      tag: { text: phaseTag | capitalize },
+      html: "This is a new service. Help us improve it and " + feedbackLinkHtml | safe + "."
+    }) }}
+  {% endif %}
+  {% if backLink %}
+    {{ govukBackLink(backLink) }}
+  {% endif %}
+{% endblock %}
 
 {% block content %}
   <h1 class="govuk-heading-l">Default page template</h1>
 {% endblock %}
-
 
 {% block bodyEnd %}
   <script type="module" nonce="{{ cspNonce }}" src="{{ getAssetPath("application.js") }}"></script>
@@ -173,19 +170,24 @@
 
 {% block footer %}
   {% set meta = {
-    items: [{
-      href: '/help/get-support/' + slug,
-      text: 'Get help with this form'
-    }, {
-      href: '/help/privacy/' + slug,
-      text: 'Privacy'
-    }, {
-      href: '/help/cookies/' + slug,
-      text: 'Cookies'
-    }, {
-      href: '/help/accessibility-statement/' + slug,
-      text: 'Accessibility Statement'
-    }]
+    items: [
+      {
+        href: '/help/get-support/' + slug,
+        text: 'Get help with this form'
+      },
+      {
+        href: '/help/privacy/' + slug,
+        text: 'Privacy'
+      },
+      {
+        href: '/help/cookies/' + slug,
+        text: 'Cookies'
+      },
+      {
+        href: '/help/accessibility-statement/' + slug,
+        text: 'Accessibility Statement'
+      }
+    ]
   } if slug %}
 
   {{ govukFooter({ meta: meta }) }}

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -129,6 +129,7 @@
 {% endblock %}
 
 {% block beforeContent %}
+  {% set feedbackLink = feedbackLink or config.feedbackLink -%}
   {% set phaseTag = phaseTag or config.phaseTag -%}
 
   {% if phaseTag %}

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -129,6 +129,8 @@
 {% endblock %}
 
 {% block beforeContent %}
+  {% set phaseTag = phaseTag or config.phaseTag -%}
+
   {% if phaseTag %}
     {% set feedbackLinkHtml -%}
       <a href="{{ feedbackLink }}" class="govuk-link" target="_blank" rel="noopener noreferrer">

--- a/src/server/views/summary.html
+++ b/src/server/views/summary.html
@@ -44,7 +44,7 @@
     </div>
   </div>
 
-  {% if cdpEnvironment == 'local' and context | length %}
+  {% if config.cdpEnvironment == 'local' and context | length %}
     {% include "partials/debug.html" %}
   {% endif %}
 {% endblock %}

--- a/src/typings/hapi/index.d.ts
+++ b/src/typings/hapi/index.d.ts
@@ -16,7 +16,7 @@ declare module '@hapi/hapi' {
   // props from plugins which doesn't export @types
   interface PluginProperties {
     crumb: {
-      generate?: (request: Request | FormRequest | FormRequestPayload) => void
+      generate?: (request: Request | FormRequest | FormRequestPayload) => string
     }
   }
 


### PR DESCRIPTION
This PR aligns `forms-runner` with `forms-designer` with a limited Nunjucks **config** context object

Bit of tech debt that came up during https://github.com/DEFRA/forms-runner/pull/646, for example:

```patch
- {% if cdpEnvironment == 'local' and context | length %}
+ {% if config.cdpEnvironment == 'local' and context | length %}
```

```patch
- <h1 class="govuk-heading-l">{{ serviceName }} privacy notice</h1>
+ <h1 class="govuk-heading-l">{{ config.serviceName }} privacy notice</h1>
```