### PR TITLE
Feature 478377: File-upload JS file submit and polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The designer is no longer a plugin and is responsible for running itself on defa
   - [Local JSON API](#local-json-api)
   - [Production](#production)
   - [npm scripts](#npm-scripts)
+  - [File Uploads with Local Development](#file-uploads-with-local-development)
 - [Docker](#docker)
   - [Development Image](#development-image)
   - [Production Image](#production-image)
@@ -75,6 +76,53 @@ To view them in your command line run:
 ```bash
 $ npm run
 ```
+
+### File Uploads with Local Development
+
+When developing locally with file upload functionality, there are specific configuration requirements to handle CORS (Cross-Origin Resource Sharing) and CSP (Content Security Policy) restrictions.
+
+### Setting up the CDP Uploader Service
+
+The forms-runner application needs to use the CDP uploader service which is available in the docker-compose setup from the forms-api-submissions repository:
+
+1. Clone the forms-api-submissions repository
+2. Start the required services with docker-compose:
+
+```bash
+$ cd forms-api-submissions
+$ docker-compose up -d
+```
+
+This will start:
+
+- The CDP uploader service on port 7337
+- A Nginx reverse proxy on port 7300
+- Supporting services (localstack, Redis) needed by the uploader
+
+### Configuring the Uploader URL
+
+For file uploads to work properly in local development, you need to use the sslip.io domain that maps to the proxy:
+
+1. Set the UPLOADER_URL in your .env file:
+
+```
+UPLOADER_URL=http://uploader.127.0.0.1.sslip.io:7300
+```
+
+2. Make sure "host.docker.internal" is enabled in your Docker Desktop settings
+
+### How it Works
+
+- The docker-compose setup includes an Nginx reverse proxy that routes requests from uploader.127.0.0.1.sslip.io:7300 to the CDP uploader service
+- When developing locally, JavaScript CORS restrictions would normally block direct requests to localhost:7337
+- The sslip.io domain (a special DNS service that maps IPs to domains) allows your browser to make cross-origin requests
+- The application automatically detects local development URLs with localhost:7337 and rewrites them to use the proxy
+
+### Troubleshooting
+
+- If file uploads fail, ensure all the required docker services are running
+- Verify the proxy is working by testing: http://uploader.127.0.0.1.sslip.io:7300
+- Check Docker logs for the cdp-uploader and proxy containers if issues persist
 
 ## Docker
 

--- a/src/client/javascripts/file-upload.js
+++ b/src/client/javascripts/file-upload.js
@@ -253,7 +253,6 @@ function handleStandardFormSubmission(
  * @param {HTMLFormElement} formElement - The form element
  * @param {HTMLInputElement} fileInput - The file input element
  * @param {HTMLButtonElement} uploadButton - The upload button
- * @param {File | null} selectedFile - The selected file
  * @param {HTMLElement | null} errorSummary - The error summary container
  * @param {string | undefined} uploadId - The upload ID
  * @returns {boolean} Whether the event was handled
@@ -263,7 +262,6 @@ function handleAjaxFormSubmission(
   formElement,
   fileInput,
   uploadButton,
-  selectedFile,
   errorSummary,
   uploadId
 ) {
@@ -272,13 +270,9 @@ function handleAjaxFormSubmission(
   }
 
   event.preventDefault()
-  renderSummary(selectedFile, 'Uploading…', formElement)
 
   const formData = new FormData(formElement)
   const uploadUrl = formElement.dataset.proxyUrl ?? formElement.action
-
-  fileInput.disabled = true
-  uploadButton.disabled = true
 
   fetch(uploadUrl, {
     method: 'POST',
@@ -350,25 +344,20 @@ export function initFileUpload() {
 
     isSubmitting = true
 
-    if (
-      handleAjaxFormSubmission(
-        event,
-        formElement,
-        fileInput,
-        uploadButton,
-        selectedFile,
-        /** @type {HTMLElement | null} */ (errorSummary),
-        uploadId
-      )
-    ) {
-      return
-    }
-
     handleStandardFormSubmission(
       formElement,
       fileInput,
       uploadButton,
       selectedFile
+    )
+
+    handleAjaxFormSubmission(
+      event,
+      formElement,
+      fileInput,
+      uploadButton,
+      /** @type {HTMLElement | null} */ (errorSummary),
+      uploadId
     )
   })
 }

--- a/src/server/plugins/blankie.test.ts
+++ b/src/server/plugins/blankie.test.ts
@@ -50,4 +50,24 @@ describe('Server Blankie Plugin', () => {
       generateNonces: true
     })
   })
+
+  test('configuration includes uploaderUrl when provided', () => {
+    config.set('googleAnalyticsTrackingId', '')
+    config.set('uploaderUrl', 'https://some-random-uploader.example.com')
+
+    const { options } = configureBlankiePlugin()
+
+    expect(options?.connectSrc).toContain(
+      'https://some-random-uploader.example.com'
+    )
+  })
+
+  test('configuration does not include uploaderUrl when not provided', () => {
+    config.set('googleAnalyticsTrackingId', '')
+    config.set('uploaderUrl', '')
+
+    const { options } = configureBlankiePlugin()
+
+    expect(options?.connectSrc).toEqual(['self'])
+  })
 })

--- a/src/server/plugins/blankie.test.ts
+++ b/src/server/plugins/blankie.test.ts
@@ -11,7 +11,7 @@ describe('Server Blankie Plugin', () => {
       defaultSrc: ['self'],
       fontSrc: ['self', 'data:'],
       frameSrc: ['self', 'data:'],
-      connectSrc: ['self'],
+      connectSrc: ['self', 'https://test-uploader.cdp-int.defra.cloud'],
       scriptSrc: ['self', 'strict-dynamic', 'unsafe-inline'],
       styleSrc: ['self', 'unsafe-inline'],
       imgSrc: ['self'],
@@ -32,7 +32,8 @@ describe('Server Blankie Plugin', () => {
         'self',
         'https://*.google-analytics.com',
         'https://*.analytics.google.com',
-        'https://*.googletagmanager.com'
+        'https://*.googletagmanager.com',
+        'https://test-uploader.cdp-int.defra.cloud'
       ],
       scriptSrc: [
         'self',

--- a/src/server/plugins/blankie.ts
+++ b/src/server/plugins/blankie.ts
@@ -3,7 +3,6 @@ import Blankie from 'blankie'
 
 import { config } from '~/src/config/index.js'
 
-const uploaderUrl = config.get('uploaderUrl')
 const googleAnalyticsOptions = {
   scriptSrc: ['https://*.googletagmanager.com'],
   imgSrc: ['https://*.google-analytics.com', 'https://*.googletagmanager.com'],
@@ -18,6 +17,7 @@ export const configureBlankiePlugin = (): ServerRegisterPluginObject<
   Record<string, boolean | string | string[]>
 > => {
   const gaTrackingId = config.get('googleAnalyticsTrackingId')
+  const uploaderUrl = config.get('uploaderUrl')
 
   /*
   Note that unsafe-inline is a fallback for old browsers that don't support nonces. It will be ignored by modern browsers as the nonce is provided.

--- a/src/server/plugins/blankie.ts
+++ b/src/server/plugins/blankie.ts
@@ -3,6 +3,7 @@ import Blankie from 'blankie'
 
 import { config } from '~/src/config/index.js'
 
+const uploaderUrl = config.get('uploaderUrl')
 const googleAnalyticsOptions = {
   scriptSrc: ['https://*.googletagmanager.com'],
   imgSrc: ['https://*.google-analytics.com', 'https://*.googletagmanager.com'],
@@ -28,7 +29,8 @@ export const configureBlankiePlugin = (): ServerRegisterPluginObject<
       fontSrc: ['self', 'data:'],
       connectSrc: [
         ['self'],
-        gaTrackingId ? googleAnalyticsOptions.connectSrc : []
+        gaTrackingId ? googleAnalyticsOptions.connectSrc : [],
+        uploaderUrl ? [uploaderUrl] : []
       ].flat(),
       scriptSrc: [
         ['self', 'strict-dynamic', 'unsafe-inline'],

--- a/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
+++ b/src/server/plugins/engine/pageControllers/FileUploadPageController.ts
@@ -14,6 +14,7 @@ import {
 } from '~/src/server/plugins/engine/helpers.js'
 import { type FormModel } from '~/src/server/plugins/engine/models/index.js'
 import { QuestionPageController } from '~/src/server/plugins/engine/pageControllers/QuestionPageController.js'
+import { getProxyUrlForLocalDevelopment } from '~/src/server/plugins/engine/pageControllers/helpers.js'
 import {
   getUploadStatus,
   initiateUpload
@@ -252,14 +253,18 @@ export class FileUploadPageController extends QuestionPageController {
 
     const index = components.indexOf(formComponent)
 
+    const proxyUrl = getProxyUrlForLocalDevelopment(upload?.uploadUrl)
+
     return {
       ...viewModel,
       formAction: upload?.uploadUrl,
+      uploadId: upload?.uploadId,
       formComponent,
 
       // Split out components before/after
       componentsBefore: components.slice(0, index),
-      components: components.slice(index)
+      components: components.slice(index),
+      proxyUrl
     }
   }
 
@@ -317,7 +322,7 @@ export class FileUploadPageController extends QuestionPageController {
     if (statusResponse.uploadStatus === UploadStatus.pending) {
       // Using exponential backoff delays:
       // Depth 1: 2000ms, Depth 2: 4000ms, Depth 3: 8000ms, Depth 4: 16000ms, Depth 5+: 30000ms (capped)
-      // A depth of 5 (or more) implies cumulative delays roughly reaching 60 seconds.
+      // A depth of 5 (or more) implies cumulative delays roughly reaching 55 seconds.
       if (depth >= 5) {
         request.logger.error(
           `Exceeded cumulative retry delay for ${uploadId} (depth: ${depth}). Re-initiating a new upload.`

--- a/src/server/plugins/engine/pageControllers/helpers.test.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.test.ts
@@ -9,6 +9,7 @@ import {
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   createPage,
+  getProxyUrlForLocalDevelopment,
   isPageController,
   type PageControllerType
 } from '~/src/server/plugins/engine/pageControllers/helpers.js'
@@ -130,6 +131,33 @@ describe('Page controller helpers', () => {
       { name: '' }
     ])("rejects invalid page controller '$name'", ({ name }) => {
       expect(isPageController(name)).toBe(false)
+    })
+  })
+
+  describe('Helper: getProxyUrlForLocalDevelopment', () => {
+    it('returns null if uploadUrl is undefined', () => {
+      expect(getProxyUrlForLocalDevelopment(undefined)).toBeNull()
+    })
+
+    it('returns null if uploadUrl does not include localhost:7337', () => {
+      expect(getProxyUrlForLocalDevelopment('https://some-url.com')).toBeNull()
+      expect(getProxyUrlForLocalDevelopment('http://localhost:8080')).toBeNull()
+    })
+
+    it('replaces localhost:7337 with uploader.127.0.0.1.sslip.io:7300', () => {
+      const originalUrl = 'http://localhost:7337/upload'
+      const expectedUrl = 'http://uploader.127.0.0.1.sslip.io:7300/upload'
+
+      expect(getProxyUrlForLocalDevelopment(originalUrl)).toBe(expectedUrl)
+    })
+
+    it('handles multiple occurrences of localhost:7337', () => {
+      const originalUrl =
+        'http://localhost:7337/path?redirect=http://localhost:7337/callback'
+      const expectedUrl =
+        'http://uploader.127.0.0.1.sslip.io:7300/path?redirect=http://uploader.127.0.0.1.sslip.io:7300/callback'
+
+      expect(getProxyUrlForLocalDevelopment(originalUrl)).toBe(expectedUrl)
     })
   })
 })

--- a/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.ts
@@ -71,3 +71,21 @@ export function createPage(model: FormModel, pageDef: Page) {
 
   return controller
 }
+
+/**
+ * In local development environments, we sometimes need to rewrite the
+ * CDP upload URL to work with CSP/CORS restrictions.
+ * This helper function rewrites localhost URLs to use the sslip.io proxy
+ * This is only used when running locally with a development proxy.
+ * In non-local environments, this function returns null
+ * @param uploadUrl - The original upload URL from CDP
+ */
+export function getProxyUrlForLocalDevelopment(
+  uploadUrl?: string
+): string | null {
+  if (!uploadUrl?.includes('localhost:7337')) {
+    return null
+  }
+
+  return uploadUrl.replace('localhost:7337', 'uploader.127.0.0.1.sslip.io:7300')
+}

--- a/src/server/plugins/engine/pageControllers/helpers.ts
+++ b/src/server/plugins/engine/pageControllers/helpers.ts
@@ -87,5 +87,8 @@ export function getProxyUrlForLocalDevelopment(
     return null
   }
 
-  return uploadUrl.replace('localhost:7337', 'uploader.127.0.0.1.sslip.io:7300')
+  return uploadUrl.replace(
+    /localhost:7337/g,
+    'uploader.127.0.0.1.sslip.io:7300'
+  )
 }

--- a/src/server/plugins/engine/types.ts
+++ b/src/server/plugins/engine/types.ts
@@ -284,6 +284,8 @@ export interface FeaturedFormPageViewModel extends FormPageViewModel {
   formAction?: string
   formComponent: ComponentViewModel
   componentsBefore: ComponentViewModel[]
+  uploadId: string | undefined
+  proxyUrl: string | null
 }
 
 export type PageViewModel =

--- a/src/server/plugins/engine/views/file-upload.html
+++ b/src/server/plugins/engine/views/file-upload.html
@@ -9,7 +9,7 @@
 
   <div class="govuk-error-summary-container"></div>
 
-  <form method="post" {%- if formAction and not context.isForceAccess %} action="{{ formAction }}" enctype="multipart/form-data" {%- endif %} novalidate>
+  <form method="post" {%- if formAction and not context.isForceAccess %} action="{{ formAction }}" enctype="multipart/form-data" data-upload-id="{{ uploadId }}" {% if proxyUrl %}data-proxy-url="{{ proxyUrl }}"{% endif %} {%- endif %} novalidate>
     {{ govukFileUpload(formComponent.model) }}
 
     {% if formAction %}


### PR DESCRIPTION
Done as part of https://dev.azure.com/defragovuk/DEFRA-CDP/_boards/board/t/DXT%20Team/Stories?System.IterationPath=%40currentIteration&workitem=478377 and a follow-up to https://github.com/DEFRA/forms-runner/pull/710.

This introduces the file submission directly from the browser with polling of the CDP Uploader file scan status. After receiving a successful (`ready`) response from CDP, we then refresh the page. By this time, the CDP callback to our service would've already ingested the response and updated the state.

