### PR TITLE
Fixup page titles when empty

### DIFF
--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -1,7 +1,10 @@
 import {
   ControllerPath,
   Engine,
+  hasComponents,
+  isFormType,
   type ComponentDef,
+  type FormDefinition,
   type Page
 } from '@defra/forms-model'
 import Boom from '@hapi/boom'
@@ -376,4 +379,29 @@ export function evaluateTemplate(
  */
 export function handleLegacyRedirect(h: ResponseToolkit, targetUrl: string) {
   return h.redirect(targetUrl).permanent().takeover()
+}
+
+/**
+ * If the page doesn't have a title, set it from the title of the first form component
+ * @param def - the form definition
+ */
+export function setPageTitles(def: FormDefinition) {
+  def.pages.forEach((page) => {
+    if (!page.title) {
+      if (hasComponents(page)) {
+        // Set the page title from the first form component
+        const firstFormComponent = page.components.find((component) =>
+          isFormType(component.type)
+        )
+
+        page.title = firstFormComponent?.title ?? ''
+      }
+
+      if (!page.title) {
+        logger.warn(
+          `Page '${page.path}' has no title${def.name ? ` in form '${def.name}'` : ''}`
+        )
+      }
+    }
+  })
 }

--- a/src/server/plugins/engine/helpers.ts
+++ b/src/server/plugins/engine/helpers.ts
@@ -398,9 +398,9 @@ export function setPageTitles(def: FormDefinition) {
       }
 
       if (!page.title) {
-        logger.warn(
-          `Page '${page.path}' has no title${def.name ? ` in form '${def.name}'` : ''}`
-        )
+        const formNameMsg = def.name ? ` in form '${def.name}'` : ''
+
+        logger.warn(`Page '${page.path}' has no title${formNameMsg}`)
       }
     }
   })

--- a/src/server/plugins/engine/models/FormModel.test.ts
+++ b/src/server/plugins/engine/models/FormModel.test.ts
@@ -1,5 +1,6 @@
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { type FormContextRequest } from '~/src/server/plugins/engine/types.js'
+import { V2 as definitionV2 } from '~/test/form/definitions/conditions-basic.js'
 import definition from '~/test/form/definitions/conditions-escaping.js'
 import conditionsListDefinition from '~/test/form/definitions/conditions-list.js'
 import fieldsRequiredDefinition from '~/test/form/definitions/fields-required.js'
@@ -10,6 +11,20 @@ describe('FormModel', () => {
       expect(
         () => new FormModel(definition, { basePath: 'test' })
       ).not.toThrow()
+    })
+
+    it('Sets the page title from first form component when empty (V2 only)', () => {
+      const noTitlesDefinition = {
+        ...definitionV2,
+        pages: definitionV2.pages.map((page) => ({ ...page, title: '' }))
+      }
+
+      const model = new FormModel(noTitlesDefinition, { basePath: 'test' })
+
+      expect(model.def.pages.at(0)?.title).toBe(
+        'Have you previously been married?'
+      )
+      expect(model.def.pages.at(1)?.title).toBe('Date of marriage')
     })
   })
 

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -27,7 +27,8 @@ import {
 import {
   findPage,
   getError,
-  getPage
+  getPage,
+  setPageTitles
 } from '~/src/server/plugins/engine/helpers.js'
 import { type ExecutableCondition } from '~/src/server/plugins/engine/models/types.js'
 import { type PageController } from '~/src/server/plugins/engine/pageControllers/PageController.js'
@@ -103,6 +104,9 @@ export class FormModel {
         }
       ]
     })
+
+    // Fix up page titles
+    setPageTitles(def)
 
     this.engine = def.engine
     this.def = def


### PR DESCRIPTION
https://dev.azure.com/defragovuk/DEFRA-CDP/_workitems/edit/545603

For V2 forms, if the page title is empty, it defaults to the title of the first form component