### PR TITLE
Feature 533156: Add /form prefix to routes & enforce strict path validation

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -9,7 +9,7 @@ module.exports = {
   resetModules: true,
   restoreMocks: true,
   clearMocks: true,
-  silent: true,
+  silent: false,
   testMatch: [
     '<rootDir>/src/**/*.test.{cjs,js,mjs,ts}',
     '<rootDir>/test/**/*.test.{cjs,js,mjs,ts}'

--- a/src/client/javascripts/file-upload.js
+++ b/src/client/javascripts/file-upload.js
@@ -229,6 +229,18 @@ function reloadPage() {
 }
 
 /**
+ * Build the upload status URL given the current pathname and the upload ID.
+ * @param {string} pathname – e.g. window.location.pathname
+ * @param {string} uploadId
+ * @returns {string} e.g. "/form/upload-status/abc123"
+ */
+export function buildUploadStatusUrl(pathname, uploadId) {
+  const pathSegments = pathname.split('/').filter((segment) => segment)
+  const prefix = pathSegments.length > 0 ? `/${pathSegments[0]}` : ''
+  return `${prefix}/upload-status/${uploadId}`
+}
+
+/**
  * Polls the upload status endpoint until the file is ready or timeout occurs
  * @param {string} uploadId - The upload ID to check
  */
@@ -243,10 +255,10 @@ function pollUploadStatus(uploadId) {
       return
     }
 
-    const currentPathname = window.location.pathname
-    const pathSegments = currentPathname.split('/').filter((segment) => segment)
-    const prefix = pathSegments.length > 0 ? `/${pathSegments[0]}` : ''
-    const uploadStatusUrl = `${prefix}/upload-status/${uploadId}`
+    const uploadStatusUrl = buildUploadStatusUrl(
+      window.location.pathname,
+      uploadId
+    )
 
     fetch(uploadStatusUrl, {
       headers: {

--- a/src/client/javascripts/file-upload.js
+++ b/src/client/javascripts/file-upload.js
@@ -243,7 +243,12 @@ function pollUploadStatus(uploadId) {
       return
     }
 
-    fetch(`/upload-status/${uploadId}`, {
+    const currentPathname = window.location.pathname
+    const pathSegments = currentPathname.split('/').filter((segment) => segment)
+    const prefix = pathSegments.length > 0 ? `/${pathSegments[0]}` : ''
+    const uploadStatusUrl = `${prefix}/upload-status/${uploadId}`
+
+    fetch(uploadStatusUrl, {
       headers: {
         Accept: 'application/json'
       }

--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -1,2 +1,3 @@
 export const PREVIEW_PATH_PREFIX = '/preview'
 export const ERROR_PREVIEW_PATH_PREFIX = '/error-preview'
+export const FORM_PREFIX = '/form'

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -54,13 +54,13 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/slug'
+        url: '/form/slug'
       }
 
       const res = await server.inject(options)
 
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-      expect(res.headers.location).toBe('/slug/page-one')
+      expect(res.headers.location).toBe('/form/slug/page-one')
       expect(getCacheSize()).toBe(1)
     })
 
@@ -74,13 +74,13 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/live/slug'
+        url: '/form/preview/live/slug'
       }
 
       const res = await server.inject(options)
 
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-      expect(res.headers.location).toBe('/preview/live/slug/page-one')
+      expect(res.headers.location).toBe('/form/preview/live/slug/page-one')
       expect(getCacheSize()).toBe(1)
     })
 
@@ -94,13 +94,13 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/draft/slug'
+        url: '/form/preview/draft/slug'
       }
 
       const res = await server.inject(options)
 
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-      expect(res.headers.location).toBe('/preview/draft/slug/page-one')
+      expect(res.headers.location).toBe('/form/preview/draft/slug/page-one')
       expect(getCacheSize()).toBe(1)
     })
 
@@ -114,7 +114,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/slug/page-one'
+        url: '/form/slug/page-one'
       }
 
       const res = await server.inject(options)
@@ -133,7 +133,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/live/slug/page-one'
+        url: '/form/preview/live/slug/page-one'
       }
 
       const res = await server.inject(options)
@@ -152,7 +152,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/draft/slug/page-one'
+        url: '/form/preview/draft/slug/page-one'
       }
 
       const res = await server.inject(options)
@@ -171,7 +171,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/slug/page-one'
+        url: '/form/slug/page-one'
       }
 
       const res = await server.inject(options)
@@ -192,7 +192,7 @@ describe('Model cache', () => {
       // Populate live/live cache item
       const options1 = {
         method: 'GET',
-        url: '/slug/page-one'
+        url: '/form/slug/page-one'
       }
 
       const res1 = await server.inject(options1)
@@ -203,7 +203,7 @@ describe('Model cache', () => {
       // Populate live/preview cache item
       const options2 = {
         method: 'GET',
-        url: '/preview/live/slug/page-one'
+        url: '/form/preview/live/slug/page-one'
       }
 
       const res2 = await server.inject(options2)
@@ -214,7 +214,7 @@ describe('Model cache', () => {
       // Populate draft/preview cache item
       const options3 = {
         method: 'GET',
-        url: '/preview/draft/slug/page-one'
+        url: '/form/preview/draft/slug/page-one'
       }
 
       const res3 = await server.inject(options3)
@@ -266,7 +266,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/slug'
+        url: '/form/slug'
       }
 
       const res = await server.inject(options)
@@ -280,7 +280,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/draft/slug'
+        url: '/form/preview/draft/slug'
       }
 
       const res = await server.inject(options)
@@ -294,7 +294,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/live/slug'
+        url: '/form/preview/live/slug'
       }
 
       const res = await server.inject(options)
@@ -312,7 +312,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/slug'
+        url: '/form/slug'
       }
 
       const res = await server.inject(options)
@@ -330,7 +330,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/draft/slug'
+        url: '/form/preview/draft/slug'
       }
 
       const res = await server.inject(options)
@@ -348,7 +348,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/live/slug'
+        url: '/form/preview/live/slug'
       }
 
       const res = await server.inject(options)
@@ -362,7 +362,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/slug/page-one'
+        url: '/form/slug/page-one'
       }
 
       const res = await server.inject(options)
@@ -376,7 +376,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/draft/slug/page-one'
+        url: '/form/preview/draft/slug/page-one'
       }
 
       const res = await server.inject(options)
@@ -390,7 +390,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/live/slug/page-one'
+        url: '/form/preview/live/slug/page-one'
       }
 
       const res = await server.inject(options)
@@ -408,7 +408,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/slug/page-one'
+        url: '/form/slug/page-one'
       }
 
       const res = await server.inject(options)
@@ -426,7 +426,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/draft/slug/page-one'
+        url: '/form/preview/draft/slug/page-one'
       }
 
       const res = await server.inject(options)
@@ -444,7 +444,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/preview/live/slug/page-one'
+        url: '/form/preview/live/slug/page-one'
       }
 
       const res = await server.inject(options)

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -55,13 +55,13 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/slug'
+        url: `${FORM_PREFIX}/slug`
       }
 
       const res = await server.inject(options)
 
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-      expect(res.headers.location).toBe('/form/slug/page-one')
+      expect(res.headers.location).toBe(`${FORM_PREFIX}/slug/page-one`)
       expect(getCacheSize()).toBe(1)
     })
 
@@ -75,13 +75,15 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/live/slug'
+        url: `${FORM_PREFIX}/preview/live/slug`
       }
 
       const res = await server.inject(options)
 
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-      expect(res.headers.location).toBe('/form/preview/live/slug/page-one')
+      expect(res.headers.location).toBe(
+        `${FORM_PREFIX}/preview/live/slug/page-one`
+      )
       expect(getCacheSize()).toBe(1)
     })
 
@@ -95,13 +97,15 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/draft/slug'
+        url: `${FORM_PREFIX}/preview/draft/slug`
       }
 
       const res = await server.inject(options)
 
       expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-      expect(res.headers.location).toBe('/form/preview/draft/slug/page-one')
+      expect(res.headers.location).toBe(
+        `${FORM_PREFIX}/preview/draft/slug/page-one`
+      )
       expect(getCacheSize()).toBe(1)
     })
 
@@ -115,7 +119,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/slug/page-one'
+        url: `${FORM_PREFIX}/slug/page-one`
       }
 
       const res = await server.inject(options)
@@ -134,7 +138,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/live/slug/page-one'
+        url: `${FORM_PREFIX}/preview/live/slug/page-one`
       }
 
       const res = await server.inject(options)
@@ -153,7 +157,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/draft/slug/page-one'
+        url: `${FORM_PREFIX}/preview/draft/slug/page-one`
       }
 
       const res = await server.inject(options)
@@ -172,7 +176,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/slug/page-one'
+        url: `${FORM_PREFIX}/slug/page-one`
       }
 
       const res = await server.inject(options)
@@ -193,7 +197,7 @@ describe('Model cache', () => {
       // Populate live/live cache item
       const options1 = {
         method: 'GET',
-        url: '/form/slug/page-one'
+        url: `${FORM_PREFIX}/slug/page-one`
       }
 
       const res1 = await server.inject(options1)
@@ -204,7 +208,7 @@ describe('Model cache', () => {
       // Populate live/preview cache item
       const options2 = {
         method: 'GET',
-        url: '/form/preview/live/slug/page-one'
+        url: `${FORM_PREFIX}/preview/live/slug/page-one`
       }
 
       const res2 = await server.inject(options2)
@@ -215,7 +219,7 @@ describe('Model cache', () => {
       // Populate draft/preview cache item
       const options3 = {
         method: 'GET',
-        url: '/form/preview/draft/slug/page-one'
+        url: `${FORM_PREFIX}/preview/draft/slug/page-one`
       }
 
       const res3 = await server.inject(options3)
@@ -267,7 +271,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/slug'
+        url: `${FORM_PREFIX}/slug`
       }
 
       const res = await server.inject(options)
@@ -281,7 +285,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/draft/slug'
+        url: `${FORM_PREFIX}/preview/draft/slug`
       }
 
       const res = await server.inject(options)
@@ -295,7 +299,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/live/slug'
+        url: `${FORM_PREFIX}/preview/live/slug`
       }
 
       const res = await server.inject(options)
@@ -313,7 +317,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/slug'
+        url: `${FORM_PREFIX}/slug`
       }
 
       const res = await server.inject(options)
@@ -331,7 +335,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/draft/slug'
+        url: `${FORM_PREFIX}/preview/draft/slug`
       }
 
       const res = await server.inject(options)
@@ -349,7 +353,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/live/slug'
+        url: `${FORM_PREFIX}/preview/live/slug`
       }
 
       const res = await server.inject(options)
@@ -363,7 +367,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/slug/page-one'
+        url: `${FORM_PREFIX}/slug/page-one`
       }
 
       const res = await server.inject(options)
@@ -377,7 +381,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/draft/slug/page-one'
+        url: `${FORM_PREFIX}/preview/draft/slug/page-one`
       }
 
       const res = await server.inject(options)
@@ -391,7 +395,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/live/slug/page-one'
+        url: `${FORM_PREFIX}/preview/live/slug/page-one`
       }
 
       const res = await server.inject(options)
@@ -409,7 +413,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/slug/page-one'
+        url: `${FORM_PREFIX}/slug/page-one`
       }
 
       const res = await server.inject(options)
@@ -427,7 +431,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/draft/slug/page-one'
+        url: `${FORM_PREFIX}/preview/draft/slug/page-one`
       }
 
       const res = await server.inject(options)
@@ -445,7 +449,7 @@ describe('Model cache', () => {
 
       const options = {
         method: 'GET',
-        url: '/form/preview/live/slug/page-one'
+        url: `${FORM_PREFIX}/preview/live/slug/page-one`
       }
 
       const res = await server.inject(options)

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -1,7 +1,7 @@
-import Boom from '@hapi/boom'
 import { type Server } from '@hapi/hapi'
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import {
   getFormDefinition,
@@ -528,7 +528,7 @@ describe('Upload status route', () => {
 
     const options = {
       method: 'GET',
-      url: '/upload-status/123e4567-e89b-12d3-a456-426614174000'
+      url: `${FORM_PREFIX}/upload-status/123e4567-e89b-12d3-a456-426614174000`
     }
 
     const res = await server.inject(options)
@@ -545,7 +545,7 @@ describe('Upload status route', () => {
 
     const options = {
       method: 'GET',
-      url: '/upload-status/123e4567-e89b-12d3-a456-426614174000'
+      url: `${FORM_PREFIX}/upload-status/123e4567-e89b-12d3-a456-426614174000`
     }
 
     const res = await server.inject(options)
@@ -561,7 +561,7 @@ describe('Upload status route', () => {
 
     const options = {
       method: 'GET',
-      url: '/upload-status/123e4567-e89b-12d3-a456-426614174000'
+      url: `${FORM_PREFIX}/upload-status/123e4567-e89b-12d3-a456-426614174000`
     }
 
     const res = await server.inject(options)
@@ -573,123 +573,11 @@ describe('Upload status route', () => {
   test('GET /upload-status/{uploadId} returns 400 for invalid uploadId format', async () => {
     const options = {
       method: 'GET',
-      url: '/upload-status/not-a-valid-guid'
+      url: `${FORM_PREFIX}/upload-status/not-a-valid-guid`
     }
 
     const res = await server.inject(options)
 
     expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST)
-  })
-})
-
-describe('onRequest Hook Redirects', () => {
-  let server: Server
-
-  beforeAll(async () => {
-    server = await createServer()
-    await server.initialize()
-  })
-
-  afterAll(async () => {
-    await server.stop()
-  })
-
-  beforeEach(() => {
-    jest.resetAllMocks()
-    jest.mocked(getFormMetadata).mockResolvedValue(fixtures.form.metadata)
-  })
-
-  describe('Legacy /preview/{state}/{slug} redirects', () => {
-    test('should redirect valid /preview/live/{slug} to /form/preview/live/{slug}', async () => {
-      const res = await server.inject({
-        method: 'GET',
-        url: '/preview/live/my-valid-slug'
-      })
-      expect(res.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
-      expect(res.headers.location).toBe('/form/preview/live/my-valid-slug')
-    })
-
-    test('should redirect valid /preview/draft/{slug} to /form/preview/draft/{slug}', async () => {
-      const res = await server.inject({
-        method: 'GET',
-        url: '/preview/draft/another-slug'
-      })
-      expect(res.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
-      expect(res.headers.location).toBe('/form/preview/draft/another-slug')
-    })
-
-    test('should return 404, log warning, and throw specific Boom error internally for /preview/{invalid-state}/{slug}', async () => {
-      const invalidPath = '/preview/invalid/my-slug'
-      const expectedLogMessage = `onRequest: Invalid format for preview path start: ${invalidPath}.`
-      const expectedBoomMessage = `Invalid preview path format: ${invalidPath}`
-
-      const loggerWarnSpy = jest.spyOn(server.logger, 'warn')
-      const boomNotFoundSpy = jest.spyOn(Boom, 'notFound')
-
-      const res = await server.inject({ method: 'GET', url: invalidPath })
-
-      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
-      expect(loggerWarnSpy).toHaveBeenCalledTimes(1)
-      expect(loggerWarnSpy).toHaveBeenCalledWith(expectedLogMessage)
-      expect(boomNotFoundSpy).toHaveBeenCalledTimes(1)
-      expect(boomNotFoundSpy).toHaveBeenCalledWith(expectedBoomMessage)
-
-      loggerWarnSpy.mockRestore()
-      boomNotFoundSpy.mockRestore()
-    })
-  })
-
-  describe('Legacy /{slug}/{path...} redirects', () => {
-    test('should redirect valid /{slug}/{page} to /form/{slug}/{page}', async () => {
-      const res = await server.inject({
-        method: 'GET',
-        url: '/my-slug/page-one'
-      })
-      expect(res.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
-      expect(res.headers.location).toBe('/form/my-slug/page-one')
-    })
-
-    test('should redirect valid /{slug}/{deep/path} to /form/{slug}/{deep/path}', async () => {
-      const res = await server.inject({
-        method: 'GET',
-        url: '/another-slug/deep/nested/path'
-      })
-      expect(res.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
-      expect(res.headers.location).toBe('/form/another-slug/deep/nested/path')
-    })
-  })
-
-  describe('Legacy /{slug} redirects', () => {
-    test('should redirect valid /{slug} to /form/{slug}', async () => {
-      const res = await server.inject({ method: 'GET', url: '/my-slug' })
-      expect(res.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
-      expect(res.headers.location).toBe('/form/my-slug')
-    })
-
-    test('should return 404 for /{invalid-slug}', async () => {
-      const res = await server.inject({ method: 'GET', url: '/invalid_slug!' })
-      expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
-    })
-  })
-
-  test('should continue processing for non-legacy, non-prefixed paths and add the prefix', async () => {
-    const res = await server.inject({ method: 'GET', url: '/some/other/path' })
-    expect(res.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
-  })
-
-  test('should continue processing for paths not matching legacy redirect patterns', async () => {
-    const pathsToTest = [
-      '/',
-      '/form/some-slug/some-page',
-      '/help/cookies/some-slug',
-      '/health',
-      '/assets/govuk.css'
-    ]
-
-    for (const testPath of pathsToTest) {
-      const res = await server.inject({ method: 'GET', url: testPath })
-
-      expect(res.statusCode).not.toBe(StatusCodes.MOVED_PERMANENTLY)
-    }
   })
 })

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -101,7 +101,7 @@ export async function createServer(routeConfig?: RouteConfig) {
 
   server.registerService(CacheService)
 
-  await server.register(pluginEngine)
+  await server.register(...pluginEngine)
 
   await server.register(pluginRouter)
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -101,11 +101,7 @@ export async function createServer(routeConfig?: RouteConfig) {
 
   server.registerService(CacheService)
 
-  await server.register(pluginEngine, {
-    routes: {
-      prefix: '/form'
-    }
-  })
+  await server.register(pluginEngine)
 
   await server.register(pluginRouter)
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -213,11 +213,6 @@ export async function createServer(routeConfig?: RouteConfig) {
           `onRequest: Redirecting legacy root slug ${path} -> ${targetUrl}`
         )
         return h.redirect(targetUrl).permanent().takeover()
-      } else {
-        server.logger.warn(
-          `onRequest: Path ${path} matched /slug pattern but failed slug validation. Responding 404.`
-        )
-        throw Boom.notFound(`Invalid slug format: ${path}`)
       }
     }
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -182,7 +182,7 @@ export async function createServer(routeConfig?: RouteConfig) {
         return h.redirect(targetUrl).permanent().takeover()
       } else {
         server.logger.warn(
-          `onRequest: Invalid format for preview path start: ${path}. Responding 404.`
+          `onRequest: Invalid format for preview path start: ${path}.`
         )
         throw Boom.notFound(`Invalid preview path format: ${path}`)
       }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,3 @@
-import { slugSchema } from '@defra/forms-model'
-import Boom from '@hapi/boom'
 import { Engine as CatboxMemory } from '@hapi/catbox-memory'
 import { Engine as CatboxRedis } from '@hapi/catbox-redis'
 import hapi, {
@@ -26,7 +24,6 @@ import { plugin as pluginViews } from '~/src/server/plugins/nunjucks/index.js'
 import pluginPulse from '~/src/server/plugins/pulse.js'
 import pluginRouter from '~/src/server/plugins/router.js'
 import pluginSession from '~/src/server/plugins/session.js'
-import { stateSchema } from '~/src/server/schemas/index.js'
 import { prepareSecureContext } from '~/src/server/secure-context.js'
 import { CacheService } from '~/src/server/services/index.js'
 import { type RouteConfig } from '~/src/server/types.js'
@@ -139,84 +136,6 @@ export async function createServer(routeConfig?: RouteConfig) {
     isSecure: config.get('isProduction'),
     path: '/',
     encoding: 'none' // handle this inside the application so we can share frontend/backend cookie modification
-  })
-
-  server.ext('onRequest', (request: Request, h: ResponseToolkit) => {
-    const { method, path } = request
-
-    const prefixesToIgnore = [
-      '/form/',
-      '/assets/',
-      '/help/',
-      '/javascripts/',
-      '/stylesheets/',
-      '/upload-status/',
-      '/health',
-      '/error-preview/'
-    ]
-    if (
-      method !== 'get' ||
-      path === '/' ||
-      prefixesToIgnore.some(
-        (prefixOrPath) => path === prefixOrPath || path.startsWith(prefixOrPath)
-      )
-    ) {
-      return h.continue
-    }
-
-    const previewRegex = /^\/preview\/([a-zA-Z0-9-]+)\/([a-zA-Z0-9-]+)/
-    const slugPathRegex = /^\/([a-zA-Z0-9-]+)\/(.+)/
-    const slugOnlyRegex = /^\/([a-zA-Z0-9-]+)$/
-
-    // /preview/{state}/{slug}
-    const previewParts = previewRegex.exec(path)
-    if (previewParts) {
-      const [, potentialState, potentialSlug] = previewParts
-      const { error: stateError } = stateSchema.validate(potentialState)
-      const { error: slugError } = slugSchema.validate(potentialSlug)
-      if (!stateError && !slugError) {
-        const targetUrl = `/form${path}`
-        server.logger.info(
-          `onRequest: Redirecting legacy preview path ${path} -> ${targetUrl}`
-        )
-        return h.redirect(targetUrl).permanent().takeover()
-      } else {
-        server.logger.warn(
-          `onRequest: Invalid format for preview path start: ${path}.`
-        )
-        throw Boom.notFound(`Invalid preview path format: ${path}`)
-      }
-    }
-
-    // /{slug}/
-    const slugPathParts = slugPathRegex.exec(path)
-    if (slugPathParts) {
-      const [, potentialSlug] = slugPathParts
-      const { error } = slugSchema.validate(potentialSlug)
-      if (!error) {
-        const targetUrl = `/form${path}`
-        server.logger.info(
-          `onRequest: Redirecting legacy slug path ${path} -> ${targetUrl}`
-        )
-        return h.redirect(targetUrl).permanent().takeover()
-      }
-    }
-
-    // /{slug}
-    const slugOnlyMatch = slugOnlyRegex.exec(path)
-    if (slugOnlyMatch) {
-      const potentialSlug = slugOnlyMatch[1]
-      const { error } = slugSchema.validate(potentialSlug)
-      if (!error) {
-        const targetUrl = `/form/${potentialSlug}`
-        server.logger.info(
-          `onRequest: Redirecting legacy root slug ${path} -> ${targetUrl}`
-        )
-        return h.redirect(targetUrl).permanent().takeover()
-      }
-    }
-
-    return h.continue
   })
 
   return server

--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -1,7 +1,6 @@
 import { join, parse } from 'node:path'
 
 import { type FormDefinition } from '@defra/forms-model'
-import { type ServerRegisterPluginObject } from '@hapi/hapi'
 
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
@@ -17,7 +16,12 @@ export const configureEnginePlugin = async ({
   formFilePath,
   services,
   controllers
-}: RouteConfig = {}): Promise<ServerRegisterPluginObject<PluginOptions>> => {
+}: RouteConfig = {}): Promise<
+  [
+    { plugin: typeof plugin; options: PluginOptions },
+    { routes: { prefix: string } }
+  ]
+> => {
   let model: FormModel | undefined
 
   if (formFileName && formFilePath) {
@@ -34,13 +38,9 @@ export const configureEnginePlugin = async ({
     )
   }
 
-  return {
-    plugin,
-    options: { model, services, controllers },
-    routes: {
-      prefix: FORM_PREFIX
-    }
-  }
+  const pluginObject = { plugin, options: { model, services, controllers } }
+  const routeOptions = { routes: { prefix: FORM_PREFIX } }
+  return [pluginObject, routeOptions]
 }
 
 export async function getForm(importPath: string) {

--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -10,6 +10,8 @@ import {
 } from '~/src/server/plugins/engine/plugin.js'
 import { type RouteConfig } from '~/src/server/types.js'
 
+const FORM_PREFIX = 'form'
+
 export const configureEnginePlugin = async ({
   formFileName,
   formFilePath,
@@ -22,7 +24,14 @@ export const configureEnginePlugin = async ({
     const definition = await getForm(join(formFilePath, formFileName))
     const { name } = parse(formFileName)
 
-    model = new FormModel(definition, { basePath: name }, services, controllers)
+    const initialBasePath = `${FORM_PREFIX}/${name}`
+
+    model = new FormModel(
+      definition,
+      { basePath: initialBasePath },
+      services,
+      controllers
+    )
   }
 
   return {

--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -2,14 +2,13 @@ import { join, parse } from 'node:path'
 
 import { type FormDefinition } from '@defra/forms-model'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import {
   plugin,
   type PluginOptions
 } from '~/src/server/plugins/engine/plugin.js'
 import { type RouteConfig } from '~/src/server/types.js'
-
-const FORM_PREFIX = '/form'
 
 export const configureEnginePlugin = async ({
   formFileName,

--- a/src/server/plugins/engine/configureEnginePlugin.ts
+++ b/src/server/plugins/engine/configureEnginePlugin.ts
@@ -10,7 +10,7 @@ import {
 } from '~/src/server/plugins/engine/plugin.js'
 import { type RouteConfig } from '~/src/server/types.js'
 
-const FORM_PREFIX = 'form'
+const FORM_PREFIX = '/form'
 
 export const configureEnginePlugin = async ({
   formFileName,
@@ -24,7 +24,7 @@ export const configureEnginePlugin = async ({
     const definition = await getForm(join(formFilePath, formFileName))
     const { name } = parse(formFileName)
 
-    const initialBasePath = `${FORM_PREFIX}/${name}`
+    const initialBasePath = `${FORM_PREFIX.substring(1)}/${name}`
 
     model = new FormModel(
       definition,
@@ -36,7 +36,10 @@ export const configureEnginePlugin = async ({
 
   return {
     plugin,
-    options: { model, services, controllers }
+    options: { model, services, controllers },
+    routes: {
+      prefix: FORM_PREFIX
+    }
   }
 }
 

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -336,7 +336,7 @@ describe('Helpers', () => {
     })
 
     it('should handle deeply nested prefixes (live)', () => {
-      const nestedFormPrefix = '/many/nested/levels/form'
+      const nestedFormPrefix = '/draft/many/nested/levels/form'
       const path = `${nestedFormPrefix}${PREVIEW_PATH_PREFIX}/live/some-slug`
 
       expect(checkFormStatus(path)).toStrictEqual({

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -335,11 +335,24 @@ describe('Helpers', () => {
       })
     })
 
-    it('should throw an error for invalid form state', () => {
-      const path = `${PREVIEW_PATH_PREFIX}/invalid-state`
-      expect(() => checkFormStatus(path)).toThrow(
-        'Invalid form state: invalid-state'
-      )
+    it('should handle deeply nested prefixes (live)', () => {
+      const nestedFormPrefix = '/many/nested/levels/form'
+      const path = `${nestedFormPrefix}${PREVIEW_PATH_PREFIX}/live/some-slug`
+
+      expect(checkFormStatus(path)).toStrictEqual({
+        state: FormStatus.Live,
+        isPreview: true
+      })
+    })
+
+    it('should handle deeply nested prefixes (draft)', () => {
+      const nestedFormPrefix = '/a/b/c/d/form'
+      const path = `${nestedFormPrefix}${PREVIEW_PATH_PREFIX}/draft/another-slug`
+
+      expect(checkFormStatus(path)).toStrictEqual({
+        state: FormStatus.Draft,
+        isPreview: true
+      })
     })
   })
 

--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -3,7 +3,6 @@ import { type ResponseObject, type ResponseToolkit } from '@hapi/hapi'
 import { StatusCodes } from 'http-status-codes'
 import { ValidationError } from 'joi'
 
-import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
 import {
   checkEmailAddressForLiveFormSubmission,
   checkFormStatus,
@@ -311,47 +310,41 @@ describe('Helpers', () => {
   })
 
   describe('checkFormStatus', () => {
-    it('should return true/live for paths starting with PREVIEW_PATH_PREFIX and form is live', () => {
-      const path = `${PREVIEW_PATH_PREFIX}/live/another/segment`
-      expect(checkFormStatus(path)).toStrictEqual({
+    it('should return true/live for params that include live state segment', () => {
+      expect(
+        checkFormStatus({
+          state: FormStatus.Live,
+          slug: 'another',
+          path: 'segment'
+        })
+      ).toStrictEqual({
         state: FormStatus.Live,
         isPreview: true
       })
     })
 
-    it('should return false for paths not starting with PREVIEW_PATH_PREFIX', () => {
-      const path = '/some/other/path'
-      expect(checkFormStatus(path)).toStrictEqual({
+    it('should return true/draft for params that include draft state segment', () => {
+      expect(
+        checkFormStatus({
+          state: FormStatus.Draft,
+          slug: 'another',
+          path: 'segment'
+        })
+      ).toStrictEqual({
+        state: FormStatus.Draft,
+        isPreview: true
+      })
+    })
+
+    it('should return false/live for paths without a state segment', () => {
+      expect(
+        checkFormStatus({
+          slug: 'some',
+          path: 'other'
+        })
+      ).toStrictEqual({
         state: FormStatus.Live,
         isPreview: false
-      })
-    })
-
-    it('should be case insensitive and return draft when form is draft', () => {
-      const path = `${PREVIEW_PATH_PREFIX.toUpperCase()}/draft/path`
-      expect(checkFormStatus(path)).toStrictEqual({
-        state: FormStatus.Draft,
-        isPreview: true
-      })
-    })
-
-    it('should handle deeply nested prefixes (live)', () => {
-      const nestedFormPrefix = '/draft/many/nested/levels/form'
-      const path = `${nestedFormPrefix}${PREVIEW_PATH_PREFIX}/live/some-slug`
-
-      expect(checkFormStatus(path)).toStrictEqual({
-        state: FormStatus.Live,
-        isPreview: true
-      })
-    })
-
-    it('should handle deeply nested prefixes (draft)', () => {
-      const nestedFormPrefix = '/a/b/c/d/form'
-      const path = `${nestedFormPrefix}${PREVIEW_PATH_PREFIX}/draft/another-slug`
-
-      expect(checkFormStatus(path)).toStrictEqual({
-        state: FormStatus.Draft,
-        isPreview: true
       })
     })
   })

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -367,3 +367,13 @@ export function evaluateTemplate(
     globals
   })
 }
+
+/**
+ * Handles logging and issuing a permanent redirect for legacy routes.
+ * @param h - The Hapi response toolkit.
+ * @param targetUrl - The URL to redirect to.
+ * @returns The Hapi response object configured for permanent redirect.
+ */
+export function handleLegacyRedirect(h: ResponseToolkit, targetUrl: string) {
+  return h.redirect(targetUrl).permanent().takeover()
+}

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -253,8 +253,8 @@ export function getStartPath(model?: FormModel) {
   return startPath ? `/${startPath}` : ControllerPath.Start
 }
 
-export function checkFormStatus(params: FormParams) {
-  const isPreview = !!params.state
+export function checkFormStatus(params?: FormParams) {
+  const isPreview = !!params?.state
 
   let state = FormStatus.Live
 

--- a/src/server/plugins/engine/models/SummaryViewModel.test.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.test.ts
@@ -1,3 +1,4 @@
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import {
   FormModel,
   SummaryViewModel
@@ -13,7 +14,7 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 import definition from '~/test/form/definitions/repeat-mixed.js'
 
-const basePath = '/form/test'
+const basePath = `${FORM_PREFIX}/test`
 
 describe('SummaryViewModel', () => {
   const itemId1 = 'abc-123'
@@ -28,7 +29,7 @@ describe('SummaryViewModel', () => {
 
   beforeEach(() => {
     model = new FormModel(definition, {
-      basePath: 'form/test'
+      basePath: `${FORM_PREFIX}/test`
     })
 
     page = createPage(model, definition.pages[2])

--- a/src/server/plugins/engine/models/SummaryViewModel.test.ts
+++ b/src/server/plugins/engine/models/SummaryViewModel.test.ts
@@ -13,7 +13,7 @@ import {
 } from '~/src/server/plugins/engine/types.js'
 import definition from '~/test/form/definitions/repeat-mixed.js'
 
-const basePath = '/test'
+const basePath = '/form/test'
 
 describe('SummaryViewModel', () => {
   const itemId1 = 'abc-123'
@@ -28,7 +28,7 @@ describe('SummaryViewModel', () => {
 
   beforeEach(() => {
     model = new FormModel(definition, {
-      basePath: 'test'
+      basePath: 'form/test'
     })
 
     page = createPage(model, definition.pages[2])

--- a/src/server/plugins/engine/pageControllers/PageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.test.ts
@@ -10,6 +10,8 @@ describe('PageController', () => {
   let controller1: PageController
   let controller2: PageController
 
+  const testBasePath = 'form/test'
+
   beforeEach(() => {
     const { pages } = definition
 
@@ -17,7 +19,7 @@ describe('PageController', () => {
     const page2 = pages[1]
 
     model = new FormModel(definition, {
-      basePath: 'test'
+      basePath: testBasePath
     })
 
     controller1 = new PageController(model, page1)
@@ -31,8 +33,8 @@ describe('PageController', () => {
     })
 
     it('returns href', () => {
-      expect(controller1).toHaveProperty('href', '/test/licence')
-      expect(controller2).toHaveProperty('href', '/test/full-name')
+      expect(controller1).toHaveProperty('href', `/${testBasePath}/licence`)
+      expect(controller2).toHaveProperty('href', `/${testBasePath}/full-name`)
     })
 
     it('returns keys (empty)', () => {
@@ -102,8 +104,8 @@ describe('PageController', () => {
         const href1 = controller1.getHref('/')
         const href2 = controller1.getHref('/page-one')
 
-        expect(href1).toBe('/test')
-        expect(href2).toBe('/test/page-one')
+        expect(href1).toBe(`/${testBasePath}`)
+        expect(href2).toBe(`/${testBasePath}/page-one`)
       })
     })
 

--- a/src/server/plugins/engine/pageControllers/PageController.test.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.test.ts
@@ -1,5 +1,6 @@
 import { type ResponseToolkit } from '@hapi/hapi'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
 import { type FormRequest } from '~/src/server/routes/types.js'
@@ -10,7 +11,7 @@ describe('PageController', () => {
   let controller1: PageController
   let controller2: PageController
 
-  const testBasePath = 'form/test'
+  const testBasePath = `${FORM_PREFIX}/test`
 
   beforeEach(() => {
     const { pages } = definition
@@ -33,8 +34,8 @@ describe('PageController', () => {
     })
 
     it('returns href', () => {
-      expect(controller1).toHaveProperty('href', `/${testBasePath}/licence`)
-      expect(controller2).toHaveProperty('href', `/${testBasePath}/full-name`)
+      expect(controller1).toHaveProperty('href', `${testBasePath}/licence`)
+      expect(controller2).toHaveProperty('href', `${testBasePath}/full-name`)
     })
 
     it('returns keys (empty)', () => {
@@ -101,11 +102,11 @@ describe('PageController', () => {
   describe('Path methods', () => {
     describe('Link href', () => {
       it('prefixes paths into link hrefs', () => {
-        const href1 = controller1.getHref('/')
+        const href1 = controller1.getHref('')
         const href2 = controller1.getHref('/page-one')
 
-        expect(href1).toBe(`/${testBasePath}`)
-        expect(href2).toBe(`/${testBasePath}/page-one`)
+        expect(href1).toBe(testBasePath)
+        expect(href2).toBe(`${testBasePath}/page-one`)
       })
     })
 

--- a/src/server/plugins/engine/pageControllers/PageController.ts
+++ b/src/server/plugins/engine/pageControllers/PageController.ts
@@ -135,12 +135,22 @@ export class PageController {
     return def.phaseBanner?.phase
   }
 
-  getHref(path: string) {
-    const { model } = this
+  getHref(path: string): string {
+    const basePath = this.model.basePath
 
-    return path === '/'
-      ? `/${model.basePath}` // Strip trailing slash
-      : `/${model.basePath}${path}`
+    if (path === '/') {
+      return `/${basePath}`
+    }
+
+    // if ever the path is not prefixed with a slash, add it
+    const relativeTargetPath = path.startsWith('/') ? path.substring(1) : path
+    let finalPath = `/${basePath}`
+    if (relativeTargetPath) {
+      finalPath += `/${relativeTargetPath}`
+    }
+    finalPath = finalPath.replace(/\/{2,}/g, '/')
+
+    return finalPath
   }
 
   getStartPath() {

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -111,7 +111,7 @@ export class SummaryPageController extends QuestionPageController {
 
       // Get the form metadata using the `slug` param
       const { notificationEmail } = await getFormMetadata(params.slug)
-      const { isPreview } = checkFormStatus(request.path)
+      const { isPreview } = checkFormStatus(request.params)
       const emailAddress = notificationEmail ?? this.model.def.outputEmail
 
       checkEmailAddressForLiveFormSubmission(emailAddress, isPreview)
@@ -153,8 +153,7 @@ async function submitForm(
 ) {
   await extendFileRetention(model, state, emailAddress)
 
-  const { path } = request
-  const formStatus = checkFormStatus(path)
+  const formStatus = checkFormStatus(request.params)
   const logTags = ['submit', 'submissionApi']
 
   request.logger.info(logTags, 'Preparing email', formStatus)

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -82,9 +82,9 @@ export const plugin = {
         return h.continue
       }
 
-      const { params, path } = request
+      const { params } = request
       const { slug } = params
-      const { isPreview, state: formState } = checkFormStatus(path)
+      const { isPreview, state: formState } = checkFormStatus(params)
 
       // Get the form metadata using the `slug` param
       const metadata = await formsService.getFormMetadata(slug)

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -130,8 +130,8 @@ export const plugin = {
 
         // Set up the basePath for the model
         const basePath = isPreview
-          ? `${PREVIEW_PATH_PREFIX.substring(1)}/${formState}/${slug}`
-          : slug
+          ? `form/${PREVIEW_PATH_PREFIX.substring(1)}/${formState}/${slug}`
+          : `form/${slug}`
 
         // Construct the form model
         const model = new FormModel(

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -61,6 +61,7 @@ export const plugin = {
   dependencies: '@hapi/vision',
   multiple: true,
   register(server, options) {
+    const prefix = server.realm.modifiers.route.prefix
     const { model, services = defaultServices, controllers } = options
     const { formsService } = services
 
@@ -129,9 +130,11 @@ export const plugin = {
         )
 
         // Set up the basePath for the model
-        const basePath = isPreview
-          ? `form/${PREVIEW_PATH_PREFIX.substring(1)}/${formState}/${slug}`
-          : `form/${slug}`
+        const basePath = (
+          isPreview
+            ? `${prefix}${PREVIEW_PATH_PREFIX}/${formState}/${slug}`
+            : `${prefix}/${slug}`
+        ).substring(1)
 
         // Construct the form model
         const model = new FormModel(

--- a/src/server/plugins/engine/services/notifyService.ts
+++ b/src/server/plugins/engine/services/notifyService.ts
@@ -19,8 +19,7 @@ export async function submit(
   submitResponse: SubmitResponsePayload
 ) {
   const logTags = ['submit', 'email']
-  const { path } = request
-  const formStatus = checkFormStatus(path)
+  const formStatus = checkFormStatus(request.params)
 
   // Get submission email personalisation
   request.logger.info(logTags, 'Getting personalisation data')

--- a/src/server/plugins/nunjucks/context.js
+++ b/src/server/plugins/nunjucks/context.js
@@ -8,8 +8,8 @@ import pkg from '~/package.json' with { type: 'json' }
 import { parseCookieConsent } from '~/src/common/cookies.js'
 import { config } from '~/src/config/index.js'
 import { createLogger } from '~/src/server/common/helpers/logging/logger.js'
-import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
 import {
+  checkFormStatus,
   encodeUrl,
   safeGenerateCrumb
 } from '~/src/server/plugins/engine/helpers.js'
@@ -34,10 +34,10 @@ export function context(request) {
     }
   }
 
-  const { params, path, query = {}, response, state } = request ?? {}
+  const { params, query = {}, response, state } = request ?? {}
 
   const isForceAccess = 'force' in query
-  const isPreviewMode = path?.startsWith(PREVIEW_PATH_PREFIX)
+  const { isPreview: isPreviewMode, state: formState } = checkFormStatus(params)
 
   // Only add the slug in to the context if the response is OK.
   // Footer meta links are not rendered when the slug is missing.
@@ -60,7 +60,7 @@ export function context(request) {
     crumb: safeGenerateCrumb(request),
     cspNonce: request?.plugins.blankie?.nonces?.script,
     currentPath: request ? `${request.path}${request.url.search}` : undefined,
-    previewMode: isPreviewMode ? params?.state : undefined,
+    previewMode: isPreviewMode ? formState : undefined,
     slug: isResponseOK ? params?.slug : undefined,
 
     getAssetPath: (asset = '') => {

--- a/src/server/plugins/router.ts
+++ b/src/server/plugins/router.ts
@@ -43,19 +43,17 @@ export default {
       server.route({
         method: 'GET',
         path: '/preview/{state}/{slug}',
-        options: {
-          handler: (request: Request, h: ResponseToolkit) => {
-            const { state, slug } = request.params
-            const { error: stateError } = stateSchema.validate(state)
-            const { error: slugError } = slugSchema.validate(slug)
+        handler: (request: Request, h: ResponseToolkit) => {
+          const { state, slug } = request.params
+          const { error: stateError } = stateSchema.validate(state)
+          const { error: slugError } = slugSchema.validate(slug)
 
-            if (stateError || slugError) {
-              throw Boom.notFound()
-            }
-
-            const targetUrl = `${FORM_PREFIX}${request.path}`
-            return handleLegacyRedirect(h, targetUrl)
+          if (stateError || slugError) {
+            throw Boom.notFound()
           }
+
+          const targetUrl = `${FORM_PREFIX}${request.path}`
+          return handleLegacyRedirect(h, targetUrl)
         }
       })
 
@@ -63,18 +61,16 @@ export default {
       server.route({
         method: 'GET',
         path: '/{slug}/{path*}',
-        options: {
-          handler: (request: Request, h: ResponseToolkit) => {
-            const { slug } = request.params
-            const { error } = slugSchema.validate(slug)
+        handler: (request: Request, h: ResponseToolkit) => {
+          const { slug } = request.params
+          const { error } = slugSchema.validate(slug)
 
-            if (error) {
-              throw Boom.notFound()
-            }
-
-            const targetUrl = `${FORM_PREFIX}${request.path}`
-            return handleLegacyRedirect(h, targetUrl)
+          if (error) {
+            throw Boom.notFound()
           }
+
+          const targetUrl = `${FORM_PREFIX}${request.path}`
+          return handleLegacyRedirect(h, targetUrl)
         }
       })
 
@@ -82,18 +78,16 @@ export default {
       server.route({
         method: 'GET',
         path: '/{slug}',
-        options: {
-          handler: (request: Request, h: ResponseToolkit) => {
-            const { slug } = request.params
-            const { error } = slugSchema.validate(slug)
+        handler: (request: Request, h: ResponseToolkit) => {
+          const { slug } = request.params
+          const { error } = slugSchema.validate(slug)
 
-            if (error) {
-              throw Boom.notFound()
-            }
-            // Note: Target URL is slightly different for this specific route
-            const targetUrl = `${FORM_PREFIX}/${slug}`
-            return handleLegacyRedirect(h, targetUrl)
+          if (error) {
+            throw Boom.notFound()
           }
+          // Note: Target URL is slightly different for this specific route
+          const targetUrl = `${FORM_PREFIX}/${slug}`
+          return handleLegacyRedirect(h, targetUrl)
         }
       })
 

--- a/test/client/javascripts/file-upload.test.js
+++ b/test/client/javascripts/file-upload.test.js
@@ -1,4 +1,7 @@
-import { initFileUpload } from '~/src/client/javascripts/file-upload.js'
+import {
+  buildUploadStatusUrl,
+  initFileUpload
+} from '~/src/client/javascripts/file-upload.js'
 
 describe('File Upload Client JS', () => {
   beforeEach(() => {
@@ -1297,5 +1300,24 @@ describe('File Upload Client JS', () => {
     triggerClick({ preventDefault: jest.fn() })
 
     expect(fileInput?.hasAttribute('aria-describedby')).toBe(false)
+  })
+})
+
+describe('buildUploadStatusUrl()', () => {
+  it('builds URL with no prefix for root paths', () => {
+    expect(buildUploadStatusUrl('/', 'abc')).toBe('/upload-status/abc')
+    expect(buildUploadStatusUrl('', 'xyz')).toBe('/upload-status/xyz')
+  })
+
+  it('uses the first segment as prefix', () => {
+    expect(buildUploadStatusUrl('/form/mypage', 'id1')).toBe(
+      '/form/upload-status/id1'
+    )
+  })
+
+  it('trims nested segments and trailing slashes', () => {
+    expect(buildUploadStatusUrl('/one/two/three/', 'id2')).toBe(
+      '/one/upload-status/id2'
+    )
   })
 })

--- a/test/condition/checkboxes.test.js
+++ b/test/condition/checkboxes.test.js
@@ -7,7 +7,7 @@ import { getFormMetadata } from '~/src/server/plugins/engine/services/formsServi
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
-const basePath = '/checkboxes'
+const basePath = '/form/checkboxes'
 const key = 'wqJmSf'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/condition/checkboxes.test.js
+++ b/test/condition/checkboxes.test.js
@@ -2,12 +2,13 @@ import { resolve } from 'node:path'
 
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
-const basePath = '/form/checkboxes'
+const basePath = `${FORM_PREFIX}/checkboxes`
 const key = 'wqJmSf'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/condition/radios.test.js
+++ b/test/condition/radios.test.js
@@ -7,7 +7,7 @@ import { getFormMetadata } from '~/src/server/plugins/engine/services/formsServi
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
-const basePath = '/radios'
+const basePath = '/form/radios'
 const key = 'wqJmSf'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/condition/radios.test.js
+++ b/test/condition/radios.test.js
@@ -2,12 +2,13 @@ import { resolve } from 'node:path'
 
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
-const basePath = '/form/radios'
+const basePath = `${FORM_PREFIX}/radios`
 const key = 'wqJmSf'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/condition/text.test.js
+++ b/test/condition/text.test.js
@@ -2,12 +2,13 @@ import { resolve } from 'node:path'
 
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
-const basePath = '/form/text'
+const basePath = `${FORM_PREFIX}/text`
 const key = 'wqJmSf'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/condition/text.test.js
+++ b/test/condition/text.test.js
@@ -7,7 +7,7 @@ import { getFormMetadata } from '~/src/server/plugins/engine/services/formsServi
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
-const basePath = '/text'
+const basePath = '/form/text'
 const key = 'wqJmSf'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/form/cookies.test.js
+++ b/test/form/cookies.test.js
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
@@ -24,7 +25,7 @@ describe(`Cookie banner and analytics`, () => {
   })
 
   test.each([
-    '/form/basic/licence', // Form pages HAVE the prefix
+    `${FORM_PREFIX}/basic/licence`, // Form pages HAVE the prefix
     '/help/accessibility-statement/basic' // Help pages DO NOT have the prefix
   ])('shows the cookie banner by default', async (path) => {
     server = await createServer({
@@ -53,7 +54,7 @@ describe(`Cookie banner and analytics`, () => {
   })
 
   test.each([
-    '/form/basic/licence', // Form pages HAVE the prefix
+    `${FORM_PREFIX}/basic/licence`, // Form pages HAVE the prefix
     '/help/accessibility-statement/basic' // Help pages DO NOT have the prefix
   ])('confirms when the user has accepted analytics cookies', async (path) => {
     server = await createServer({
@@ -104,7 +105,7 @@ describe(`Cookie banner and analytics`, () => {
 
   test.each([
     // form pages
-    '/form/basic/licence',
+    `${FORM_PREFIX}/basic/licence`,
     // non-form pages
     '/help/accessibility-statement/basic'
   ])('confirms when the user has rejected analytics cookies', async (path) => {
@@ -157,9 +158,8 @@ describe(`Cookie banner and analytics`, () => {
 
   test.each([
     // form pages
-    '/form/basic/start',
+    `${FORM_PREFIX}/basic/start`
     // non-form pages
-    '/'
   ])('hides the cookie banner once dismissed', async (path) => {
     server = await createServer({
       formFileName: 'basic.js',

--- a/test/form/cookies.test.js
+++ b/test/form/cookies.test.js
@@ -24,8 +24,8 @@ describe(`Cookie banner and analytics`, () => {
   })
 
   test.each([
-    '/basic/licence', // form pages
-    '/help/accessibility-statement/basic' // non-form pages
+    '/form/basic/licence', // Form pages HAVE the prefix
+    '/help/accessibility-statement/basic' // Help pages DO NOT have the prefix
   ])('shows the cookie banner by default', async (path) => {
     server = await createServer({
       formFileName: 'basic.js',
@@ -53,10 +53,8 @@ describe(`Cookie banner and analytics`, () => {
   })
 
   test.each([
-    // form pages
-    '/basic/licence',
-    // non-form pages
-    '/help/accessibility-statement/basic'
+    '/form/basic/licence', // Form pages HAVE the prefix
+    '/help/accessibility-statement/basic' // Help pages DO NOT have the prefix
   ])('confirms when the user has accepted analytics cookies', async (path) => {
     server = await createServer({
       formFileName: 'basic.js',
@@ -106,7 +104,7 @@ describe(`Cookie banner and analytics`, () => {
 
   test.each([
     // form pages
-    '/basic/licence',
+    '/form/basic/licence',
     // non-form pages
     '/help/accessibility-statement/basic'
   ])('confirms when the user has rejected analytics cookies', async (path) => {
@@ -159,7 +157,7 @@ describe(`Cookie banner and analytics`, () => {
 
   test.each([
     // form pages
-    '/basic/start',
+    '/form/basic/start',
     // non-form pages
     '/'
   ])('hides the cookie banner once dismissed', async (path) => {

--- a/test/form/csrf.test.js
+++ b/test/form/csrf.test.js
@@ -2,13 +2,14 @@ import { join } from 'node:path'
 
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie } from '~/test/utils/get-cookie.js'
 
-const basePath = '/form/basic'
+const basePath = `${FORM_PREFIX}/basic`
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 

--- a/test/form/csrf.test.js
+++ b/test/form/csrf.test.js
@@ -8,7 +8,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie } from '~/test/utils/get-cookie.js'
 
-const basePath = '/basic'
+const basePath = '/form/basic'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 

--- a/test/form/exit-page.test.js
+++ b/test/form/exit-page.test.js
@@ -8,7 +8,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/demo-cph-number'
+const basePath = '/form/demo-cph-number'
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/form/exit-page.test.js
+++ b/test/form/exit-page.test.js
@@ -2,13 +2,14 @@ import { join } from 'node:path'
 
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/form/demo-cph-number'
+const basePath = `${FORM_PREFIX}/demo-cph-number`
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/form/feedback.test.js
+++ b/test/form/feedback.test.js
@@ -34,8 +34,7 @@ describe('Feedback link', () => {
 
   it.each([
     {
-      // Default feedback link
-      url: '/help/cookies',
+      url: '/form/help/cookies',
       name: 'give your feedback (opens in new tab)',
       href: FEEDBACK_LINK
     },
@@ -58,7 +57,7 @@ describe('Feedback link', () => {
     expect($link).toHaveAttribute('href', href)
     expect($link).toHaveClass('govuk-link')
 
-    expect($phaseBanner).toHaveAttribute('class', 'govuk-phase-banner')
+    expect($phaseBanner).toBeInTheDocument()
     expect($phaseBanner).toContainElement($link)
   })
 })

--- a/test/form/feedback.test.js
+++ b/test/form/feedback.test.js
@@ -6,7 +6,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 const { FEEDBACK_LINK } = process.env
-const basePath = '/feedback'
+const basePath = '/form/feedback'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 

--- a/test/form/feedback.test.js
+++ b/test/form/feedback.test.js
@@ -1,12 +1,13 @@
 import { join } from 'node:path'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 
 const { FEEDBACK_LINK } = process.env
-const basePath = '/form/feedback'
+const basePath = `${FORM_PREFIX}/feedback`
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
@@ -34,7 +35,7 @@ describe('Feedback link', () => {
 
   it.each([
     {
-      url: '/form/help/cookies',
+      url: `${FORM_PREFIX}/help/cookies`,
       name: 'give your feedback (opens in new tab)',
       href: FEEDBACK_LINK
     },

--- a/test/form/fields-optional.test.js
+++ b/test/form/fields-optional.test.js
@@ -2,13 +2,14 @@ import { join } from 'node:path'
 
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/form/fields-optional'
+const basePath = `${FORM_PREFIX}/fields-optional`
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 

--- a/test/form/fields-optional.test.js
+++ b/test/form/fields-optional.test.js
@@ -8,7 +8,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/fields-optional'
+const basePath = '/form/fields-optional'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 

--- a/test/form/fields-required.test.js
+++ b/test/form/fields-required.test.js
@@ -3,13 +3,14 @@ import { join } from 'node:path'
 import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/form/fields-required'
+const basePath = `${FORM_PREFIX}/fields-required`
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 

--- a/test/form/fields-required.test.js
+++ b/test/form/fields-required.test.js
@@ -9,7 +9,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/fields-required'
+const basePath = '/form/fields-required'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 

--- a/test/form/file-upload.test.js
+++ b/test/form/file-upload.test.js
@@ -14,7 +14,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/file-upload'
+const basePath = '/form/file-upload'
 
 jest.mock('~/src/server/plugins/engine/services/uploadService.js')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/form/file-upload.test.js
+++ b/test/form/file-upload.test.js
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import {
@@ -14,7 +15,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/form/file-upload'
+const basePath = `${FORM_PREFIX}/file-upload`
 
 jest.mock('~/src/server/plugins/engine/services/uploadService.js')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -19,7 +19,7 @@ import { sendNotification } from '~/src/server/utils/notify.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/components'
+const basePath = '/form/components'
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/uploadService.js')

--- a/test/form/govuk-notify.test.js
+++ b/test/form/govuk-notify.test.js
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { StatusCodes } from 'http-status-codes'
 import { outdent } from 'outdent'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import {
   persistFiles,
@@ -19,7 +20,7 @@ import { sendNotification } from '~/src/server/utils/notify.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/form/components'
+const basePath = `${FORM_PREFIX}/components`
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/uploadService.js')

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -11,7 +11,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/basic'
+const basePath = '/form/basic'
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
@@ -122,6 +122,8 @@ describe('Form journey', () => {
   })
 
   beforeEach(() => {
+    // server.app.models.clear()
+    jest.clearAllMocks()
     jest.mocked(getFormMetadata).mockResolvedValue(fixtures.form.metadata)
   })
 

--- a/test/form/journey-basic.test.js
+++ b/test/form/journey-basic.test.js
@@ -3,6 +3,7 @@ import { join } from 'node:path'
 import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { submit } from '~/src/server/plugins/engine/services/formSubmissionService.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
@@ -11,7 +12,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/form/basic'
+const basePath = `${FORM_PREFIX}/basic`
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/form/legacy-redirects.test.js
+++ b/test/form/legacy-redirects.test.js
@@ -1,0 +1,142 @@
+import { StatusCodes } from 'http-status-codes'
+
+import { FORM_PREFIX } from '~/src/server/constants.js'
+import { createServer } from '~/src/server/index.js'
+import { FormStatus } from '~/src/server/routes/types.js'
+
+describe('Legacy Redirect Routes', () => {
+  /** @type {import('@hapi/hapi').Server} */
+  let server
+
+  beforeAll(async () => {
+    server = await createServer({})
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  describe('GET /preview/{state}/{slug}', () => {
+    it('should permanently redirect valid live preview paths', async () => {
+      const state = FormStatus.Live
+      const slug = 'my-valid-slug'
+      const response = await server.inject({
+        method: 'GET',
+        url: `/preview/${state}/${slug}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
+      expect(response.headers.location).toBe(
+        `${FORM_PREFIX}/preview/${state}/${slug}`
+      )
+    })
+
+    it('should permanently redirect valid draft preview paths', async () => {
+      const state = FormStatus.Draft
+      const slug = 'another-slug-123'
+      const response = await server.inject({
+        method: 'GET',
+        url: `/preview/${state}/${slug}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
+      expect(response.headers.location).toBe(
+        `${FORM_PREFIX}/preview/${state}/${slug}`
+      )
+    })
+
+    it('should return 404 for invalid state', async () => {
+      const state = 'invalid-state'
+      const slug = 'my-valid-slug'
+      const response = await server.inject({
+        method: 'GET',
+        url: `/preview/${state}/${slug}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+
+    it('should return 404 for invalid slug', async () => {
+      const state = FormStatus.Live
+      const slug = 'InvalidSlugWithCaps'
+      const response = await server.inject({
+        method: 'GET',
+        url: `/preview/${state}/${slug}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+
+    it('should return 404 for invalid state and slug', async () => {
+      const state = 'bad'
+      const slug = 'BadSlug'
+      const response = await server.inject({
+        method: 'GET',
+        url: `/preview/${state}/${slug}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+  })
+
+  describe('GET /{slug}/{path*}', () => {
+    it('should permanently redirect valid paths with path segments', async () => {
+      const slug = 'my-valid-slug'
+      const path = 'page-one/sub-page'
+      const response = await server.inject({
+        method: 'GET',
+        url: `/${slug}/${path}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
+      expect(response.headers.location).toBe(`${FORM_PREFIX}/${slug}/${path}`)
+    })
+
+    it('should permanently redirect valid paths with single path segment', async () => {
+      const slug = 'another-slug'
+      const path = 'summary'
+      const response = await server.inject({
+        method: 'GET',
+        url: `/${slug}/${path}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
+      expect(response.headers.location).toBe(`${FORM_PREFIX}/${slug}/${path}`)
+    })
+
+    it('should return 404 for invalid slug', async () => {
+      const slug = 'InvalidSlug'
+      const path = 'page-one'
+      const response = await server.inject({
+        method: 'GET',
+        url: `/${slug}/${path}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+  })
+
+  describe('GET /{slug}', () => {
+    it('should permanently redirect valid paths with only a slug', async () => {
+      const slug = 'my-valid-slug-123'
+      const response = await server.inject({
+        method: 'GET',
+        url: `/${slug}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.MOVED_PERMANENTLY)
+      expect(response.headers.location).toBe(`${FORM_PREFIX}/${slug}`)
+    })
+
+    it('should return 404 for invalid slug', async () => {
+      const slug = 'Invalid-Slug!'
+      const response = await server.inject({
+        method: 'GET',
+        url: `/${slug}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.NOT_FOUND)
+    })
+  })
+})

--- a/test/form/persist-files.test.js
+++ b/test/form/persist-files.test.js
@@ -15,7 +15,7 @@ import { CacheService } from '~/src/server/services/cacheService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/file-upload-basic'
+const basePath = '/form/file-upload-basic'
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/form/persist-files.test.js
+++ b/test/form/persist-files.test.js
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import {
   persistFiles,
@@ -15,7 +16,7 @@ import { CacheService } from '~/src/server/services/cacheService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/form/file-upload-basic'
+const basePath = `${FORM_PREFIX}/file-upload-basic`
 
 jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')

--- a/test/form/phase-banner.test.js
+++ b/test/form/phase-banner.test.js
@@ -22,7 +22,7 @@ describe(`Phase banner`, () => {
   })
 
   test('shows the server phase tag by default', async () => {
-    const basePath = '/phase-default'
+    const basePath = '/form/phase-default'
 
     server = await createServer({
       formFileName: 'phase-default.json',
@@ -44,7 +44,7 @@ describe(`Phase banner`, () => {
   })
 
   test('shows the form phase tag if provided', async () => {
-    const basePath = '/phase-alpha'
+    const basePath = '/form/phase-alpha'
 
     server = await createServer({
       formFileName: 'phase-alpha.json',

--- a/test/form/phase-banner.test.js
+++ b/test/form/phase-banner.test.js
@@ -2,11 +2,11 @@ import { join } from 'node:path'
 
 import { within } from '@testing-library/dom'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
-
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
 describe(`Phase banner`, () => {
@@ -22,7 +22,7 @@ describe(`Phase banner`, () => {
   })
 
   test('shows the server phase tag by default', async () => {
-    const basePath = '/form/phase-default'
+    const basePath = `${FORM_PREFIX}/phase-default`
 
     server = await createServer({
       formFileName: 'phase-default.json',
@@ -44,7 +44,7 @@ describe(`Phase banner`, () => {
   })
 
   test('shows the form phase tag if provided', async () => {
-    const basePath = '/form/phase-alpha'
+    const basePath = `${FORM_PREFIX}/phase-alpha`
 
     server = await createServer({
       formFileName: 'phase-alpha.json',

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -5,6 +5,7 @@ import { hasRepeater } from '@defra/forms-model'
 import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { isRepeatState } from '~/src/server/plugins/engine/components/FormComponent.js'
 import { submit } from '~/src/server/plugins/engine/services/formSubmissionService.js'
@@ -18,7 +19,7 @@ jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 jest.mock('~/src/server/plugins/engine/services/formSubmissionService.js')
 
-const basePath = '/form/repeat'
+const basePath = `${FORM_PREFIX}/repeat`
 
 /**
  * POST a new repeat item
@@ -170,7 +171,7 @@ describe('Repeat GET tests', () => {
 
     expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
     expect(res.headers.location).toMatch(
-      /^\/form\/repeat\/pizza-order\/[0-9a-f-]+$/
+      new RegExp(`^${FORM_PREFIX}/repeat/pizza-order/[0-9a-f-]+$`)
     )
   })
 
@@ -397,9 +398,10 @@ describe('Repeat POST tests', () => {
     })
 
     expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
-    expect(res.headers.location).toMatch(
-      /^\/form\/repeat\/pizza-order\/summary$/
+    const expectedPathRegex = new RegExp(
+      `^${FORM_PREFIX}/repeat/pizza-order/summary$`
     )
+    expect(res.headers.location).toMatch(expectedPathRegex)
   })
 
   test('POST /pizza-order/{id}/confirm-delete with 1 item returns 404', async () => {
@@ -432,7 +434,7 @@ describe('Repeat POST tests', () => {
 
     expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
     expect(res.headers.location).toMatch(
-      /^\/form\/repeat\/pizza-order\/summary$/
+      new RegExp(`^${FORM_PREFIX}/repeat/pizza-order/summary$`)
     )
   })
 

--- a/test/form/repeat.test.js
+++ b/test/form/repeat.test.js
@@ -18,7 +18,7 @@ jest.mock('~/src/server/utils/notify.ts')
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 jest.mock('~/src/server/plugins/engine/services/formSubmissionService.js')
 
-const basePath = '/repeat'
+const basePath = '/form/repeat'
 
 /**
  * POST a new repeat item
@@ -117,7 +117,9 @@ describe('Repeat GET tests', () => {
     })
 
     expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-    expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/[0-9a-f-]+$/)
+    expect(res.headers.location).toMatch(
+      /^\/form\/repeat\/pizza-order\/[0-9a-f-]+$/
+    )
   })
 
   test('GET /pizza-order with 1 item returns 302 to repeater summary', async () => {
@@ -167,7 +169,9 @@ describe('Repeat GET tests', () => {
     })
 
     expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY)
-    expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/[0-9a-f-]+$/)
+    expect(res.headers.location).toMatch(
+      /^\/form\/repeat\/pizza-order\/[0-9a-f-]+$/
+    )
   })
 
   test('GET /pizza-order/{id} returns 200', async () => {
@@ -393,7 +397,9 @@ describe('Repeat POST tests', () => {
     })
 
     expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
-    expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/summary?/)
+    expect(res.headers.location).toMatch(
+      /^\/form\/repeat\/pizza-order\/summary$/
+    )
   })
 
   test('POST /pizza-order/{id}/confirm-delete with 1 item returns 404', async () => {
@@ -425,7 +431,9 @@ describe('Repeat POST tests', () => {
     })
 
     expect(res.statusCode).toBe(StatusCodes.SEE_OTHER)
-    expect(res.headers.location).toMatch(/^\/repeat\/pizza-order\/summary/)
+    expect(res.headers.location).toMatch(
+      /^\/form\/repeat\/pizza-order\/summary$/
+    )
   })
 
   test('POST /pizza-order/summary ADD_ANOTHER returns 303', async () => {

--- a/test/form/summary-submission-email.test.js
+++ b/test/form/summary-submission-email.test.js
@@ -6,7 +6,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/minimal'
+const basePath = '/form/minimal'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 jest.mock('~/src/server/plugins/engine/services/formSubmissionService.js')

--- a/test/form/summary-submission-email.test.js
+++ b/test/form/summary-submission-email.test.js
@@ -1,12 +1,13 @@
 import { join } from 'node:path'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/form/minimal'
+const basePath = `${FORM_PREFIX}/minimal`
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 jest.mock('~/src/server/plugins/engine/services/formSubmissionService.js')

--- a/test/form/template.test.js
+++ b/test/form/template.test.js
@@ -3,13 +3,14 @@ import { join } from 'node:path'
 import { within } from '@testing-library/dom'
 import { StatusCodes } from 'http-status-codes'
 
+import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
 import { getFormMetadata } from '~/src/server/plugins/engine/services/formsService.js'
 import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/form/templates'
+const basePath = `${FORM_PREFIX}/templates`
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
@@ -250,7 +251,9 @@ describe('Form template journey', () => {
 
     const $output4 = container.getByTestId('output-4')
     expect($output4).toBeInTheDocument()
-    expect($output4.textContent).toBe('/form/templates/are-you-in-england')
+    expect($output4.textContent).toBe(
+      `${FORM_PREFIX}/templates/are-you-in-england`
+    )
   })
 
   test('POST /information', async () => {

--- a/test/form/template.test.js
+++ b/test/form/template.test.js
@@ -9,7 +9,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/templates'
+const basePath = '/form/templates'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 
@@ -250,7 +250,7 @@ describe('Form template journey', () => {
 
     const $output4 = container.getByTestId('output-4')
     expect($output4).toBeInTheDocument()
-    expect($output4.textContent).toBe('/templates/are-you-in-england')
+    expect($output4.textContent).toBe('/form/templates/are-you-in-england')
   })
 
   test('POST /information', async () => {

--- a/test/form/titles.test.js
+++ b/test/form/titles.test.js
@@ -6,7 +6,7 @@ import * as fixtures from '~/test/fixtures/index.js'
 import { renderResponse } from '~/test/helpers/component-helpers.js'
 import { getCookie, getCookieHeader } from '~/test/utils/get-cookie.js'
 
-const basePath = '/titles'
+const basePath = '/form/titles'
 
 jest.mock('~/src/server/plugins/engine/services/formsService.js')
 


### PR DESCRIPTION
This PR prefixes all form routes with `/form` and implements strict path validation with legacy redirect support (which at some point could be removed 🤔 ?).

The legacy redirect logic resides within an `onRequest` hook that intercepts incoming `GET` requests:

1.  **Ignored Prefixes:** Paths already starting with `/form/`, `/help/`, `/assets/`, etc., along with the root path `/`, are immediately passed through (`h.continue`).
2.  `/preview/{state}/{slug}`: Paths matching this are validated so that `state` must be 'live' or 'draft', and the `slug` must be conformant to the `slugSchema` (lowercase letters, numbers, hyphens).
    *   Valid paths (e.g., `/preview/live/my-slug`) are permanently redirected to `/form/preview/live/my-slug`.
    *   Paths with an invalid state or slug (e.g., `/preview/invalid/my-slug` or `/preview/live/InvalidSlug`) result in a 404.
3.  `/{slug}/{path...}`: Paths matching this  have their initial `slug` segment validated against `slugSchema`.
    *   Valid paths (e.g., `/my-slug/page-one`) are permanently redirected to `/form/my-slug/page-one`.
    *   If the slug is invalid (e.g., `/Invalid-Slug/page`), the redirect is skipped, and the request continues (likely resulting in a 404 from the router).
4.  `/{slug}`: Paths containing only a valid `slug` (matching regex and `slugSchema`, e.g., `/my-slug`) are permanently redirected to `/form/my-slug`.
5.  Other Paths: Any remaining paths that don't match the ignore list or the legacy redirect patterns (e.g., `/robots.txt`) fall through to `h.continue` and are handled by the router will typically resulting in a 404 (the original point of this story).
