### PR TITLE
Allow back link to return to repeater items

### DIFF
--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -22,12 +22,12 @@ import {
 const logger = createLogger()
 
 export function proceed(
-  request: Pick<FormContextRequest, 'method' | 'payload' | 'query'>,
+  request: FormContextRequest,
   h: Pick<ResponseToolkit, 'redirect' | 'view'>,
   nextUrl: string
 ) {
   const { method, payload, query } = request
-  const { returnUrl } = query
+  const { itemId, returnUrl } = query
 
   const isReturnAllowed =
     payload && 'action' in payload
@@ -37,9 +37,9 @@ export function proceed(
 
   // Redirect to return location (optional)
   const response =
-    isReturnAllowed && isPathRelative(returnUrl)
-      ? h.redirect(returnUrl)
-      : h.redirect(redirectPath(nextUrl, { returnUrl }))
+    returnUrl && isReturnAllowed && isPathRelative(returnUrl)
+      ? h.redirect(redirectPath(returnUrl, { itemId }))
+      : h.redirect(redirectPath(nextUrl, { itemId, returnUrl }))
 
   // Redirect POST to GET to avoid resubmission
   return method === 'post'

--- a/src/server/plugins/engine/pageControllers/RepeatPageController.ts
+++ b/src/server/plugins/engine/pageControllers/RepeatPageController.ts
@@ -176,6 +176,27 @@ export class RepeatPageController extends QuestionPageController {
     }
   }
 
+  makePostRouteHandler() {
+    return async (
+      request: FormRequestPayload,
+      context: FormContext,
+      h: Pick<ResponseToolkit, 'redirect' | 'view'>
+    ) => {
+      const { query } = request
+      const { returnUrl } = query
+
+      const summaryPath = this.getSummaryPath(request)
+      const summaryHref = this.getHref(summaryPath)
+
+      // Append item ID for list summary back link
+      if (!returnUrl || summaryHref.startsWith(returnUrl)) {
+        request.query.itemId = this.getItemId(request)
+      }
+
+      return super.makePostRouteHandler()(request, context, h)
+    }
+  }
+
   makeGetListSummaryRouteHandler() {
     return (
       request: FormRequest,
@@ -261,6 +282,7 @@ export class RepeatPageController extends QuestionPageController {
         return super.proceed(request, h, nextPath)
       }
 
+      delete query.itemId
       const nextPath = this.getNextPath(context)
       return super.proceed(request, h, nextPath)
     }
@@ -464,6 +486,7 @@ export class RepeatPageController extends QuestionPageController {
     request: FormContextRequest,
     context: FormContext
   ): BackLink | undefined {
+    const { path } = this
     const { query } = request
     const { returnUrl } = query
 
@@ -480,6 +503,16 @@ export class RepeatPageController extends QuestionPageController {
           text: 'Go back to add another',
           href: returnUrl
         }
+      }
+    }
+
+    // Item back link
+    if (query.itemId) {
+      const backPath = `${path}/${query.itemId}`
+
+      return {
+        text: 'Back',
+        href: this.getHref(backPath, { returnUrl })
       }
     }
 

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -51,7 +51,9 @@ async function createRepeatItem(
   })
 
   expect(res1.statusCode).toBe(StatusCodes.SEE_OTHER)
-  expect(res1.headers.location).toBe(`${basePath}/pizza-order/summary`)
+  expect(res1.headers.location).toBe(
+    `${basePath}/pizza-order/summary?itemId=${itemId}`
+  )
 
   // Extract the session cookie
   const request = res1.request


### PR DESCRIPTION
We currently handle these back link scenarios:

1. Click back to the previous page
2. Click back to the main page from the "Confirm item delete" sub page

This PR adds a third case flagged in [bug #490505](https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/490505) by @alexluckett:

3. Click back to the sub page after creating or editing a repeater item