### PR TITLE
fix: prevent 500s from malformed requests in crumb generation

### DIFF
--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -17,7 +17,9 @@ import {
 import {
   FormAction,
   FormStatus,
-  type FormQuery
+  type FormQuery,
+  type FormRequest,
+  type FormRequestPayload
 } from '~/src/server/routes/types.js'
 
 const logger = createLogger()
@@ -235,4 +237,23 @@ export function getError(detail: ValidationErrorItem): FormSubmissionError {
     text,
     context
   }
+}
+
+/**
+ * A small helper to safely generate a crumb token.
+ * Checks that the crumb plugin is available, that crumb
+ * is not disabled on the current route, and that cookies/state are present.
+ */
+export function safeGenerateCrumb(
+  request: FormRequest | FormRequestPayload | null
+): string | undefined {
+  if (
+    !request?.server.plugins.crumb.generate ||
+    request.route.settings.plugins?.crumb === false ||
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    !request?.state
+  ) {
+    return undefined
+  }
+  return request.server.plugins.crumb.generate(request)
 }

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -247,13 +247,20 @@ export function getError(detail: ValidationErrorItem): FormSubmissionError {
 export function safeGenerateCrumb(
   request: FormRequest | FormRequestPayload | null
 ): string | undefined {
-  if (
-    !request?.server.plugins.crumb.generate ||
-    request.route.settings.plugins?.crumb === false ||
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    !request?.state
-  ) {
+  // no request or no .state
+  if (!request?.state) {
     return undefined
   }
+
+  // crumb plugin or its generate method doesn’t exist
+  if (!request.server.plugins.crumb.generate) {
+    return undefined
+  }
+
+  // crumb is explicitly disabled for this route
+  if (request.route.settings.plugins?.crumb === false) {
+    return undefined
+  }
+
   return request.server.plugins.crumb.generate(request)
 }

--- a/src/server/plugins/nunjucks/context.js
+++ b/src/server/plugins/nunjucks/context.js
@@ -9,7 +9,10 @@ import { parseCookieConsent } from '~/src/common/cookies.js'
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
 import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
-import { encodeUrl } from '~/src/server/plugins/engine/helpers.js'
+import {
+  encodeUrl,
+  safeGenerateCrumb
+} from '~/src/server/plugins/engine/helpers.js'
 
 const logger = createLogger()
 
@@ -54,14 +57,7 @@ export function context(request) {
       serviceName: config.get('serviceName'),
       serviceVersion: config.get('serviceVersion')
     },
-    // only generate crumb if plugin exists and is enabled for this route
-    crumb:
-      request?.server.plugins.crumb.generate &&
-      request.route.settings.plugins?.crumb !== false &&
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      request.state
-        ? request.server.plugins.crumb.generate(request)
-        : undefined,
+    crumb: safeGenerateCrumb(request),
     cspNonce: request?.plugins.blankie?.nonces?.script,
     currentPath: request ? `${request.path}${request.url.search}` : undefined,
     previewMode: isPreviewMode ? params?.state : undefined,

--- a/src/server/plugins/nunjucks/context.js
+++ b/src/server/plugins/nunjucks/context.js
@@ -54,7 +54,14 @@ export function context(request) {
       serviceName: config.get('serviceName'),
       serviceVersion: config.get('serviceVersion')
     },
-    crumb: request?.server.plugins.crumb.generate?.(request),
+    // only generate crumb if plugin exists and is enabled for this route
+    crumb:
+      request?.server.plugins.crumb.generate &&
+      request.route.settings.plugins?.crumb !== false &&
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      request.state
+        ? request.server.plugins.crumb.generate(request)
+        : undefined,
     cspNonce: request?.plugins.blankie?.nonces?.script,
     currentPath: request ? `${request.path}${request.url.search}` : undefined,
     previewMode: isPreviewMode ? params?.state : undefined,


### PR DESCRIPTION
**Summary of Attempted Solutions That Didn't Work:**

1. **Yar Configuration**
   - Tried enabling `storeBlank: true` in session plugin
   - Didn't resolve the state initialisation timing issue and there's the issue of it breaking our auth tests mentioned in the comment

3. **Crumb Plugin Changes**
   - Added `skip` function with state checks
   - Added try/catch and defensive checks
   - Still hit errors before skip function was called

**Root Issue:**
The error occurs because crumb tries to access `request.state` before Yar has a chance to initialise it
