### PR TITLE
Conditional GA text depending on config

### DIFF
--- a/src/server/routes/index.test.ts
+++ b/src/server/routes/index.test.ts
@@ -21,8 +21,9 @@ describe('Routes', () => {
     await server.stop()
   })
 
-  test('cookies page is served with 24 hour duration', async () => {
+  test('cookies page is served with 24 hour duration and GA info', async () => {
     config.set('sessionTimeout', 86400000)
+    config.set('googleAnalyticsContainerId', '12345')
 
     const options = {
       method: 'GET',
@@ -44,10 +45,49 @@ describe('Routes', () => {
       name: 'session Remembers the information you enter When you close the browser, or after 1 day'
     })
 
+    const $cookieConsentRow = container.getByRole('row', {
+      name: 'cookieConsent Remembers your cookie preferences 1 year'
+    })
+
     expect($heading).toBeInTheDocument()
     expect($heading).toHaveClass('govuk-heading-l')
     expect($googleAnalyticsRowheader).toBeInTheDocument()
     expect($sessionDurationRow).toBeInTheDocument()
+    expect($cookieConsentRow).toBeInTheDocument()
+  })
+
+  test('cookies page is served without GA info', async () => {
+    config.set('sessionTimeout', 86400000)
+    config.reset('googleAnalyticsTrackingId')
+
+    const options = {
+      method: 'GET',
+      url: '/help/cookies/slug'
+    }
+
+    const { container } = await renderResponse(server, options)
+
+    const $heading = container.getByRole('heading', {
+      name: 'Cookies',
+      level: 1
+    })
+    const $googleAnalyticsRowheader = container.queryByRole('rowheader', {
+      name: '_ga_123456789'
+    })
+
+    const $sessionDurationRow = container.getByRole('row', {
+      name: 'session Remembers the information you enter When you close the browser, or after 1 day'
+    })
+
+    const $cookieConsentRow = container.queryByRole('row', {
+      name: 'cookieConsent Remembers your cookie preferences 1 year'
+    })
+
+    expect($heading).toBeInTheDocument()
+    expect($heading).toHaveClass('govuk-heading-l')
+    expect($googleAnalyticsRowheader).not.toBeInTheDocument()
+    expect($sessionDurationRow).toBeInTheDocument()
+    expect($cookieConsentRow).not.toBeInTheDocument()
   })
 
   test('accessibility statement page is served', async () => {

--- a/src/server/views/help/cookies.html
+++ b/src/server/views/help/cookies.html
@@ -13,6 +13,26 @@
 
     <h2 class="govuk-heading-m">Essential cookies</h2>
     <p class="govuk-body">Essential cookies keep your information secure. We do not need to ask your permission to use them.</p>
+    {% set essentialTableRows = [
+      [
+        { text: "session" },
+        { text: "Remembers the information you enter" },
+        { text: "When you close the browser, or after " + sessionDurationPretty }
+      ],
+      [
+        { text: "crumb" },
+        { text: "Ensures forms can only be submitted from this website" },
+        { text: "When you close the browser" }
+      ]
+    ] %}
+    {% if googleAnalyticsContainerId %}
+    {% set essentialTableRows = (essentialTableRows.unshift([
+          { text: "cookieConsent" },
+          { text: "Remembers your cookie preferences" },
+          { text: "1 year" }
+        ]), essentialTableRows)
+    %}
+    {% endif %}
     {{ govukTable({
       firstCellIsHeader: true,
       caption: "Essential cookies we use",
@@ -21,51 +41,37 @@
         { text: "Purpose" },
         { text: "Expires" }
       ],
-      rows: [
-        [
-          { text: "cookieConsent" },
-          { text: "Remembers your cookie preferences" },
-          { text: "1 year" }
-        ],
-        [
-          { text: "session" },
-          { text: "Remembers the information you enter" },
-          { text: "When you close the browser, or after " + sessionDurationPretty }
-        ],
-        [
-          { text: "crumb" },
-          { text: "Ensures forms can only be submitted from this website" },
-          { text: "When you close the browser" }
-        ]
-      ]
+      rows: essentialTableRows
     }) }}
 
-    <h2 class="govuk-heading-m">Analytics cookies</h2>
-    <p class="govuk-body">We use Google Analytics software to understand how people use our forms. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.</p>
-    {{ govukTable({
-      firstCellIsHeader: true,
-      caption: "Analytics cookies we use",
-      head: [
-        { text: "Name" },
-        { text: "Purpose" },
-        { text: "Expires" }
-      ],
-      rows: [
-        [
-          { text: "_ga" },
-          { text: "Used by Google Analytics to help us count how many people visit our forms by tracking if you’ve visited before" },
-          { text: "2 years" }
+    {% if googleAnalyticsContainerId %}
+      <h2 class="govuk-heading-m">Analytics cookies</h2>
+      <p class="govuk-body">We use Google Analytics software to understand how people use our forms. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.</p>
+      {{ govukTable({
+        firstCellIsHeader: true,
+        caption: "Analytics cookies we use",
+        head: [
+          { text: "Name" },
+          { text: "Purpose" },
+          { text: "Expires" }
         ],
-        [
-          { text: "_ga_" + googleAnalyticsContainerId },
-          { text: "Used by Google Analytics to find and track an individual session with your device" },
-          { text: "2 years" }
+        rows: [
+          [
+            { text: "_ga" },
+            { text: "Used by Google Analytics to help us count how many people visit our forms by tracking if you’ve visited before" },
+            { text: "2 years" }
+          ],
+          [
+            { text: "_ga_" + googleAnalyticsContainerId },
+            { text: "Used by Google Analytics to find and track an individual session with your device" },
+            { text: "2 years" }
+          ]
         ]
-      ]
-    }) }}
+      }) }}
 
-    <h2 class="govuk-heading-m">Change your settings</h2>
-    <p class="govuk-body">You can <a class="govuk-link" href="/help/cookie-preferences/{{ slug }}">change which cookies you’re happy for us to use</a>.</p>
+      <h2 class="govuk-heading-m">Change your settings</h2>
+      <p class="govuk-body">You can <a class="govuk-link" href="/help/cookie-preferences/{{ slug }}">change which cookies you’re happy for us to use</a>.</p>
+    {% endif %}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
If GA tracking id is not set, the relevant extra GA text is hidden in the cookies page