### PR TITLE
Add app-prose-scope class to the markdown component wrapper element

### DIFF
--- a/src/server/plugins/engine/views/components/markdown.html
+++ b/src/server/plugins/engine/views/components/markdown.html
@@ -1,5 +1,5 @@
 {% macro Markdown(component) %}
-  <div class="govuk-body">
+  <div class="app-prose-scope">
     {{ component.model.content | markdown | safe }}
   </div>
 {% endmacro %}


### PR DESCRIPTION
```
{% macro Markdown(component) %}
  <div class="app-prose-scope">
    {{ component.model.content | markdown | safe }}
  </div>
{% endmacro %}
```