### PR TITLE
Fix: Remove aria-describedby attribute based on the presence of an error summary title element 

### DIFF
--- a/src/client/javascripts/file-upload.js
+++ b/src/client/javascripts/file-upload.js
@@ -161,7 +161,12 @@ function showError(message, errorSummary, fileInput) {
   const topErrorSummary = document.querySelector('.govuk-error-summary')
 
   if (topErrorSummary) {
-    fileInput.setAttribute(ARIA_DESCRIBEDBY, 'error-summary-title')
+    const titleElement = document.getElementById('error-summary-title')
+    if (titleElement) {
+      fileInput.setAttribute(ARIA_DESCRIBEDBY, 'error-summary-title')
+    } else {
+      fileInput.removeAttribute(ARIA_DESCRIBEDBY)
+    }
     return
   }
 

--- a/src/client/javascripts/file-upload.js
+++ b/src/client/javascripts/file-upload.js
@@ -1,5 +1,6 @@
 export const MAX_POLLING_DURATION = 300 // 5 minutes
 const ARIA_DESCRIBEDBY = 'aria-describedby'
+const ERROR_SUMMARY_TITLE_ID = 'error-summary-title'
 
 /**
  * Creates or updates status announcer for screen readers
@@ -161,9 +162,9 @@ function showError(message, errorSummary, fileInput) {
   const topErrorSummary = document.querySelector('.govuk-error-summary')
 
   if (topErrorSummary) {
-    const titleElement = document.getElementById('error-summary-title')
+    const titleElement = document.getElementById(ERROR_SUMMARY_TITLE_ID)
     if (titleElement) {
-      fileInput.setAttribute(ARIA_DESCRIBEDBY, 'error-summary-title')
+      fileInput.setAttribute(ARIA_DESCRIBEDBY, ERROR_SUMMARY_TITLE_ID)
     } else {
       fileInput.removeAttribute(ARIA_DESCRIBEDBY)
     }
@@ -174,7 +175,7 @@ function showError(message, errorSummary, fileInput) {
     errorSummary.innerHTML = `
         <div class="govuk-error-summary" data-module="govuk-error-summary">
           <div role="alert">
-            <h2 class="govuk-error-summary__title" id="error-summary-title">
+            <h2 class="govuk-error-summary__title" id="${ERROR_SUMMARY_TITLE_ID}">
               There is a problem
             </h2>
             <div class="govuk-error-summary__body">
@@ -188,7 +189,7 @@ function showError(message, errorSummary, fileInput) {
         </div>
       `
 
-    fileInput.setAttribute(ARIA_DESCRIBEDBY, 'error-summary-title')
+    fileInput.setAttribute(ARIA_DESCRIBEDBY, ERROR_SUMMARY_TITLE_ID)
   }
 
   const formGroup = fileInput.closest('.govuk-form-group')

--- a/test/client/javascripts/file-upload.test.js
+++ b/test/client/javascripts/file-upload.test.js
@@ -1254,4 +1254,48 @@ describe('File Upload Client JS', () => {
       `${fileInput?.id}-error`
     )
   })
+
+  test('sets aria-describedby when error summary exists with title element', () => {
+    document.body.innerHTML = `
+      <div class="govuk-error-summary">
+        <div role="alert">
+          <h2 class="govuk-error-summary__title" id="error-summary-title">Existing error</h2>
+        </div>
+      </div>
+      <div class="govuk-error-summary-container"></div>
+      <form>
+        <input type="file" id="file-upload">
+        <button class="govuk-button govuk-button--secondary upload-file-button">Upload file</button>
+      </form>
+    `
+
+    const { triggerClick, fileInput } = setupTestableComponent()
+    triggerClick({ preventDefault: jest.fn() })
+
+    expect(fileInput?.getAttribute('aria-describedby')).toBe(
+      'error-summary-title'
+    )
+  })
+
+  test('removes aria-describedby when error summary exists without title element', () => {
+    document.body.innerHTML = `
+      <div class="govuk-error-summary">
+        <div role="alert">
+          <h2 class="govuk-error-summary__title">Existing error without ID</h2>
+        </div>
+      </div>
+      <div class="govuk-error-summary-container"></div>
+      <form>
+        <input type="file" id="file-upload">
+        <button class="govuk-button govuk-button--secondary upload-file-button">Upload file</button>
+      </form>
+    `
+
+    const { triggerClick, fileInput } = setupTestableComponent()
+
+    fileInput?.setAttribute('aria-describedby', 'some-value')
+    triggerClick({ preventDefault: jest.fn() })
+
+    expect(fileInput?.hasAttribute('aria-describedby')).toBe(false)
+  })
 })


### PR DESCRIPTION
This PR enhances the accessibility in file upload component by conditionally setting or removing `aria-describedby` attribute based on the presence of an error summary title element. Added unit tests to verify the new behaviour for both scenarios.