### PR TITLE
New designer: Update preview banner text

### DIFF
--- a/src/server/plugins/engine/views/partials/preview-banner.html
+++ b/src/server/plugins/engine/views/partials/preview-banner.html
@@ -4,7 +4,7 @@
 
 {%- macro _closeLink() -%}
   <p class="govuk-notification-banner__heading govuk-!-margin-top-1 js-preview-banner-close" hidden>
-    <a href="{{ config.designerUrl }}" class="govuk-link--no-visited-state">Close preview and go back to the editor</a>
+    <a href="{{ config.designerUrl }}/library/{{ slug }}/editor" class="govuk-link--no-visited-state">Close preview and go back to the editor</a>
   </p>
 {%- endmacro -%}
 

--- a/src/server/plugins/engine/views/partials/preview-banner.html
+++ b/src/server/plugins/engine/views/partials/preview-banner.html
@@ -4,7 +4,7 @@
 
 {%- macro _closeLink() -%}
   <p class="govuk-notification-banner__heading govuk-!-margin-top-1 js-preview-banner-close" hidden>
-    <a href="{{ config.designerUrl }}/library/{{ slug }}/editor" class="govuk-link--no-visited-state">Close preview and go back to the editor</a>
+    <a href="{{ config.designerUrl }}/library/{{ slug }}/editor" class="govuk-link--no-visited-state">Go back to the editor</a>
   </p>
 {%- endmacro -%}
 
@@ -17,7 +17,7 @@
     {{ _closeLink() }}
   {% else %}
     <p class="govuk-notification-banner__heading govuk-!-margin-bottom-0">
-      This is a preview of a {{ previewMode }} form page.
+      This is a preview of a {{ previewMode }} form page you are editing.
     </p>
 
     {{ _closeLink() }}

--- a/src/server/plugins/engine/views/partials/preview-banner.test.js
+++ b/src/server/plugins/engine/views/partials/preview-banner.test.js
@@ -67,7 +67,7 @@ describe('Preview banner partial', () => {
 
       it('should have text content', () => {
         expect($paragraphs[0]).toHaveTextContent(
-          `This is a preview of a ${status} form page.`
+          `This is a preview of a ${status} form page you are editing.`
         )
 
         expect($paragraphs[1]).toBeUndefined()
@@ -110,7 +110,7 @@ describe('Preview banner partial', () => {
 
       it('should have text content', () => {
         expect($paragraphs[0]).toHaveTextContent(
-          `This is a preview of a ${status} form page.`
+          `This is a preview of a ${status} form page you are editing.`
         )
 
         expect($paragraphs[1]).toHaveTextContent(


### PR DESCRIPTION
Some changes made to https://github.com/DEFRA/forms-runner/pull/658 due to old designs

The Figma link for **Flow 5** of [story #475713](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/475713) has been corrected

# Before

<img width="690" alt="Preview banner" src="https://github.com/user-attachments/assets/5bfc3b54-5f11-47c0-9337-3ceba870a89e" />

# After

<img width="674" alt="Preview banner updated" src="https://github.com/user-attachments/assets/a7f957ac-9f68-49c8-9c54-6a99d7aaaaf6" />
