### PR TITLE
Check for valid date when building form context

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -298,6 +298,17 @@ describe('DatePartsField', () => {
         expect(value2).toBeNull()
       })
 
+      it('returns null context when date is invalid', () => {
+        const state1 = getFormState({ day: 1, month: 0, year: 2025 })
+        const state2 = getFormState({})
+
+        const value1 = field.getContextValueFromState(state1)
+        const value2 = field.getContextValueFromState(state2)
+
+        expect(value1).toBeNull()
+        expect(value2).toBeNull()
+      })
+
       it('returns state from payload', () => {
         const payload1 = getFormData(date)
         const payload2 = getFormData({})

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -119,7 +119,16 @@ export class DatePartsField extends FormComponent {
   getContextValueFromState(state: FormSubmissionState) {
     const value = this.getFormValueFromState(state)
 
-    if (!value) {
+    if (
+      !value ||
+      !isValid(
+        parse(
+          `${value.year}-${value.month}-${value.day}`,
+          'yyyy-MM-dd',
+          new Date()
+        )
+      )
+    ) {
       return null
     }
 


### PR DESCRIPTION
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/513237

1. Add a date field to a form
2. Preview the form
3. Enter invalid date: 01 00 20225

Expected: UI Error - "Date must be a real date"
Actual: Sorry, there is a problem with the service