### PR TITLE
Fix: Adjust fetch options for file uploads in local development

### DIFF
--- a/src/client/javascripts/file-upload.js
+++ b/src/client/javascripts/file-upload.js
@@ -272,13 +272,21 @@ function handleAjaxFormSubmission(
   event.preventDefault()
 
   const formData = new FormData(formElement)
+  const isLocalDev = !!formElement.dataset.proxyUrl
   const uploadUrl = formElement.dataset.proxyUrl ?? formElement.action
 
-  fetch(uploadUrl, {
+  const fetchOptions = /** @type {RequestInit} */ ({
     method: 'POST',
     body: formData,
-    redirect: 'manual'
+    redirect: isLocalDev ? 'follow' : 'manual' // follow mode if local development with the proxy
   })
+
+  // no-cors mode if needed local development with the proxy
+  if (isLocalDev) {
+    fetchOptions.mode = 'no-cors'
+  }
+
+  fetch(uploadUrl, fetchOptions)
     .then(() => {
       pollUploadStatus(uploadId)
     })

--- a/test/client/javascripts/file-upload.test.js
+++ b/test/client/javascripts/file-upload.test.js
@@ -1069,7 +1069,6 @@ describe('File Upload Client JS', () => {
     )
     global.fetch = fetchMock
 
-    // Mock FormData
     const originalFormData = global.FormData
     const formDataMock = jest.fn(function () {
       return {
@@ -1107,13 +1106,75 @@ describe('File Upload Client JS', () => {
 
     expect(preventDefaultMock).toHaveBeenCalled()
     expect(formDataMock).toHaveBeenCalled()
+
+    // local development configuration (proxy URL exists)
     expect(fetchMock).toHaveBeenCalledWith(
       '/proxy-endpoint',
       expect.objectContaining({
         method: 'POST',
-        redirect: 'manual'
+        redirect: 'follow',
+        mode: 'no-cors'
       })
     )
+
+    global.fetch = originalFetch
+    global.FormData = originalFormData
+  })
+
+  test('handles AJAX form submission without proxy URL (production)', () => {
+    const originalFetch = global.fetch
+    const fetchMock = jest.fn(() =>
+      Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+    )
+    global.fetch = fetchMock
+
+    const originalFormData = global.FormData
+    const formDataMock = jest.fn(function () {
+      return {
+        append: jest.fn()
+      }
+    })
+    global.FormData = /** @type {any} */ (formDataMock)
+
+    document.body.innerHTML = `
+      <div class="govuk-error-summary-container"></div>
+      <form action="/upload-endpoint" data-upload-id="test-id" enctype="multipart/form-data">
+        <input type="file" id="file-upload">
+        <button class="govuk-button govuk-button--secondary upload-file-button">Upload file</button>
+      </form>
+      <form>
+        <div id="uploadedFilesContainer">
+          <h2 class="govuk-heading-m">Uploaded files</h2>
+          <p class="govuk-body">0 files uploaded</p>
+        </div>
+        <button class="govuk-button">Continue</button>
+      </form>
+    `
+
+    const tempGlobal = /** @type {any} */ (global)
+    // eslint-disable-next-line @typescript-eslint/dot-notation, @typescript-eslint/no-unsafe-member-access
+    tempGlobal['pollUploadStatus'] = jest.fn()
+
+    const { loadFile, triggerChange, triggerClick } = setupTestableComponent()
+
+    loadFile('some-file.pdf')
+    triggerChange()
+
+    const preventDefaultMock = jest.fn()
+    triggerClick({ preventDefault: preventDefaultMock })
+
+    expect(preventDefaultMock).toHaveBeenCalled()
+    expect(formDataMock).toHaveBeenCalled()
+
+    expect(fetchMock).toHaveBeenCalled()
+    const [actualUrl, options] = /** @type {[string, RequestInit]} */ (
+      /** @type {unknown} */ (fetchMock.mock.calls[0])
+    )
+    expect(actualUrl.endsWith('/upload-endpoint')).toBe(true)
+    expect(options).toMatchObject({
+      method: 'POST',
+      redirect: 'manual'
+    })
 
     global.fetch = originalFetch
     global.FormData = originalFormData

--- a/test/client/javascripts/file-upload.test.js
+++ b/test/client/javascripts/file-upload.test.js
@@ -1107,13 +1107,20 @@ describe('File Upload Client JS', () => {
     expect(preventDefaultMock).toHaveBeenCalled()
     expect(formDataMock).toHaveBeenCalled()
 
-    // local development configuration (proxy URL exists)
     expect(fetchMock).toHaveBeenCalledWith(
       '/proxy-endpoint',
       expect.objectContaining({
         method: 'POST',
         redirect: 'follow',
         mode: 'no-cors'
+      })
+    )
+
+    // it was NOT called with 'manual' redirect
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/proxy-endpoint',
+      expect.objectContaining({
+        redirect: 'manual'
       })
     )
 
@@ -1175,6 +1182,8 @@ describe('File Upload Client JS', () => {
       method: 'POST',
       redirect: 'manual'
     })
+
+    expect(options.mode).not.toBe('no-cors')
 
     global.fetch = originalFetch
     global.FormData = originalFormData


### PR DESCRIPTION
The PR modifies fetch to:

- Use `redirect: 'follow'` instead of `'manual'` when a proxy URL is present locally as in production, we're receiving the redirect from CDP but not doing anything with it.
- Add `mode: 'no-cors'` to handle CORS in local development.

Done on the back off: https://github.com/DEFRA/forms-runner/pull/720/files

