### PR TITLE
Feature: support for 'v2' conditions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.462",
+        "@defra/forms-model": "^3.0.471",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/boom": "^10.0.1",
@@ -2039,14 +2039,14 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.462",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.462.tgz",
-      "integrity": "sha512-tShsARqKAj8sinEK7e951q83gPqxFpkD2YnO87CdwFeGheqWGc4rntYSuJ0p+IIty85CAeBDsHgIVVQrFa51Vw==",
+      "version": "3.0.471",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.471.tgz",
+      "integrity": "sha512-VoqAbzoyQA4jRo4E5rX81Hz1a/R1xgLyms4vKnS8m9Ug1PpaNj9owkmljxoodzRgOxUxxpIgj0OVGiel74NRXQ==",
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "marked": "^15.0.11",
+        "marked": "^15.0.12",
         "nanoid": "^5.0.7",
-        "slug": "^10.0.0",
+        "slug": "^11.0.0",
         "uuid": "^11.1.0"
       },
       "engines": {
@@ -14992,9 +14992,10 @@
       }
     },
     "node_modules/slug": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/slug/-/slug-10.0.0.tgz",
-      "integrity": "sha512-M8s2PWOUeSCdD4S1NH5lCzXg2zFV1fozrtfr0FSKl65x+EF1rUowj+/vyFlnHgxPxWzT+DL0VXKfYc1DHJoymg==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/slug/-/slug-11.0.0.tgz",
+      "integrity": "sha512-71pb27F9TII2dIweGr2ybS220IUZo1A9GKZ+e2q8rpUr24mejBb6fTaSStM0SE1ITUUOshilqZze8Yt1BKj+ew==",
+      "license": "MIT",
       "bin": {
         "slug": "cli.js"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.441",
+        "@defra/forms-model": "^3.0.462",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/boom": "^10.0.1",
@@ -2039,12 +2039,12 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.441",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.441.tgz",
-      "integrity": "sha512-j3PvXk4Ms/aiONJd/MA52sLnprMDNtRiJEXu0o6RipkX5EUBd8wh/MCemnisWbL2QTUwTWeroMAbhBJB1SD/Dw==",
+      "version": "3.0.462",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.462.tgz",
+      "integrity": "sha512-tShsARqKAj8sinEK7e951q83gPqxFpkD2YnO87CdwFeGheqWGc4rntYSuJ0p+IIty85CAeBDsHgIVVQrFa51Vw==",
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "marked": "^15.0.7",
+        "marked": "^15.0.11",
         "nanoid": "^5.0.7",
         "slug": "^10.0.0",
         "uuid": "^11.1.0"
@@ -12077,9 +12077,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.8.tgz",
-      "integrity": "sha512-rli4l2LyZqpQuRve5C0rkn6pj3hT8EWPC+zkAxFTAJLxRbENfTAhEQq9itrmf1Y81QtAX5D/MYlGlIomNgj9lA==",
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.471",
+        "@defra/forms-model": "^3.0.472",
         "@defra/hapi-tracing": "^1.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/boom": "^10.0.1",
@@ -2039,9 +2039,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.471",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.471.tgz",
-      "integrity": "sha512-VoqAbzoyQA4jRo4E5rX81Hz1a/R1xgLyms4vKnS8m9Ug1PpaNj9owkmljxoodzRgOxUxxpIgj0OVGiel74NRXQ==",
+      "version": "3.0.472",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.472.tgz",
+      "integrity": "sha512-kBsDPXSLcSEeZyZePdk8435tFeTSCNB1ASosxvntbHmsF3TkLjVAKUouPWbpUQ8BHap1rwbFFHNKA8QsiJPJWA==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "marked": "^15.0.12",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@defra/forms-model": "^3.0.441",
+    "@defra/forms-model": "^3.0.462",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@defra/forms-model": "^3.0.471",
+    "@defra/forms-model": "^3.0.472",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
-    "@defra/forms-model": "^3.0.462",
+    "@defra/forms-model": "^3.0.471",
     "@defra/hapi-tracing": "^1.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/boom": "^10.0.1",

--- a/src/server/plugins/engine/models/FormModel.test.ts
+++ b/src/server/plugins/engine/models/FormModel.test.ts
@@ -1,4 +1,8 @@
-import { formDefinitionV2Schema, type FormDefinition } from '@defra/forms-model'
+import {
+  SchemaVersion,
+  formDefinitionV2Schema,
+  type FormDefinition
+} from '@defra/forms-model'
 
 import { FormModel } from '~/src/server/plugins/engine/models/FormModel.js'
 import { type FormContextRequest } from '~/src/server/plugins/engine/types.js'
@@ -105,6 +109,22 @@ describe('FormModel', () => {
       expect(() => new FormModel(definitionV2, { basePath: 'test' })).toThrow(
         'Validation error'
       )
+    })
+
+    it('assigns v1 to the schema if not defined', () => {
+      const definitionWithoutSchema: FormDefinition = {
+        ...definition,
+        schema: undefined
+      }
+
+      // Mock validation to just return the definition
+      formDefinitionV2Schema.validate = jest
+        .fn()
+        .mockReturnValue({ value: definitionWithoutSchema })
+
+      const model = new FormModel(definitionWithoutSchema, { basePath: 'test' })
+
+      expect(model.schemaVersion).toBe(SchemaVersion.V1)
     })
   })
 

--- a/src/server/plugins/engine/models/FormModel.test.ts
+++ b/src/server/plugins/engine/models/FormModel.test.ts
@@ -103,9 +103,10 @@ describe('FormModel', () => {
     it('throws an error if schema validation fails', () => {
       jest.mock('@defra/forms-model')
 
-      formDefinitionV2Schema.validate = jest.fn().mockImplementation(() => {
-        throw new Error('Validation error')
+      formDefinitionV2Schema.validate = jest.fn().mockReturnValueOnce({
+        error: 'Validation error'
       })
+
       expect(() => new FormModel(definitionV2, { basePath: 'test' })).toThrow(
         'Validation error'
       )

--- a/src/server/plugins/engine/models/FormModel.test.ts
+++ b/src/server/plugins/engine/models/FormModel.test.ts
@@ -95,6 +95,17 @@ describe('FormModel', () => {
       )
       expect(model.listDefIdMap.size).toBe(1)
     })
+
+    it('throws an error if schema validation fails', () => {
+      jest.mock('@defra/forms-model')
+
+      formDefinitionV2Schema.validate = jest.fn().mockImplementation(() => {
+        throw new Error('Validation error')
+      })
+      expect(() => new FormModel(definitionV2, { basePath: 'test' })).toThrow(
+        'Validation error'
+      )
+    })
   })
 
   describe('getFormContext', () => {

--- a/src/server/plugins/engine/models/FormModel.test.ts
+++ b/src/server/plugins/engine/models/FormModel.test.ts
@@ -17,7 +17,7 @@ describe('FormModel', () => {
   })
 
   describe('Constructor', () => {
-    it("doesn't throw when conditions are passed with apostrophes", () => {
+    it('loads a valid form definition', () => {
       expect(
         () => new FormModel(definition, { basePath: 'test' })
       ).not.toThrow()
@@ -37,7 +37,7 @@ describe('FormModel', () => {
       expect(model.def.pages.at(1)?.title).toBe('Date of marriage')
     })
 
-    it('Builds a map of lists from the definition and only indexes those with IDs', () => {
+    it('Gets a list by ID', () => {
       jest.mock('@defra/forms-model')
 
       const definitionWithLists: FormDefinition = {
@@ -79,13 +79,13 @@ describe('FormModel', () => {
 
       const model = new FormModel(definitionWithLists, { basePath: 'test' })
 
-      expect(Array.from(model.listDefIdMap.keys())).toContain(
-        'c5eba145-b04d-4d41-a50c-e5e2f9b6357f'
-      )
+      expect(
+        model.getListById('c5eba145-b04d-4d41-a50c-e5e2f9b6357f')
+      ).toBeDefined()
       expect(model.listDefIdMap.size).toBe(2) // 1 + the yes/no list. list 'bar' isn't present as there's no ID
     })
 
-    it('Builds a map of components from the definition and only indexes those with IDs', () => {
+    it('Gets a component by ID', () => {
       jest.mock('@defra/forms-model')
 
       formDefinitionV2Schema.validate = jest
@@ -94,10 +94,22 @@ describe('FormModel', () => {
 
       const model = new FormModel(definitionV2, { basePath: 'test' })
 
-      expect(Array.from(model.componentDefIdMap.keys())).toContain(
-        '717eb213-4e4b-4a2d-9cfd-2780f5e1e3e5'
-      )
+      expect(
+        model.getComponentById('717eb213-4e4b-4a2d-9cfd-2780f5e1e3e5')
+      ).toBeDefined()
       expect(model.listDefIdMap.size).toBe(1)
+    })
+
+    it('gets a condition by its ID', () => {
+      jest.mock('@defra/forms-model')
+      formDefinitionV2Schema.validate = jest
+        .fn()
+        .mockReturnValue({ value: definitionV2 })
+      const model = new FormModel(definitionV2, { basePath: 'test' })
+
+      expect(
+        model.getConditionById('6c9e2f4a-1d7b-5e8c-3f6a-9e2d5b7c4f1a')
+      ).toBeDefined()
     })
 
     it('throws an error if schema validation fails', () => {

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -145,13 +145,9 @@ export class FormModel {
     this.listDefMap = new Map(def.lists.map((list) => [list.name, list]))
     this.listDefIdMap = new Map(
       def.lists
-        .filter((component) => component.id) // Skip components without an ID
-        .map((list) => {
-          if (!list.id) {
-            throw Error('List ID is required') // this shouldn't happen with the above filter
-          }
-          return [list.id, list]
-        })
+        .filter((list) => list.id) // Skip lists without an ID
+        // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
+        .map((list) => [list.id as string, list])
     )
     this.componentDefMap = new Map(
       def.pages
@@ -165,10 +161,8 @@ export class FormModel {
         page.components
           .filter((component) => component.id) // Skip components without an ID
           .map((component) => {
-            if (!component.id) {
-              throw Error('Component ID is required') // this shouldn't happen with the above filter
-            }
-            return [component.id, component]
+            // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
+            return [component.id as string, component]
           })
       )
     )

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -206,13 +206,6 @@ export class FormModel {
   }
 
   /**
-   * build the entire model schema from individual pages/sections
-   */
-  makeSchema() {
-    return this.makeFilteredSchema(this.pages)
-  }
-
-  /**
    * build the entire model schema from individual pages/sections and filter out answers
    * for pages which are no longer accessible due to an answer that has been changed
    */

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -4,6 +4,7 @@ import {
   ControllerPath,
   ControllerType,
   Engine,
+  SchemaVersion,
   convertConditionWrapperFromV2,
   formDefinitionSchema,
   formDefinitionV2Schema,
@@ -57,6 +58,8 @@ export class FormModel {
   /** The runtime engine that should be used */
   engine?: Engine
 
+  schemaVersion: SchemaVersion
+
   /** the entire form JSON as an object */
   def: FormDefinition
 
@@ -89,7 +92,7 @@ export class FormModel {
   ) {
     let schema = formDefinitionSchema
 
-    if (def.engine === Engine.V2) {
+    if (def.schema === SchemaVersion.V2) {
       schema = formDefinitionV2Schema
     }
 
@@ -127,6 +130,7 @@ export class FormModel {
     setPageTitles(def)
 
     this.engine = def.engine
+    this.schemaVersion = def.schema ?? SchemaVersion.V1
     this.def = def
     this.lists = def.lists
     this.sections = def.sections
@@ -503,7 +507,7 @@ export class FormModel {
   /**
    * Returns a condition by its ID. O(n) lookup time.
    * @param conditionId
-   * @returns ConditionWrapperV2
+   * @returns
    */
   getConditionById(conditionId: string): ConditionWrapperV2 | undefined {
     return this.def.conditions

--- a/src/server/plugins/engine/models/FormModel.ts
+++ b/src/server/plugins/engine/models/FormModel.ts
@@ -12,12 +12,12 @@ import {
   isConditionWrapperV2,
   type ComponentDef,
   type ConditionWrapper,
+  type ConditionWrapperV2,
   type ConditionsModelData,
   type DateUnits,
   type FormDefinition,
   type List,
-  type Page,
-  type RuntimeFormModel
+  type Page
 } from '@defra/forms-model'
 import { add } from 'date-fns'
 import { Parser, type Value } from 'expr-eval'
@@ -77,6 +77,7 @@ export class FormModel {
 
   componentDefMap: Map<string, ComponentDef>
   componentDefIdMap: Map<string, ComponentDef>
+
   pageMap: Map<string, PageControllerClass>
   componentMap: Map<string, Component>
 
@@ -168,20 +169,10 @@ export class FormModel {
       )
     )
 
-    const accessors: RuntimeFormModel = {
-      getListById: (listId: string) => this.getListById(listId),
-      getComponentById: (componentId: string) =>
-        this.getComponentById(componentId),
-      getConditionById: (conditionId: string) =>
-        def.conditions
-          .filter(isConditionWrapperV2)
-          .find((condition) => condition.id === conditionId)
-    }
-
     def.conditions.forEach((conditionDef) => {
       const condition = this.makeCondition(
         isConditionWrapperV2(conditionDef)
-          ? convertConditionWrapperFromV2(conditionDef, accessors)
+          ? convertConditionWrapperFromV2(conditionDef, this)
           : conditionDef
       )
       this.conditions[condition.name] = condition
@@ -507,6 +498,17 @@ export class FormModel {
 
   getListById(listId: string): List | undefined {
     return this.listDefIdMap.get(listId)
+  }
+
+  /**
+   * Returns a condition by its ID. O(n) lookup time.
+   * @param conditionId
+   * @returns ConditionWrapperV2
+   */
+  getConditionById(conditionId: string): ConditionWrapperV2 | undefined {
+    return this.def.conditions
+      .filter(isConditionWrapperV2)
+      .find((condition) => condition.id === conditionId)
   }
 }
 

--- a/test/form/definitions/conditions-basic.js
+++ b/test/form/definitions/conditions-basic.js
@@ -162,7 +162,7 @@ export const V2 = /** @satisfies {FormDefinition} */ ({
     {
       id: '6c9e2f4a-1d7b-5e8c-3f6a-9e2d5b7c4f1a',
       displayName: 'Not previously married',
-      conditions: [
+      items: [
         {
           id: '4f7e1a9c-2b5d-8e3f-6c1a-7f9e2d4b5c8a',
           componentId: '717eb213-4e4b-4a2d-9cfd-2780f5e1e3e5',

--- a/test/form/definitions/conditions-basic.js
+++ b/test/form/definitions/conditions-basic.js
@@ -4,7 +4,8 @@ import {
   ControllerPath,
   ControllerType,
   Engine,
-  OperatorName
+  OperatorName,
+  SchemaVersion
 } from '@defra/forms-model'
 
 export default /** @satisfies {FormDefinition} */ ({
@@ -97,6 +98,7 @@ export default /** @satisfies {FormDefinition} */ ({
 
 export const V2 = /** @satisfies {FormDefinition} */ ({
   name: 'Conditions V2',
+  schema: SchemaVersion.V2,
   engine: Engine.V2,
   startPage: '/first-page',
   pages: /** @type {const} */ ([
@@ -105,6 +107,7 @@ export const V2 = /** @satisfies {FormDefinition} */ ({
       path: '/first-page',
       components: [
         {
+          id: '717eb213-4e4b-4a2d-9cfd-2780f5e1e3e5',
           name: 'yesNoField',
           title: 'Have you previously been married?',
           type: ComponentType.YesNoField,
@@ -138,7 +141,7 @@ export const V2 = /** @satisfies {FormDefinition} */ ({
           schema: {}
         }
       ],
-      condition: 'isNotPreviouslyMarried',
+      condition: '6c9e2f4a-1d7b-5e8c-3f6a-9e2d5b7c4f1a',
       section: 'marriage',
       next: []
     },
@@ -157,26 +160,19 @@ export const V2 = /** @satisfies {FormDefinition} */ ({
   ],
   conditions: [
     {
+      id: '6c9e2f4a-1d7b-5e8c-3f6a-9e2d5b7c4f1a',
       displayName: 'Not previously married',
-      name: 'isNotPreviouslyMarried',
-      value: {
-        name: 'Not previously married',
-        conditions: [
-          {
-            field: {
-              name: 'yesNoField',
-              display: 'Have you previously been married?',
-              type: ComponentType.YesNoField
-            },
-            operator: OperatorName.Is,
-            value: {
-              type: ConditionType.Value,
-              value: 'false',
-              display: 'No'
-            }
+      conditions: [
+        {
+          id: '4f7e1a9c-2b5d-8e3f-6c1a-7f9e2d4b5c8a',
+          componentId: '717eb213-4e4b-4a2d-9cfd-2780f5e1e3e5',
+          operator: OperatorName.Is,
+          value: {
+            type: ConditionType.StringValue,
+            value: 'false'
           }
-        ]
-      }
+        }
+      ]
     }
   ],
   outputEmail: 'enrique.chase@defra.gov.uk'


### PR DESCRIPTION
Schema v1 forms support the legacy condition format
Schema v2 forms support the new condition format

If a v2 schema is loaded, this works by translating v2 conditions down to v1, so runner works on a common format and we don't need to introduce extra branches. 

In the future we will reverse this format, so the code targets v2 and v1 will be "upgraded" to v2. We'll do this once conditions are stable.