### PR TITLE
Remove subject from SNS submission message

### DIFF
--- a/src/server/messaging/formAdapterEventPublisher.test.js
+++ b/src/server/messaging/formAdapterEventPublisher.test.js
@@ -75,8 +75,7 @@ describe('formAdapterEventPublisher', () => {
       expect(getSNSClient).toHaveBeenCalled()
       expect(PublishCommand).toHaveBeenCalledWith({
         TopicArn: 'arn:aws:sns:eu-west-2:123456789012:test-adapter-topic',
-        Message: JSON.stringify(mockPayload),
-        Subject: 'Form submission: Test Form'
+        Message: JSON.stringify(mockPayload)
       })
       expect(mockSnsClient.send).toHaveBeenCalledWith(
         expect.any(PublishCommand)
@@ -104,27 +103,6 @@ describe('formAdapterEventPublisher', () => {
 
       expect(getSNSClient).toHaveBeenCalled()
       expect(mockSnsClient.send).toHaveBeenCalled()
-    })
-
-    it('uses correct subject format with form name', async () => {
-      mockSnsClient.send.mockResolvedValue({ MessageId: 'msg-456' })
-
-      const customPayload =
-        /** @type {FormAdapterSubmissionMessagePayload} */ ({
-          ...mockPayload,
-          meta: {
-            ...mockPayload.meta,
-            formName: 'Special & Characters Form!'
-          }
-        })
-
-      await publishFormAdapterEvent(customPayload)
-
-      expect(PublishCommand).toHaveBeenCalledWith(
-        expect.objectContaining({
-          Subject: 'Form submission: Special & Characters Form!'
-        })
-      )
     })
 
     it('serializes entire payload as JSON message', async () => {

--- a/src/server/messaging/formAdapterEventPublisher.ts
+++ b/src/server/messaging/formAdapterEventPublisher.ts
@@ -60,8 +60,7 @@ export async function publishFormAdapterEvent(
   const result = await snsClient.send(
     new PublishCommand({
       TopicArn: snsAdapterTopicArn,
-      Message: JSON.stringify(validatedPayload),
-      Subject: `Form submission: ${validatedPayload.meta.formName}`
+      Message: JSON.stringify(validatedPayload)
     })
   )
 


### PR DESCRIPTION
Removes the `Subject` field from the SNS message as it is not required.
It is [limited to 100 chars](https://docs.aws.amazon.com/sns/latest/api/API_Publish.html#API_Publish_RequestParameters) and throws if the string exceeds that.