### PR TITLE
Fixed re-evaluate condition on validation error

### DIFF
--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -12,6 +12,7 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
 import { CacheService } from '~/src/server/services/cacheService.js'
+import conditionalReveal from '~/test/form/definitions/conditional-reveal.js'
 import definitionConditionsBasic, {
   V2 as definitionConditionsBasicV2
 } from '~/test/form/definitions/conditions-basic.js'
@@ -396,6 +397,86 @@ describe('QuestionPageController', () => {
         dateField__month: 1,
         dateField__year: 2024
       })
+    })
+
+    it('filters on condition A', () => {
+      const { pages } = conditionalReveal
+
+      const model = new FormModel(conditionalReveal, {
+        basePath: 'test'
+      })
+
+      const controller = new QuestionPageController(model, pages[0])
+
+      // The state below shows we said we had a UKPassport and entered details for an applicant
+      const state: FormSubmissionState = {}
+
+      const request = {
+        method: 'get',
+        url: new URL('http://example.com/test/page-one'),
+        path: '/test/first-page',
+        params: {
+          path: 'first-page',
+          slug: 'test'
+        },
+        query: {},
+        app: { model }
+      } satisfies FormContextRequest
+
+      const context = controller.model.getFormContext(request, state)
+      const evaluationState = { animalType: 'Barn owl' }
+
+      const viewModel = controller.getViewModel(request, context)
+
+      const filtered = controller.filterConditionalComponents(
+        viewModel,
+        model,
+        evaluationState
+      )
+
+      expect(filtered).toHaveLength(2)
+      expect(filtered[0].model.content).toBe('This is info for Barn owls')
+      expect(filtered[1].model.label?.text).toBe('Select from the list')
+    })
+
+    it('filters on condition B', () => {
+      const { pages } = conditionalReveal
+
+      const model = new FormModel(conditionalReveal, {
+        basePath: 'test'
+      })
+
+      const controller = new QuestionPageController(model, pages[0])
+
+      // The state below shows we said we had a UKPassport and entered details for an applicant
+      const state: FormSubmissionState = {}
+
+      const request = {
+        method: 'get',
+        url: new URL('http://example.com/test/page-one'),
+        path: '/test/first-page',
+        params: {
+          path: 'first-page',
+          slug: 'test'
+        },
+        query: {},
+        app: { model }
+      } satisfies FormContextRequest
+
+      const context = controller.model.getFormContext(request, state)
+      const evaluationState = { animalType: 'Swan' }
+
+      const viewModel = controller.getViewModel(request, context)
+
+      const filtered = controller.filterConditionalComponents(
+        viewModel,
+        model,
+        evaluationState
+      )
+
+      expect(filtered).toHaveLength(2)
+      expect(filtered[0].model.content).toBe('This is info for other breeds')
+      expect(filtered[1].model.label?.text).toBe('Select from the list')
     })
   })
 

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.test.ts
@@ -437,6 +437,22 @@ describe('QuestionPageController', () => {
       expect(filtered).toHaveLength(2)
       expect(filtered[0].model.content).toBe('This is info for Barn owls')
       expect(filtered[1].model.label?.text).toBe('Select from the list')
+      expect(filtered[1].model.items).toEqual([
+        {
+          checked: false,
+          condition: 'isBarnOwl',
+          selected: false,
+          text: 'Option 1',
+          value: '1'
+        },
+        {
+          checked: false,
+          condition: 'isBarnOwl',
+          selected: false,
+          text: 'Option 2',
+          value: '2'
+        }
+      ])
     })
 
     it('filters on condition B', () => {
@@ -477,6 +493,22 @@ describe('QuestionPageController', () => {
       expect(filtered).toHaveLength(2)
       expect(filtered[0].model.content).toBe('This is info for other breeds')
       expect(filtered[1].model.label?.text).toBe('Select from the list')
+      expect(filtered[1].model.items).toEqual([
+        {
+          checked: false,
+          condition: 'notBarnOwl',
+          selected: false,
+          text: 'Option 3',
+          value: '3'
+        },
+        {
+          checked: false,
+          condition: 'notBarnOwl',
+          selected: false,
+          text: 'Option 4',
+          value: '4'
+        }
+      ])
     })
   })
 

--- a/src/server/plugins/engine/pageControllers/QuestionPageController.ts
+++ b/src/server/plugins/engine/pageControllers/QuestionPageController.ts
@@ -349,7 +349,7 @@ export class QuestionPageController extends PageController {
     filtered = filtered.map((component) => {
       const evaluatedComponent = component
       const content = evaluatedComponent.model.content
-      if (content instanceof Array) {
+      if (Array.isArray(content)) {
         evaluatedComponent.model.content = content.filter((item) =>
           item.condition
             ? model.conditions[item.condition]?.fn(evaluationState)
@@ -359,7 +359,7 @@ export class QuestionPageController extends PageController {
       // apply condition to items for radios, checkboxes etc
       const items = evaluatedComponent.model.items
 
-      if (items instanceof Array) {
+      if (Array.isArray(items)) {
         evaluatedComponent.model.items = items.filter((item) =>
           item.condition
             ? model.conditions[item.condition]?.fn(evaluationState)

--- a/test/form/definitions/conditional-reveal.js
+++ b/test/form/definitions/conditional-reveal.js
@@ -57,19 +57,23 @@ export default /** @satisfies {FormDefinition} */ ({
       items: [
         {
           text: 'Option 1',
-          value: '1'
+          value: '1',
+          condition: 'isBarnOwl'
         },
         {
           text: 'Option 2',
-          value: '2'
+          value: '2',
+          condition: 'isBarnOwl'
         },
         {
           text: 'Option 3',
-          value: '3'
+          value: '3',
+          condition: 'notBarnOwl'
         },
         {
           text: 'Option 4',
-          value: '4'
+          value: '4',
+          condition: 'notBarnOwl'
         }
       ]
     }

--- a/test/form/definitions/conditional-reveal.js
+++ b/test/form/definitions/conditional-reveal.js
@@ -1,0 +1,136 @@
+import {
+  ComponentType,
+  ConditionType,
+  ControllerPath,
+  ControllerType,
+  OperatorName
+} from '@defra/forms-model'
+
+export default /** @satisfies {FormDefinition} */ ({
+  name: 'Conditions',
+  startPage: '/first-page',
+  pages: /** @type {const} */ ([
+    {
+      title: 'Pay charges',
+      path: '/first-page',
+      components: [
+        {
+          name: 'HJrybi',
+          title: 'Html',
+          type: ComponentType.Html,
+          content: 'This is info for Barn owls',
+          options: {
+            condition: 'isBarnOwl'
+          }
+        },
+        {
+          name: 'VjISpj',
+          title: 'Html',
+          type: ComponentType.Html,
+          content: 'This is info for other breeds',
+          options: {
+            condition: 'notBarnOwl'
+          }
+        },
+        {
+          name: 'XEaUmK',
+          title: 'Select from the list',
+          type: ComponentType.RadiosField,
+          hint: '',
+          list: 'condList',
+          options: {}
+        }
+      ],
+      next: [{ path: '/summary' }]
+    },
+    {
+      title: 'Summary',
+      path: ControllerPath.Summary,
+      controller: ControllerType.Summary
+    }
+  ]),
+  lists: [
+    {
+      title: 'Example list with conditional elements',
+      name: 'condList',
+      type: 'string',
+      items: [
+        {
+          text: 'Option 1',
+          value: '1'
+        },
+        {
+          text: 'Option 2',
+          value: '2'
+        },
+        {
+          text: 'Option 3',
+          value: '3'
+        },
+        {
+          text: 'Option 4',
+          value: '4'
+        }
+      ]
+    }
+  ],
+  sections: [
+    {
+      name: 'charges',
+      title: 'Charges'
+    }
+  ],
+  conditions: [
+    {
+      name: 'isBarnOwl',
+      displayName: 'Is barn owl',
+      value: {
+        name: 'Is barn owl',
+        conditions: [
+          {
+            field: {
+              name: 'animalType',
+              type: ComponentType.RadiosField,
+              display:
+                'Which species do you want to apply for a class licence for?'
+            },
+            operator: OperatorName.Is,
+            value: {
+              type: ConditionType.Value,
+              value: 'Barn owl',
+              display: 'Barn owl '
+            }
+          }
+        ]
+      }
+    },
+    {
+      name: 'notBarnOwl',
+      displayName: 'Is not barn owl',
+      value: {
+        name: 'Is not barn owl',
+        conditions: [
+          {
+            field: {
+              name: 'animalType',
+              type: ComponentType.RadiosField,
+              display:
+                'Which species do you want to apply for a class licence for?'
+            },
+            operator: OperatorName.IsNot,
+            value: {
+              type: ConditionType.Value,
+              value: 'Barn owl',
+              display: 'Barn owl '
+            }
+          }
+        ]
+      }
+    }
+  ],
+  outputEmail: 'enrique.chase@defra.gov.uk'
+})
+
+/**
+ * @import { FormDefinition } from '@defra/forms-model'
+ */


### PR DESCRIPTION
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/509789
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/512634

509789 - Conditional Item View is being ignored
512634 - Conditional guidance components were not being re-evaluated on validation error
