### PR TITLE
Check for valid month year date when building form context

### DIFF
--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -301,12 +301,18 @@ describe('DatePartsField', () => {
       it('returns null context when date is invalid', () => {
         const state1 = getFormState({ day: 1, month: 0, year: 2025 })
         const state2 = getFormState({})
+        const state3 = getFormState({ day: 1, month: 13, year: 2025 })
+        const state4 = getFormState({ day: 32, month: 12, year: 2025 })
 
         const value1 = field.getContextValueFromState(state1)
         const value2 = field.getContextValueFromState(state2)
+        const value3 = field.getContextValueFromState(state3)
+        const value4 = field.getContextValueFromState(state4)
 
         expect(value1).toBeNull()
         expect(value2).toBeNull()
+        expect(value3).toBeNull()
+        expect(value4).toBeNull()
       })
 
       it('returns state from payload', () => {

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -252,6 +252,20 @@ describe('MonthYearField', () => {
         expect(value2).toBeNull()
       })
 
+      it('returns null context when date is invalid', () => {
+        const state1 = getFormState({ month: 0, year: 2025 })
+        const state2 = getFormState({})
+        const state3 = getFormState({ month: 13, year: 2025 })
+
+        const value1 = field.getContextValueFromState(state1)
+        const value2 = field.getContextValueFromState(state2)
+        const value3 = field.getContextValueFromState(state3)
+
+        expect(value1).toBeNull()
+        expect(value2).toBeNull()
+        expect(value3).toBeNull()
+      })
+
       it('returns state from payload', () => {
         const payload1 = getFormData(date)
         const payload2 = {}

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -1,5 +1,5 @@
 import { ComponentType, type MonthYearFieldComponent } from '@defra/forms-model'
-import { format } from 'date-fns'
+import { format, isValid, parse } from 'date-fns'
 import {
   type Context,
   type CustomValidator,
@@ -111,7 +111,12 @@ export class MonthYearField extends FormComponent {
   getContextValueFromState(state: FormSubmissionState) {
     const value = this.getFormValueFromState(state)
 
-    if (!value) {
+    if (
+      !value ||
+      !isValid(
+        parse(`${value.year}-${value.month}-01`, 'yyyy-MM-dd', new Date())
+      )
+    ) {
       return null
     }
 


### PR DESCRIPTION
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/513237

Add a month year field to a form
Preview the form
Enter invalid date: 00 2025 or 13 2025
Expected: UI Error - "Month & year must be a real date"
Actual: Sorry, there is a problem with the service