### PR TITLE
Change “Go back to add another” to “Back” after it’s clicked

### DIFF
--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -365,9 +365,10 @@ export class QuestionPageController extends PageController {
     // Check answers back link
     if (returnUrl) {
       return {
-        text: hasRepeater(pageDef)
-          ? 'Go back to add another'
-          : 'Go back to check answers',
+        text:
+          hasRepeater(pageDef) && itemId
+            ? 'Go back to add another'
+            : 'Go back to check answers',
         href: returnUrl
       }
     }


### PR DESCRIPTION
Quick bug fix to change the “Go back to add another” text to "Back" when you're already on the mini summary

Missed it in https://github.com/DEFRA/forms-runner/pull/637 for [bug #490505](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490505)

# Back link guidance

We've followed the back link guidance for complex journeys:

>For more complex user journeys, consider using different link text, like ‘Go back to [page]’. For example, in an admin system with many different areas. In this case, if you used ‘Back’, it might not be clear to users what they are going back to.

When changing answers from the summary (or mini repeater summary) pages

<img width="693" alt="Back to add another" src="https://github.com/user-attachments/assets/3b91950a-722e-4ecc-95d1-a2ed0baa00cc" />

<br>

<img width="511" alt="Back to check answers" src="https://github.com/user-attachments/assets/b40258b8-2191-4831-8785-3090382b86d2" />
