### PR TITLE
Feature/strict path validation 2

### DIFF
--- a/src/server/plugins/engine/helpers.test.ts
+++ b/src/server/plugins/engine/helpers.test.ts
@@ -3,7 +3,6 @@ import { type ResponseObject, type ResponseToolkit } from '@hapi/hapi'
 import { StatusCodes } from 'http-status-codes'
 import { ValidationError } from 'joi'
 
-import { PREVIEW_PATH_PREFIX } from '~/src/server/constants.js'
 import {
   checkEmailAddressForLiveFormSubmission,
   checkFormStatus,
@@ -311,47 +310,41 @@ describe('Helpers', () => {
   })
 
   describe('checkFormStatus', () => {
-    it('should return true/live for paths starting with PREVIEW_PATH_PREFIX and form is live', () => {
-      const path = `${PREVIEW_PATH_PREFIX}/live/another/segment`
-      expect(checkFormStatus(path)).toStrictEqual({
+    it('should return true/live for params that include live state segment', () => {
+      expect(
+        checkFormStatus({
+          state: FormStatus.Live,
+          slug: 'another',
+          path: 'segment'
+        })
+      ).toStrictEqual({
         state: FormStatus.Live,
         isPreview: true
       })
     })
 
-    it('should return false for paths not starting with PREVIEW_PATH_PREFIX', () => {
-      const path = '/some/other/path'
-      expect(checkFormStatus(path)).toStrictEqual({
+    it('should return true/draft for params that include draft state segment', () => {
+      expect(
+        checkFormStatus({
+          state: FormStatus.Draft,
+          slug: 'another',
+          path: 'segment'
+        })
+      ).toStrictEqual({
+        state: FormStatus.Draft,
+        isPreview: true
+      })
+    })
+
+    it('should return false/live for paths without a state segment', () => {
+      expect(
+        checkFormStatus({
+          slug: 'some',
+          path: 'other'
+        })
+      ).toStrictEqual({
         state: FormStatus.Live,
         isPreview: false
-      })
-    })
-
-    it('should be case insensitive and return draft when form is draft', () => {
-      const path = `${PREVIEW_PATH_PREFIX.toUpperCase()}/draft/path`
-      expect(checkFormStatus(path)).toStrictEqual({
-        state: FormStatus.Draft,
-        isPreview: true
-      })
-    })
-
-    it('should handle deeply nested prefixes (live)', () => {
-      const nestedFormPrefix = '/draft/many/nested/levels/form'
-      const path = `${nestedFormPrefix}${PREVIEW_PATH_PREFIX}/live/some-slug`
-
-      expect(checkFormStatus(path)).toStrictEqual({
-        state: FormStatus.Live,
-        isPreview: true
-      })
-    })
-
-    it('should handle deeply nested prefixes (draft)', () => {
-      const nestedFormPrefix = '/a/b/c/d/form'
-      const path = `${nestedFormPrefix}${PREVIEW_PATH_PREFIX}/draft/another-slug`
-
-      expect(checkFormStatus(path)).toStrictEqual({
-        state: FormStatus.Draft,
-        isPreview: true
       })
     })
   })

--- a/src/server/plugins/engine/pageControllers/SummaryPageController.ts
+++ b/src/server/plugins/engine/pageControllers/SummaryPageController.ts
@@ -111,7 +111,7 @@ export class SummaryPageController extends QuestionPageController {
 
       // Get the form metadata using the `slug` param
       const { notificationEmail } = await getFormMetadata(params.slug)
-      const { isPreview } = checkFormStatus(request.path)
+      const { isPreview } = checkFormStatus(request.params)
       const emailAddress = notificationEmail ?? this.model.def.outputEmail
 
       checkEmailAddressForLiveFormSubmission(emailAddress, isPreview)
@@ -153,8 +153,7 @@ async function submitForm(
 ) {
   await extendFileRetention(model, state, emailAddress)
 
-  const { path } = request
-  const formStatus = checkFormStatus(path)
+  const formStatus = checkFormStatus(request.params)
   const logTags = ['submit', 'submissionApi']
 
   request.logger.info(logTags, 'Preparing email', formStatus)

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -82,9 +82,9 @@ export const plugin = {
         return h.continue
       }
 
-      const { params, path } = request
+      const { params } = request
       const { slug } = params
-      const { isPreview, state: formState } = checkFormStatus(path)
+      const { isPreview, state: formState } = checkFormStatus(params)
 
       // Get the form metadata using the `slug` param
       const metadata = await formsService.getFormMetadata(slug)

--- a/src/server/plugins/engine/plugin.ts
+++ b/src/server/plugins/engine/plugin.ts
@@ -61,6 +61,7 @@ export const plugin = {
   dependencies: '@hapi/vision',
   multiple: true,
   register(server, options) {
+    const prefix = server.realm.modifiers.route.prefix
     const { model, services = defaultServices, controllers } = options
     const { formsService } = services
 
@@ -129,9 +130,11 @@ export const plugin = {
         )
 
         // Set up the basePath for the model
-        const basePath = isPreview
-          ? `form/${PREVIEW_PATH_PREFIX.substring(1)}/${formState}/${slug}`
-          : `form/${slug}`
+        const basePath = (
+          isPreview
+            ? `${prefix}${PREVIEW_PATH_PREFIX}/${formState}/${slug}`
+            : `${prefix}/${slug}`
+        ).substring(1)
 
         // Construct the form model
         const model = new FormModel(

--- a/src/server/plugins/engine/services/notifyService.ts
+++ b/src/server/plugins/engine/services/notifyService.ts
@@ -19,8 +19,7 @@ export async function submit(
   submitResponse: SubmitResponsePayload
 ) {
   const logTags = ['submit', 'email']
-  const { path } = request
-  const formStatus = checkFormStatus(path)
+  const formStatus = checkFormStatus(request.params)
 
   // Get submission email personalisation
   request.logger.info(logTags, 'Getting personalisation data')


### PR DESCRIPTION
@mokhld I've been taking a look at your PR and have been testing out a couple of commits here.

The first [use prefix from server.realm](https://github.com/DEFRA/forms-runner/pull/785/commits/9b21c9c8a0cf8b210bcce65aa7121c0ac4254175) - rather than use the constant prefix "form" inside the plugin, we can use hapi's `server.realm.modifiers.route.prefix`, that way it'll work if the plugin is registered with something other than "/form" as the prefix.

The second commit [simplify the checkFromStatus method](https://github.com/DEFRA/forms-runner/pull/785/commits/361b505c3733d0c84a078c0ebcf7b41115b1adcf) is something I've been meaning to look at for a while as it can be much simpler. We know we're in "preview mode" simply by looking if there's a `state` entry in the params.

Speak tomorrow :wave: 

