### PR TITLE
Add query handling to `page.getHref()` for back links

### DIFF
--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -9,7 +9,6 @@ import {
   checkFormStatus,
   encodeUrl,
   getErrors,
-  getPageHref,
   proceed
 } from '~/src/server/plugins/engine/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
@@ -220,71 +219,6 @@ describe('Helpers', () => {
 
     it('should throw when invalid url is provided', () => {
       expect(() => encodeUrl('not a url')).toThrow()
-    })
-  })
-
-  describe('getPageHref', () => {
-    it('should return page href', () => {
-      const returned = getPageHref(page)
-      expect(returned).toEqual(page.href)
-    })
-
-    it('should return page href (path override)', () => {
-      const nextPath = '/badgers/monkeys'
-      const nextHref = '/test/badgers/monkeys'
-
-      const returned = getPageHref(page, nextPath)
-      expect(returned).toEqual(nextHref)
-    })
-
-    it('should return page href without query params', () => {
-      request.query.myParam = 'myValue'
-      request.query.myParam2 = 'myValue2'
-
-      const returned = getPageHref(page)
-      expect(returned).toEqual(page.href)
-    })
-
-    it('should return page href (path override) without query params', () => {
-      request.query.myParam = 'myValue'
-      request.query.myParam2 = 'myValue2'
-
-      const nextPath = '/badgers/monkeys'
-      const nextHref = '/test/badgers/monkeys'
-
-      const returned = getPageHref(page, nextPath)
-      expect(returned).toEqual(nextHref)
-    })
-
-    it('should return page href with new query params', () => {
-      const returned = getPageHref(page, {
-        returnUrl: page.getSummaryPath(),
-        badger: 'monkeys'
-      })
-
-      expect(returned).toBe(
-        `${page.href}?returnUrl=${encodeURIComponent('/summary')}&badger=monkeys`
-      )
-    })
-
-    it('should return page href (path override) with new query params', () => {
-      const nextPath = '/badgers/monkeys'
-      const nextHref = '/test/badgers/monkeys'
-
-      const returned = getPageHref(page, nextPath, {
-        returnUrl: page.getSummaryPath(),
-        badger: 'monkeys'
-      })
-
-      expect(returned).toBe(
-        `${nextHref}?returnUrl=${encodeURIComponent('/summary')}&badger=monkeys`
-      )
-    })
-
-    it('should throw when absolute URL is provided', () => {
-      expect(() =>
-        getPageHref(page, 'https://www.gov.uk/help/privacy-notice')
-      ).toThrow('Only relative URLs are allowed')
     })
   })
 

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -9,7 +9,6 @@ import upperFirst from 'lodash/upperFirst.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
-import { type PageControllerClass } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import {
   type FormContextRequest,
   type FormSubmissionError
@@ -63,39 +62,6 @@ export function encodeUrl(link?: string) {
 }
 
 /**
- * Get page href
- */
-export function getPageHref(
-  page: PageControllerClass,
-  query?: FormQuery
-): string
-
-/**
- * Get page href by path
- */
-export function getPageHref(
-  page: PageControllerClass,
-  path: string,
-  query?: FormQuery
-): string
-
-export function getPageHref(
-  page: PageControllerClass,
-  pathOrQuery?: string | FormQuery,
-  queryOnly: FormQuery = {}
-) {
-  const path = typeof pathOrQuery === 'string' ? pathOrQuery : page.path
-  const query = typeof pathOrQuery === 'object' ? pathOrQuery : queryOnly
-
-  if (!isPathRelative(path)) {
-    throw Error(`Only relative URLs are allowed: ${path}`)
-  }
-
-  // Return path with page href as base
-  return redirectPath(page.getHref(path), query)
-}
-
-/**
  * Get redirect path with optional query params
  */
 export function redirectPath(nextUrl: string, query: FormQuery = {}) {
@@ -123,7 +89,7 @@ export function redirectPath(nextUrl: string, query: FormQuery = {}) {
   return url.href
 }
 
-export function isPathRelative(path?: string) {
+export function isPathRelative(path?: string): path is string {
   return (path ?? '').startsWith('/')
 }
 

--- a/src/server/plugins/engine/index.ts
+++ b/src/server/plugins/engine/index.ts
@@ -1,2 +1,1 @@
-export { getPageHref } from '~/src/server/plugins/engine/helpers.js'
 export { configureEnginePlugin } from '~/src/server/plugins/engine/configureEnginePlugin.js'

--- a/src/server/plugins/engine/models/SummaryViewModel.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.ts
@@ -5,7 +5,7 @@ import {
   type Field
 } from '~/src/server/plugins/engine/components/helpers.js'
 import { type BackLink } from '~/src/server/plugins/engine/components/types.js'
-import { getError, getPageHref } from '~/src/server/plugins/engine/helpers.js'
+import { getError } from '~/src/server/plugins/engine/helpers.js'
 import {
   type Detail,
   type DetailItem,
@@ -172,8 +172,8 @@ function ItemRepeat(
     label: title,
     title: values.length ? `${unit} added` : unit,
     value: values.length ? `You added ${values.length} ${unit}` : '',
-    href: getPageHref(page, options.path, {
-      returnUrl: getPageHref(page, page.getSummaryPath())
+    href: page.getHref(options.path, {
+      returnUrl: page.getHref(page.getSummaryPath())
     }),
     state,
     page,
@@ -206,8 +206,8 @@ function ItemField(
     title: field.title,
     error: field.getError(options.errors),
     value: getAnswer(field, state),
-    href: getPageHref(page, options.path, {
-      returnUrl: getPageHref(page, page.getSummaryPath())
+    href: page.getHref(options.path, {
+      returnUrl: page.getHref(page.getSummaryPath())
     }),
     state,
     page,

--- a/src/server/plugins/engine/pageControllers/PageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.test.ts
@@ -85,9 +85,63 @@ describe('PageController', () => {
       it('prefixes paths into link hrefs', () => {
         const href1 = controller1.getHref('/')
         const href2 = controller1.getHref('/page-one')
+        const href3 = controller1.getHref('/page-one', {
+          returnUrl: '/test/summary'
+        })
 
         expect(href1).toBe('/test')
         expect(href2).toBe('/test/page-one')
+        expect(href3).toBe(
+          `/test/page-one?returnUrl=${encodeURIComponent('/test/summary')}`
+        )
+      })
+
+      it('should return page href', () => {
+        const { href, path } = controller1
+
+        const returned = controller1.getHref(path)
+        expect(returned).toEqual(href)
+      })
+
+      it('should return page href (path override)', () => {
+        const nextPath = '/badgers/monkeys'
+        const nextHref = '/test/badgers/monkeys'
+
+        const returned = controller1.getHref(nextPath)
+        expect(returned).toEqual(nextHref)
+      })
+
+      it('should return page href with new query params', () => {
+        const { href, path } = controller1
+
+        const returned = controller1.getHref(path, {
+          returnUrl: controller1.getSummaryPath(),
+          badger: 'monkeys'
+        })
+
+        expect(returned).toBe(
+          `${href}?returnUrl=${encodeURIComponent('/summary')}&badger=monkeys`
+        )
+      })
+
+      it('should return page href (path override) with new query params', () => {
+        const nextPath = '/badgers/monkeys'
+        const nextHref = '/test/badgers/monkeys'
+
+        const returned = controller1.getHref(nextPath, {
+          returnUrl: controller1.getSummaryPath(),
+          badger: 'monkeys'
+        })
+
+        expect(returned).toBe(
+          `${nextHref}?returnUrl=${encodeURIComponent('/summary')}&badger=monkeys`
+        )
+      })
+
+      it('should throw when absolute URL is provided', () => {
+        expect(() =>
+          controller1.getHref('https://www.gov.uk/help/privacy-notice')
+        ).toThrow('Only relative URLs are allowed')
       })
     })
 

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -15,7 +15,9 @@ import { type ComponentCollection } from '~/src/server/plugins/engine/components
 import {
   encodeUrl,
   getStartPath,
-  normalisePath
+  isPathRelative,
+  normalisePath,
+  redirectPath
 } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import {
@@ -23,6 +25,7 @@ import {
   type PageViewModelBase
 } from '~/src/server/plugins/engine/types.js'
 import {
+  type FormQuery,
   type FormRequest,
   type FormRequestPayload,
   type FormRequestPayloadRefs,
@@ -120,12 +123,19 @@ export class PageController {
     return def.phaseBanner?.phase
   }
 
-  getHref(path: string) {
+  getHref(path: string, query: FormQuery = {}) {
     const { model } = this
 
-    return path === '/'
-      ? `/${model.basePath}` // Strip trailing slash
-      : `/${model.basePath}${path}`
+    if (!isPathRelative(path)) {
+      throw Error('Only relative URLs are allowed')
+    }
+
+    const href =
+      path === '/'
+        ? `/${model.basePath}` // Strip trailing slash
+        : `/${model.basePath}${path}`
+
+    return redirectPath(href, query)
   }
 
   getStartPath() {

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -366,7 +366,7 @@ export class RepeatPageController extends QuestionPageController {
     context: FormContext,
     list: RepeatListState
   ): RepeaterSummaryPageViewModel {
-    const { collection, href, repeat } = this
+    const { collection, path, repeat } = this
     const { query } = request
     const { isForceAccess, errors } = context
 
@@ -390,7 +390,7 @@ export class RepeatPageController extends QuestionPageController {
         // Remove summary list actions from previews
         if (!isForceAccess) {
           items.push({
-            href: redirectPath(`${href}/${item.itemId}`, {
+            href: this.getHref(`${path}/${item.itemId}`, {
               returnUrl: query.returnUrl ?? this.getHref(summaryPath)
             }),
             text: 'Change',
@@ -400,7 +400,7 @@ export class RepeatPageController extends QuestionPageController {
 
           if (count > 1) {
             items.push({
-              href: redirectPath(`${href}/${item.itemId}/confirm-delete`, {
+              href: this.getHref(`${path}/${item.itemId}/confirm-delete`, {
                 returnUrl: query.returnUrl
               }),
               text: 'Remove',

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -17,8 +17,7 @@ import {
   getPage,
   getStartPath,
   normalisePath,
-  proceed,
-  redirectPath
+  proceed
 } from '~/src/server/plugins/engine/helpers.js'
 import { FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { FileUploadPageController } from '~/src/server/plugins/engine/pageControllers/FileUploadPageController.js'
@@ -214,7 +213,7 @@ export const plugin = {
 
         // Redirect to GET for preview URL direct access
         if (isForceAccess && !hasFormComponents(pageDef)) {
-          return proceed(request, h, redirectPath(page.href, query))
+          return proceed(request, h, page.getHref(page.path, query))
         }
 
         return page.makePostRouteHandler()(request, context, h)


### PR DESCRIPTION
This PR adds query support to `page.getHref()` and removes `getPageHref()`

Allows us to easily append `?itemId` or `?returnUrl` for back links in [bug #490505](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490505)