### PR TITLE
Feat/526386  render short description

### DIFF
--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -317,9 +317,8 @@ describe.each([
             shortDescription: 'Your example text',
             name: 'myComponent',
             type: ComponentType.AutocompleteField,
-
-            options: {},
-            schema: {}
+            list: 'ABCE',
+            options: {}
           } satisfies AutocompleteFieldComponent,
           assertions: [
             {

--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -34,7 +34,7 @@ describe.each([
       list: listString,
       examples: listStringExamples,
       allow: ['1', '2', '3', '4'],
-      shortDescription: 'my string list'
+      shortDescription: 'My string list'
     }
   },
   {
@@ -50,7 +50,7 @@ describe.each([
       list: listNumber,
       examples: listNumberExamples,
       allow: [1, 2, 3, 4],
-      shortDescription: 'my number list'
+      shortDescription: 'My number list'
     }
   }
 ])('AutocompleteField: $component.title', ({ component: def, options }) => {
@@ -156,7 +156,7 @@ describe.each([
 
         expect(result.errors).toEqual([
           expect.objectContaining({
-            text: `Enter ${def.title.toLowerCase()}`
+            text: `Enter ${lowerFirst(def.title)}`
           })
         ])
       })
@@ -171,6 +171,20 @@ describe.each([
         expect(result.errors).toEqual([
           expect.objectContaining({
             text: `Enter ${lowerFirst(options.shortDescription)}`
+          })
+        ])
+      })
+
+      it('adds errors for empty value if shortDescription exists but is empty', () => {
+        collection = new ComponentCollection(
+          [{ ...def, shortDescription: '' }],
+          { model }
+        )
+        const result = collection.validate(getFormData(''))
+
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            text: `Enter ${lowerFirst(def.title)}`
           })
         ])
       })

--- a/src/server/plugins/engine/components/AutocompleteField.test.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.test.ts
@@ -2,6 +2,7 @@ import {
   ComponentType,
   type AutocompleteFieldComponent
 } from '@defra/forms-model'
+import lowerFirst from 'lodash/lowerFirst.js'
 
 import { AutocompleteField } from '~/src/server/plugins/engine/components/AutocompleteField.js'
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
@@ -32,7 +33,8 @@ describe.each([
     options: {
       list: listString,
       examples: listStringExamples,
-      allow: ['1', '2', '3', '4']
+      allow: ['1', '2', '3', '4'],
+      shortDescription: 'my string list'
     }
   },
   {
@@ -47,7 +49,8 @@ describe.each([
     options: {
       list: listNumber,
       examples: listNumberExamples,
-      allow: [1, 2, 3, 4]
+      allow: [1, 2, 3, 4],
+      shortDescription: 'my number list'
     }
   }
 ])('AutocompleteField: $component.title', ({ component: def, options }) => {
@@ -154,6 +157,20 @@ describe.each([
         expect(result.errors).toEqual([
           expect.objectContaining({
             text: `Enter ${def.title.toLowerCase()}`
+          })
+        ])
+      })
+
+      it('adds errors for empty value if shortDescription exists', () => {
+        collection = new ComponentCollection(
+          [{ ...def, shortDescription: options.shortDescription }],
+          { model }
+        )
+        const result = collection.validate(getFormData(''))
+
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            text: `Enter ${lowerFirst(options.shortDescription)}`
           })
         ])
       })
@@ -289,6 +306,36 @@ describe.each([
         const { items } = new AutocompleteField(def, { model })
         expect(items).toEqual([])
       })
+    })
+
+    describe('Validation', () => {
+      describe.each([
+        {
+          description: 'Use short description if it exists',
+          component: {
+            title: 'What is your example text?',
+            shortDescription: 'Your example text',
+            name: 'myComponent',
+            type: ComponentType.AutocompleteField,
+
+            options: {},
+            schema: {}
+          } satisfies AutocompleteFieldComponent,
+          assertions: [
+            {
+              input: getFormData(''),
+              output: {
+                value: getFormData(''),
+                errors: [
+                  expect.objectContaining({
+                    text: 'Enter your example text'
+                  })
+                ]
+              }
+            }
+          ]
+        }
+      ])
     })
   })
 })

--- a/src/server/plugins/engine/components/AutocompleteField.ts
+++ b/src/server/plugins/engine/components/AutocompleteField.ts
@@ -23,7 +23,9 @@ export class AutocompleteField extends SelectField {
       const messages = options.customValidationMessages
 
       formSchema = formSchema.messages({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         'any.only': messages?.['any.only'] ?? messageTemplate.required,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         'any.required': messages?.['any.required'] ?? messageTemplate.required
       })
     }

--- a/src/server/plugins/engine/components/CheckboxesField.test.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.test.ts
@@ -2,6 +2,8 @@ import {
   ComponentType,
   type CheckboxesFieldComponent
 } from '@defra/forms-model'
+import { toLower } from 'lodash'
+import lowerFirst from 'lodash/lowerFirst.js'
 import { outdent } from 'outdent'
 
 import { CheckboxesField } from '~/src/server/plugins/engine/components/CheckboxesField.js'
@@ -194,7 +196,7 @@ describe.each([
 
         expect(result.errors).toEqual([
           expect.objectContaining({
-            text: `Select ${options.label.toLowerCase()}`
+            text: `Select ${lowerFirst(options.label)}`
           })
         ])
       })
@@ -222,7 +224,7 @@ describe.each([
 
           expect(result.errors).toEqual([
             expect.objectContaining({
-              text: `Select ${def.shortDescription.toLowerCase()}`
+              text: `Select ${toLower(def.shortDescription)}`
             })
           ])
         }
@@ -235,7 +237,7 @@ describe.each([
 
           expect(result.errors).toEqual([
             expect.objectContaining({
-              text: `Select ${options.label.toLowerCase()}`
+              text: `Select ${lowerFirst(options.label)}`
             })
           ])
         }

--- a/src/server/plugins/engine/components/CheckboxesField.test.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.test.ts
@@ -23,7 +23,8 @@ import { getFormData, getFormState } from '~/test/helpers/component-helpers.js'
 describe.each([
   {
     component: {
-      title: 'String list',
+      title: 'String list title',
+      shortDescription: 'String list',
       name: 'myComponent',
       type: ComponentType.CheckboxesField,
       list: 'listString',
@@ -31,6 +32,7 @@ describe.each([
     } satisfies CheckboxesFieldComponent,
 
     options: {
+      label: 'string list',
       list: listString,
       examples: listStringExamples,
       allow: ['1', '2', '3', '4'],
@@ -39,14 +41,34 @@ describe.each([
   },
   {
     component: {
-      title: 'Number list',
+      title: 'String list title',
+      shortDescription: 'String list',
       name: 'myComponent',
+      type: ComponentType.CheckboxesField,
+      list: 'listString',
+      options: {}
+    } satisfies CheckboxesFieldComponent,
+
+    options: {
+      label: 'string list',
+      list: listString,
+      examples: listStringExamples,
+      allow: ['1', '2', '3', '4'],
+      deny: ['5', '6', '7', '8']
+    }
+  },
+  {
+    component: {
+      title: 'Number list title',
+      name: 'myComponent',
+      shortDescription: 'Number list',
       type: ComponentType.CheckboxesField,
       list: 'listNumber',
       options: {}
     } satisfies CheckboxesFieldComponent,
 
     options: {
+      label: 'number list',
       list: listNumber,
       examples: listNumberExamples,
       allow: [1, 2, 3, 4],
@@ -72,14 +94,14 @@ describe.each([
 
   describe('Defaults', () => {
     describe('Schema', () => {
-      it('uses component title as label', () => {
+      it('uses component short description as label', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
         expect(keys).toHaveProperty(
           'myComponent',
           expect.objectContaining({
-            flags: expect.objectContaining({ label: def.title })
+            flags: expect.objectContaining({ label: def.shortDescription })
           })
         )
       })
@@ -157,7 +179,7 @@ describe.each([
               {
                 allow: options.allow,
                 flags: {
-                  label: def.title,
+                  label: def.shortDescription,
                   only: true
                 },
                 type: options.list.type
@@ -172,7 +194,7 @@ describe.each([
 
         expect(result.errors).toEqual([
           expect.objectContaining({
-            text: `Select ${def.title.toLowerCase()}`
+            text: `Select ${options.label.toLowerCase()}`
           })
         ])
       })
@@ -200,7 +222,7 @@ describe.each([
 
           expect(result.errors).toEqual([
             expect.objectContaining({
-              text: `Select ${def.title.toLowerCase()}`
+              text: `Select ${def.shortDescription.toLowerCase()}`
             })
           ])
         }
@@ -213,7 +235,7 @@ describe.each([
 
           expect(result.errors).toEqual([
             expect.objectContaining({
-              text: `Select ${def.title.toLowerCase()}`
+              text: `Select ${options.label.toLowerCase()}`
             })
           ])
         }

--- a/src/server/plugins/engine/components/CheckboxesField.ts
+++ b/src/server/plugins/engine/components/CheckboxesField.ts
@@ -23,16 +23,20 @@ export class CheckboxesField extends SelectionControlField {
     super(def, props)
 
     const { listType: type } = this
-    const { options, title } = def
+    const { options } = def
 
     let formSchema =
       type === 'string' ? joi.array<string>() : joi.array<number>()
 
     const itemsSchema = joi[type]()
       .valid(...this.values)
-      .label(title)
+      .label(this.label)
 
-    formSchema = formSchema.items(itemsSchema).single().label(title).required()
+    formSchema = formSchema
+      .items(itemsSchema)
+      .single()
+      .label(this.label)
+      .required()
 
     if (options.required === false) {
       formSchema = formSchema.optional()

--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -22,7 +22,6 @@ export class ComponentBase {
   type: ComponentDef['type']
   name: ComponentDef['name']
   title: ComponentDef['title']
-  label: string
   schema?: Extract<ComponentDef, { schema: object }>['schema']
   options?: Extract<ComponentDef, { options: object }>['options']
 
@@ -44,10 +43,6 @@ export class ComponentBase {
     this.type = def.type
     this.name = def.name
     this.title = def.title
-    this.label =
-      'shortDescription' in def
-        ? (def.shortDescription ?? def.title)
-        : def.title
 
     if ('schema' in def) {
       this.schema = def.schema

--- a/src/server/plugins/engine/components/ComponentBase.ts
+++ b/src/server/plugins/engine/components/ComponentBase.ts
@@ -22,6 +22,7 @@ export class ComponentBase {
   type: ComponentDef['type']
   name: ComponentDef['name']
   title: ComponentDef['title']
+  label: string
   schema?: Extract<ComponentDef, { schema: object }>['schema']
   options?: Extract<ComponentDef, { options: object }>['options']
 
@@ -43,6 +44,10 @@ export class ComponentBase {
     this.type = def.type
     this.name = def.name
     this.title = def.title
+    this.label =
+      'shortDescription' in def
+        ? (def.shortDescription ?? def.title)
+        : def.title
 
     if ('schema' in def) {
       this.schema = def.schema

--- a/src/server/plugins/engine/components/ComponentCollection.ts
+++ b/src/server/plugins/engine/components/ComponentCollection.ts
@@ -124,7 +124,7 @@ export class ComponentCollection {
         }
 
         // Update error with parent title
-        error.local.title ??= parent?.title
+        error.local.title ??= parent?.label
 
         return error
       })

--- a/src/server/plugins/engine/components/DatePartsField.test.ts
+++ b/src/server/plugins/engine/components/DatePartsField.test.ts
@@ -31,6 +31,7 @@ describe('DatePartsField', () => {
     beforeEach(() => {
       def = {
         title: 'Example date parts field',
+        shortDescription: 'Example date parts',
         name: 'myComponent',
         type: ComponentType.DatePartsField,
         options: {}
@@ -199,7 +200,7 @@ describe('DatePartsField', () => {
         expect(result3.errors).toBeUndefined()
       })
 
-      it('adds errors for empty value', () => {
+      it('adds errors for empty value when short description exists', () => {
         const result = collection.validate(
           getFormData({
             day: '',
@@ -210,13 +211,13 @@ describe('DatePartsField', () => {
 
         expect(result.errors).toEqual([
           expect.objectContaining({
-            text: 'Example date parts field must include a day'
+            text: 'Example date parts must include a day'
           }),
           expect.objectContaining({
-            text: 'Example date parts field must include a month'
+            text: 'Example date parts must include a month'
           }),
           expect.objectContaining({
-            text: 'Example date parts field must include a year'
+            text: 'Example date parts must include a year'
           })
         ])
       })

--- a/src/server/plugins/engine/components/DatePartsField.ts
+++ b/src/server/plugins/engine/components/DatePartsField.ts
@@ -41,7 +41,9 @@ export class DatePartsField extends FormComponent {
     const isRequired = options.required !== false
 
     const customValidationMessages: LanguageMessages = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'any.required': messageTemplate.objectMissing,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'number.base': messageTemplate.objectMissing,
       'number.precision': messageTemplate.dateFormat,
       'number.integer': messageTemplate.dateFormat,

--- a/src/server/plugins/engine/components/EmailAddressField.test.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.test.ts
@@ -29,6 +29,7 @@ describe('EmailAddressField', () => {
     beforeEach(() => {
       def = {
         title: 'Example email address field',
+        shortDescription: 'Example email address',
         name: 'myComponent',
         type: ComponentType.EmailAddressField,
         options: {}
@@ -47,7 +48,7 @@ describe('EmailAddressField', () => {
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: 'Example email address field'
+              label: 'Example email address'
             })
           })
         )
@@ -109,6 +110,24 @@ describe('EmailAddressField', () => {
       })
 
       it('adds errors for empty value', () => {
+        const result = collection.validate(getFormData(''))
+
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            text: 'Enter example email address'
+          })
+        ])
+      })
+
+      it('adds errors for empty value given no shortDescription', () => {
+        def = {
+          title: 'Example email address field',
+          name: 'myComponent',
+          type: ComponentType.EmailAddressField,
+          options: {}
+        } satisfies EmailAddressFieldComponent
+
+        collection = new ComponentCollection([def], { model })
         const result = collection.validate(getFormData(''))
 
         expect(result.errors).toEqual([
@@ -266,6 +285,29 @@ describe('EmailAddressField', () => {
           {
             input: getFormData('defra.helpline@defra.gov.uk'),
             output: { value: getFormData('defra.helpline@defra.gov.uk') }
+          }
+        ]
+      },
+      {
+        description: 'Email address validation',
+        component: {
+          title: 'Example email address field',
+          shortDescription: 'Example email address',
+          name: 'myComponent',
+          type: ComponentType.EmailAddressField,
+          options: {}
+        } satisfies EmailAddressFieldComponent,
+        assertions: [
+          {
+            input: getFormData('defra.helpline'),
+            output: {
+              value: getFormData('defra.helpline'),
+              errors: [
+                expect.objectContaining({
+                  text: 'Enter example email address in the correct format'
+                })
+              ]
+            }
           }
         ]
       },

--- a/src/server/plugins/engine/components/EmailAddressField.ts
+++ b/src/server/plugins/engine/components/EmailAddressField.ts
@@ -16,9 +16,9 @@ export class EmailAddressField extends FormComponent {
   ) {
     super(def, props)
 
-    const { options, title } = def
+    const { options } = def
 
-    let formSchema = joi.string().email().trim().label(title).required()
+    let formSchema = joi.string().email().trim().label(this.label).required()
 
     if (options.required === false) {
       formSchema = formSchema.allow('')

--- a/src/server/plugins/engine/components/FileUploadField.test.ts
+++ b/src/server/plugins/engine/components/FileUploadField.test.ts
@@ -157,6 +157,7 @@ describe('FileUploadField', () => {
     beforeEach(() => {
       def = {
         title: 'Example file upload field',
+        shortDescription: 'Example file upload',
         name: 'myComponent',
         type: ComponentType.FileUploadField,
         options: {},
@@ -169,7 +170,32 @@ describe('FileUploadField', () => {
     })
 
     describe('Schema', () => {
+      it('uses component short description as label', () => {
+        const { formSchema } = collection
+        const { keys } = formSchema.describe()
+
+        expect(keys).toHaveProperty(
+          'myComponent',
+          expect.objectContaining({
+            flags: expect.objectContaining({
+              label: 'Example file upload'
+            })
+          })
+        )
+      })
+
       it('uses component title as label', () => {
+        def = {
+          title: 'Example file upload field',
+          name: 'myComponent',
+          type: ComponentType.FileUploadField,
+          options: {},
+          schema: {}
+        } satisfies FileUploadFieldComponent
+
+        page = createPage(model, definition.pages[0])
+        collection = new ComponentCollection([def], { page, model })
+
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
@@ -244,6 +270,25 @@ describe('FileUploadField', () => {
       })
 
       it('adds errors for empty value', () => {
+        const result = collection.validate(getFormData())
+
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            text: 'Select example file upload'
+          })
+        ])
+      })
+
+      it('adds errors for empty value with no shortDescription', () => {
+        def = {
+          title: 'Example file upload field',
+          name: 'myComponent',
+          type: ComponentType.FileUploadField,
+          options: {},
+          schema: {}
+        } satisfies FileUploadFieldComponent
+
+        collection = new ComponentCollection([def], { model })
         const result = collection.validate(getFormData())
 
         expect(result.errors).toEqual([

--- a/src/server/plugins/engine/components/FileUploadField.ts
+++ b/src/server/plugins/engine/components/FileUploadField.ts
@@ -104,9 +104,13 @@ export class FileUploadField extends FormComponent {
   ) {
     super(def, props)
 
-    const { options, schema, title } = def
+    const { options, schema } = def
 
-    let formSchema = joi.array<FileState>().label(title).single().required()
+    let formSchema = joi
+      .array<FileState>()
+      .label(this.label)
+      .single()
+      .required()
 
     if (options.required === false) {
       formSchema = formSchema.optional()

--- a/src/server/plugins/engine/components/FormComponent.ts
+++ b/src/server/plugins/engine/components/FormComponent.ts
@@ -18,6 +18,7 @@ import {
 export class FormComponent extends ComponentBase {
   type: FormComponentsDef['type']
   hint: FormComponentsDef['hint']
+  label: string
 
   isFormComponent = true
 
@@ -31,6 +32,10 @@ export class FormComponent extends ComponentBase {
 
     this.type = type
     this.hint = hint
+    this.label =
+      'shortDescription' in def && def.shortDescription
+        ? def.shortDescription
+        : def.title
   }
 
   get keys() {

--- a/src/server/plugins/engine/components/ListFormComponent.ts
+++ b/src/server/plugins/engine/components/ListFormComponent.ts
@@ -61,7 +61,7 @@ export class ListFormComponent extends FormComponent {
   ) {
     super(def, props)
 
-    const { options, title } = def
+    const { options } = def
     const { model } = props
 
     if ('list' in def) {
@@ -71,7 +71,7 @@ export class ListFormComponent extends FormComponent {
 
     let formSchema = joi[this.listType]()
       .valid(...this.values)
-      .label(title)
+      .label(this.label)
       .required()
 
     if (options.customValidationMessages) {

--- a/src/server/plugins/engine/components/MonthYearField.test.ts
+++ b/src/server/plugins/engine/components/MonthYearField.test.ts
@@ -31,6 +31,7 @@ describe('MonthYearField', () => {
     beforeEach(() => {
       def = {
         title: 'Example month/year field',
+        shortDescription: 'Example month/year',
         name: 'myComponent',
         type: ComponentType.MonthYearField,
         options: {}
@@ -161,6 +162,32 @@ describe('MonthYearField', () => {
       })
 
       it('adds errors for empty value', () => {
+        const result = collection.validate(
+          getFormData({
+            month: '',
+            year: ''
+          })
+        )
+
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            text: 'Example month/year must include a month'
+          }),
+          expect.objectContaining({
+            text: 'Example month/year must include a year'
+          })
+        ])
+      })
+
+      it('adds errors for empty value given no short desc exists', () => {
+        def = {
+          title: 'Example month/year field',
+          name: 'myComponent',
+          type: ComponentType.MonthYearField,
+          options: {}
+        } satisfies MonthYearFieldComponent
+
+        collection = new ComponentCollection([def], { model })
         const result = collection.validate(
           getFormData({
             month: '',

--- a/src/server/plugins/engine/components/MonthYearField.ts
+++ b/src/server/plugins/engine/components/MonthYearField.ts
@@ -41,7 +41,9 @@ export class MonthYearField extends FormComponent {
     const isRequired = options.required !== false
 
     const customValidationMessages: LanguageMessages = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'any.required': messageTemplate.objectMissing,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       'number.base': messageTemplate.objectMissing,
       'number.precision': messageTemplate.dateFormat,
       'number.integer': messageTemplate.dateFormat,

--- a/src/server/plugins/engine/components/MultilineTextField.test.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.test.ts
@@ -29,7 +29,8 @@ describe('MultilineTextField', () => {
 
     beforeEach(() => {
       def = {
-        title: 'Example textarea',
+        title: 'Example textarea title',
+        shortDescription: 'Example textarea',
         name: 'myComponent',
         type: ComponentType.MultilineTextField,
         options: {},
@@ -41,7 +42,7 @@ describe('MultilineTextField', () => {
     })
 
     describe('Schema', () => {
-      it('uses component title as label', () => {
+      it('uses component short description as label', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
@@ -113,6 +114,25 @@ describe('MultilineTextField', () => {
         expect(result.errors).toEqual([
           expect.objectContaining({
             text: 'Enter example textarea'
+          })
+        ])
+      })
+
+      it('adds errors for empty value given no short description', () => {
+        def = {
+          title: 'Example textarea title',
+          name: 'myComponent',
+          type: ComponentType.MultilineTextField,
+          options: {},
+          schema: {}
+        } satisfies MultilineTextFieldComponent
+
+        collection = new ComponentCollection([def], { model })
+        const result = collection.validate(getFormData(''))
+
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            text: 'Enter example textarea title'
           })
         ])
       })

--- a/src/server/plugins/engine/components/MultilineTextField.ts
+++ b/src/server/plugins/engine/components/MultilineTextField.ts
@@ -22,9 +22,9 @@ export class MultilineTextField extends FormComponent {
   ) {
     super(def, props)
 
-    const { schema, options, title } = def
+    const { schema, options } = def
 
-    let formSchema = Joi.string().trim().label(title).required()
+    let formSchema = Joi.string().trim().label(this.label).required()
 
     if (options.required === false) {
       formSchema = formSchema.allow('')

--- a/src/server/plugins/engine/components/NumberField.test.ts
+++ b/src/server/plugins/engine/components/NumberField.test.ts
@@ -27,6 +27,7 @@ describe('NumberField', () => {
     beforeEach(() => {
       def = {
         title: 'Example number field',
+        shortDescription: 'Example number',
         name: 'myComponent',
         type: ComponentType.NumberField,
         options: {},
@@ -46,7 +47,7 @@ describe('NumberField', () => {
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: 'Example number field'
+              label: 'Example number'
             })
           })
         )
@@ -113,9 +114,22 @@ describe('NumberField', () => {
 
         expect(result.errors).toEqual([
           expect.objectContaining({
-            text: 'Enter example number field'
+            text: 'Enter example number'
           })
         ])
+      })
+
+      it('adds errors for empty value given no short description exists', () => {
+        def = {
+          title: 'Example number field',
+          name: 'myComponent',
+          type: ComponentType.NumberField,
+          options: {},
+          schema: {}
+        } satisfies NumberFieldComponent
+
+        collection = new ComponentCollection([def], { model })
+        const result = collection.validate(getFormData(''))
 
         expect(result.errors).toEqual([
           expect.objectContaining({

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -40,6 +40,7 @@ export class NumberField extends FormComponent {
       const messages = options.customValidationMessages
 
       formSchema = formSchema.empty('').messages({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         'any.required': messages?.['any.required'] ?? messageTemplate.required
       })
     }

--- a/src/server/plugins/engine/components/NumberField.ts
+++ b/src/server/plugins/engine/components/NumberField.ts
@@ -26,12 +26,12 @@ export class NumberField extends FormComponent {
   ) {
     super(def, props)
 
-    const { options, schema, title } = def
+    const { options, schema } = def
 
     let formSchema = joi
       .number()
       .custom(getValidatorPrecision(this))
-      .label(title)
+      .label(this.label)
       .required()
 
     if (options.required === false) {

--- a/src/server/plugins/engine/components/RadiosField.test.ts
+++ b/src/server/plugins/engine/components/RadiosField.test.ts
@@ -1,4 +1,5 @@
 import { ComponentType, type RadiosFieldComponent } from '@defra/forms-model'
+import lowerFirst from 'lodash/lowerFirst.js'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { RadiosField } from '~/src/server/plugins/engine/components/RadiosField.js'
@@ -151,7 +152,7 @@ describe.each([
 
         expect(result.errors).toEqual([
           expect.objectContaining({
-            text: `Select ${def.title.toLowerCase()}`
+            text: `Select ${lowerFirst(def.title)}`
           })
         ])
       })

--- a/src/server/plugins/engine/components/SelectField.test.ts
+++ b/src/server/plugins/engine/components/SelectField.test.ts
@@ -1,4 +1,5 @@
 import { ComponentType, type SelectFieldComponent } from '@defra/forms-model'
+import lowerFirst from 'lodash/lowerFirst.js'
 
 import { ComponentCollection } from '~/src/server/plugins/engine/components/ComponentCollection.js'
 import { SelectField } from '~/src/server/plugins/engine/components/SelectField.js'
@@ -152,7 +153,7 @@ describe.each([
 
         expect(result.errors).toEqual([
           expect.objectContaining({
-            text: `Select ${def.title.toLowerCase()}`
+            text: `Select ${lowerFirst(def.title)}`
           })
         ])
       })

--- a/src/server/plugins/engine/components/TelephoneNumberField.test.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.test.ts
@@ -29,6 +29,7 @@ describe('TelephoneNumberField', () => {
     beforeEach(() => {
       def = {
         title: 'Example telephone number field',
+        shortDescription: 'Example telephone number',
         name: 'myComponent',
         type: ComponentType.TelephoneNumberField,
         options: {}
@@ -39,7 +40,7 @@ describe('TelephoneNumberField', () => {
     })
 
     describe('Schema', () => {
-      it('uses component title as label', () => {
+      it('uses component short description as label', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
@@ -47,7 +48,7 @@ describe('TelephoneNumberField', () => {
           'myComponent',
           expect.objectContaining({
             flags: expect.objectContaining({
-              label: 'Example telephone number field'
+              label: 'Example telephone number'
             })
           })
         )
@@ -119,6 +120,25 @@ describe('TelephoneNumberField', () => {
       })
 
       it('adds errors for empty value', () => {
+        const result = collection.validate(getFormData(''))
+
+        expect(result.errors).toEqual([
+          expect.objectContaining({
+            text: 'Enter example telephone number'
+          })
+        ])
+      })
+
+      it('adds errors for empty value given no short description exists', () => {
+        def = {
+          title: 'Example telephone number field',
+          name: 'myComponent',
+          type: ComponentType.TelephoneNumberField,
+          options: {}
+        } satisfies TelephoneNumberFieldComponent
+
+        collection = new ComponentCollection([def], { model })
+
         const result = collection.validate(getFormData(''))
 
         expect(result.errors).toEqual([

--- a/src/server/plugins/engine/components/TelephoneNumberField.ts
+++ b/src/server/plugins/engine/components/TelephoneNumberField.ts
@@ -21,13 +21,13 @@ export class TelephoneNumberField extends FormComponent {
   ) {
     super(def, props)
 
-    const { options, title } = def
+    const { options } = def
 
     let formSchema = joi
       .string()
       .trim()
       .pattern(PATTERN)
-      .label(title)
+      .label(this.label)
       .required()
 
     if (options.required === false) {

--- a/src/server/plugins/engine/components/TextField.test.ts
+++ b/src/server/plugins/engine/components/TextField.test.ts
@@ -37,7 +37,7 @@ describe('TextField', () => {
     })
 
     describe('Schema', () => {
-      it('uses component title as label', () => {
+      it('uses component title as label as default', () => {
         const { formSchema } = collection
         const { keys } = formSchema.describe()
 
@@ -200,6 +200,30 @@ describe('TextField', () => {
 
   describe('Validation', () => {
     describe.each([
+      {
+        description: 'Use short description if it exists',
+        component: {
+          title: 'What is your example text?',
+          shortDescription: 'Your example text',
+          name: 'myComponent',
+          type: ComponentType.TextField,
+          options: {},
+          schema: {}
+        } satisfies TextFieldComponent,
+        assertions: [
+          {
+            input: getFormData(''),
+            output: {
+              value: getFormData(''),
+              errors: [
+                expect.objectContaining({
+                  text: 'Enter your example text'
+                })
+              ]
+            }
+          }
+        ]
+      },
       {
         description: 'Trim empty spaces',
         component: {

--- a/src/server/plugins/engine/components/TextField.ts
+++ b/src/server/plugins/engine/components/TextField.ts
@@ -30,10 +30,10 @@ export class TextField extends FormComponent {
   ) {
     super(def, props)
 
-    const { options, title } = def
+    const { options } = def
     const schema = 'schema' in def ? def.schema : {}
 
-    let formSchema = joi.string().trim().label(title).required()
+    let formSchema = joi.string().trim().label(this.label).required()
 
     if (options.required === false) {
       formSchema = formSchema.allow('')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "paths": {
       "~/*": ["./*"]
     },
-    "types": ["@testing-library/jest-dom"]
+    "types": ["@testing-library/jest-dom", "jest"]
   },
   "include": [
     "**/*.cjs",
@@ -22,7 +22,8 @@
     "**/*.ts",
     ".eslintrc.*",
     ".prettierrc.*",
-    ".lintstagedrc.*"
+    ".lintstagedrc.*",
+    "node_modules/@types/jest/index.d.ts"
   ],
   "exclude": ["coverage", "node_modules", ".public", ".server"]
 }


### PR DESCRIPTION
## Error message uses short description if it exists

The error message should now use the short description field if it exists. An example:

![image](https://github.com/user-attachments/assets/76d85f9f-73b6-4084-a779-10673c283a65)

This completes the following ticket:

https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/526386

A new label field now exists on ComponentBase and this is used rather than title.  Slightly more complex logic for Date fields.