### PR TITLE
Temporary workaround - remove returnUrl from subsequent pages

### DIFF
--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -40,7 +40,7 @@ export function proceed(
   const response =
     isReturnAllowed && isPathRelative(returnUrl)
       ? h.redirect(returnUrl)
-      : h.redirect(redirectPath(nextUrl, { returnUrl }))
+      : h.redirect(redirectPath(nextUrl))
 
   // Redirect POST to GET to avoid resubmission
   return method === 'post'

--- a/test/form/exit-page.test.js
+++ b/test/form/exit-page.test.js
@@ -198,9 +198,7 @@ describe('Exit pages', () => {
 
         // Redirect back to relevant page (with return URL)
         expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-        expect(response.headers.location).toBe(
-          `${basePath}${paths.next}?returnUrl=${encodeURIComponent(`${basePath}/summary`)}`
-        )
+        expect(response.headers.location).toBe(`${basePath}${paths.next}`)
       })
     }
   )

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -433,9 +433,7 @@ describe('Form journey', () => {
 
       // Redirect back to start
       expect(response.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-      expect(response.headers.location).toBe(
-        `${basePath}/licence?returnUrl=${encodeURIComponent(`${basePath}/summary`)}`
-      )
+      expect(response.headers.location).toBe(`${basePath}/licence`)
     })
   })
 })


### PR DESCRIPTION
This offers a short term workaround for https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490505#20015655.

Tl;Dr: when the user changes their answer and moves on to another branch, ignore the returnUrl in the back link and resume the journey as normal.

This still supports the usual "change your answer" redirect back to the summary screen. I'm just preventing that redirect if the branch changes.