### PR TITLE
New designer: Show preview close link via `rel="opener"`

### DIFF
--- a/src/client/javascripts/application.js
+++ b/src/client/javascripts/application.js
@@ -19,6 +19,17 @@ createAll(NotificationBanner)
 createAll(Radios)
 createAll(SkipLink)
 
+// Show preview close link via `rel="opener"`
+if (window.opener) {
+  const $closeLink = document.querySelector('.js-preview-banner-close')
+
+  $closeLink?.removeAttribute('hidden')
+  $closeLink?.addEventListener('click', (event) => {
+    event.preventDefault()
+    window.close()
+  })
+}
+
 /**
  * Initialise autocomplete
  * @param {HTMLSelectElement | null} $select

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -42,10 +42,7 @@ export class SummaryViewModel {
   phaseTag?: string
   errors?: FormSubmissionError[]
   serviceUrl: string
-  notificationEmailWarning?: {
-    slug: string
-    designerUrl: string
-  }
+  hasMissingNotificationEmail?: boolean
 
   constructor(
     request: FormContextRequest,

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -491,8 +491,8 @@ describe('QuestionPageController', () => {
 
       for (const controller of [controller1, controller2]) {
         jest
-          .spyOn(controller, 'buildMissingEmailWarningModel')
-          .mockResolvedValue(undefined)
+          .spyOn(controller, 'hasMissingNotificationEmail')
+          .mockResolvedValue(false)
 
         jest.spyOn(controller, 'getState').mockResolvedValue(state)
       }

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -9,7 +9,6 @@ import {
 import { type ResponseToolkit, type RouteOptions } from '@hapi/hapi'
 import { type ValidationErrorItem } from 'joi'
 
-import { config } from '~/src/config/index.js'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { optionalText } from '~/src/server/plugins/engine/components/constants.js'
 import { type BackLink } from '~/src/server/plugins/engine/components/types.js'
@@ -345,17 +344,17 @@ export class QuestionPageController extends PageController {
         return evaluatedComponent
       })
 
-      viewModel.notificationEmailWarning =
-        await this.buildMissingEmailWarningModel(request, context)
+      viewModel.hasMissingNotificationEmail =
+        await this.hasMissingNotificationEmail(request, context)
 
       return h.view(viewName, viewModel)
     }
   }
 
-  async buildMissingEmailWarningModel(
+  async hasMissingNotificationEmail(
     request: FormRequest,
     context: FormContext
-  ): Promise<FormPageViewModel['notificationEmailWarning']> {
+  ) {
     const { path } = this
     const { params } = request
     const { isForceAccess } = context
@@ -366,14 +365,10 @@ export class QuestionPageController extends PageController {
     // Warn the user if the form has no notification email set only on start page and summary page
     if ([startPath, summaryPath].includes(path) && !isForceAccess) {
       const { notificationEmail } = await getFormMetadata(params.slug)
-
-      if (!notificationEmail) {
-        return {
-          slug: params.slug,
-          designerUrl: config.get('designerUrl')
-        }
-      }
+      return !notificationEmail
     }
+
+    return false
   }
 
   /**

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -86,8 +86,8 @@ export class SummaryPageController extends QuestionPageController {
 
       const viewModel = this.getSummaryViewModel(request, context)
 
-      viewModel.notificationEmailWarning =
-        await this.buildMissingEmailWarningModel(request, context)
+      viewModel.hasMissingNotificationEmail =
+        await this.hasMissingNotificationEmail(request, context)
 
       return h.view(viewName, viewModel)
     }

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -270,10 +270,7 @@ export interface FormPageViewModel extends PageViewModelBase {
   components: ComponentViewModel[]
   context: FormContext
   errors?: FormSubmissionError[]
-  notificationEmailWarning?: {
-    slug: string
-    designerUrl: string
-  }
+  hasMissingNotificationEmail?: boolean
 }
 
 export interface RepeaterSummaryPageViewModel extends PageViewModelBase {

--- a/src/server/plugins/engine/views/index.html
+++ b/src/server/plugins/engine/views/index.html
@@ -17,7 +17,7 @@
         }) }}
       {% endif %}
 
-      {% if notificationEmailWarning %}
+      {% if hasMissingNotificationEmail %}
         {% include "partials/warn-missing-notification-email.html" %}
       {% endif %}
 

--- a/src/server/plugins/engine/views/partials/preview-banner.html
+++ b/src/server/plugins/engine/views/partials/preview-banner.html
@@ -3,27 +3,27 @@
 {% set hasPreviousPages = context.relevantPages | length > 1 -%}
 
 {%- macro _closeLink() -%}
-  <p class="govuk-notification-banner__heading js-preview-banner-close" hidden>
+  <p class="govuk-notification-banner__heading govuk-!-margin-top-1 js-preview-banner-close" hidden>
     <a href="{{ config.designerUrl }}" class="govuk-link--no-visited-state">Close preview and go back to the editor</a>
   </p>
 {%- endmacro -%}
 
 {% call govukNotificationBanner() %}
   {% if not context.isForceAccess %}
-    <p class="govuk-notification-banner__heading">
+    <p class="govuk-notification-banner__heading govuk-!-margin-bottom-0">
       This is a preview of a {{ previewMode }} form. Do not enter personal information.
     </p>
 
     {{ _closeLink() }}
   {% else %}
-    <p class="govuk-notification-banner__heading {{- " govuk-!-margin-bottom-1" if hasPreviousPages }}">
+    <p class="govuk-notification-banner__heading govuk-!-margin-bottom-0">
       This is a preview of a {{ previewMode }} form page.
     </p>
 
     {{ _closeLink() }}
 
     {% if hasPreviousPages %}
-      <p class="govuk-body">
+      <p class="govuk-body govuk-!-margin-top-2">
         It depends on answers from earlier pages in the form. In the live
         version, users will need to complete those questions first.
       </p>

--- a/src/server/plugins/engine/views/partials/preview-banner.html
+++ b/src/server/plugins/engine/views/partials/preview-banner.html
@@ -2,15 +2,25 @@
 
 {% set hasPreviousPages = context.relevantPages | length > 1 -%}
 
+{%- macro _closeLink() -%}
+  <p class="govuk-notification-banner__heading js-preview-banner-close" hidden>
+    <a href="{{ config.designerUrl }}" class="govuk-link--no-visited-state">Close preview and go back to the editor</a>
+  </p>
+{%- endmacro -%}
+
 {% call govukNotificationBanner() %}
   {% if not context.isForceAccess %}
     <p class="govuk-notification-banner__heading">
       This is a preview of a {{ previewMode }} form. Do not enter personal information.
     </p>
+
+    {{ _closeLink() }}
   {% else %}
     <p class="govuk-notification-banner__heading {{- " govuk-!-margin-bottom-1" if hasPreviousPages }}">
       This is a preview of a {{ previewMode }} form page.
     </p>
+
+    {{ _closeLink() }}
 
     {% if hasPreviousPages %}
       <p class="govuk-body">

--- a/src/server/plugins/engine/views/partials/warn-missing-notification-email.html
+++ b/src/server/plugins/engine/views/partials/warn-missing-notification-email.html
@@ -1,7 +1,7 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set html %}
-    If you want to receive a test email, <a target="_blank" rel="noopener noreferrer" class="govuk-link" href="{{notificationEmailWarning.designerUrl}}/library/{{notificationEmailWarning.slug}}/edit/notification-email">enter the email address (opens in new tab)</a> you want form submissions to go to.
+    If you want to receive a test email, <a target="_blank" rel="noopener noreferrer" class="govuk-link" href="{{ config.designerUrl }}/library/{{ slug }}/edit/notification-email">enter the email address (opens in new tab)</a> you want form submissions to go to.
 {% endset %}
 
 {{ govukWarningText({

--- a/src/server/plugins/nunjucks/context.js
+++ b/src/server/plugins/nunjucks/context.js
@@ -47,6 +47,7 @@ export function context(request) {
     assetPath: '/assets',
     config: {
       cdpEnvironment: config.get('cdpEnvironment'),
+      designerUrl: config.get('designerUrl'),
       feedbackLink: encodeUrl(config.get('feedbackLink')),
       phaseTag: config.get('phaseTag'),
       serviceBannerText: config.get('serviceBannerText'),

--- a/src/server/views/summary.html
+++ b/src/server/views/summary.html
@@ -10,7 +10,7 @@
         {% include "partials/preview-banner.html" %}
       {% endif %}
 
-      {% if notificationEmailWarning %}
+      {% if hasMissingNotificationEmail %}
         {% include "partials/warn-missing-notification-email.html" %}
       {% endif %}
 


### PR DESCRIPTION
This PR adds a **Close preview and go back to the editor link** to `?force` previews

Will need designers to review the preview banner content as it changed in https://github.com/DEFRA/forms-runner/pull/646/commits/19b7457c949712e38238d439d43df74b40532963

Closes [story #475713](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/475713)

<img width="690" alt="Close link on preview" src="https://github.com/user-attachments/assets/d10465f4-734a-480a-a275-62d6868d8bda" />
