### PR TITLE
DF-927: Tighten CSP and use nonce-aware GTM

### DIFF
--- a/src/server/plugins/blankie.test.ts
+++ b/src/server/plugins/blankie.test.ts
@@ -9,13 +9,17 @@ describe('Server Blankie Plugin', () => {
 
     expect(options).toEqual({
       defaultSrc: ['self'],
+      baseUri: ['none'],
       fontSrc: ['self', 'data:'],
-      frameSrc: ['self', 'data:'],
+      frameSrc: ['none'],
       connectSrc: ['self', 'https://test-uploader.cdp-int.defra.cloud'],
-      scriptSrc: ['self', 'strict-dynamic', 'unsafe-inline'],
+      scriptSrc: ['strict-dynamic'],
       styleSrc: ['self', 'unsafe-inline'],
       imgSrc: ['self', 'data:'],
-      workerSrc: ['self', 'blob:'],
+      workerSrc: ['blob:'],
+      formAction: ['self'],
+      frameAncestors: ['none'],
+      objectSrc: ['none'],
       generateNonces: 'script'
     })
   })
@@ -27,29 +31,29 @@ describe('Server Blankie Plugin', () => {
 
     expect(options).toEqual({
       defaultSrc: ['self'],
+      baseUri: ['none'],
       fontSrc: ['self', 'data:'],
-      frameSrc: ['self', 'data:', 'https://www.googletagmanager.com'],
+      frameSrc: ['https://www.googletagmanager.com'],
       connectSrc: [
         'self',
-        'https://*.google-analytics.com',
-        'https://*.analytics.google.com',
-        'https://*.googletagmanager.com',
+        'https://www.google-analytics.com',
+        'https://analytics.google.com',
+        'https://www.googletagmanager.com',
+        'https://region1.google-analytics.com',
         'https://test-uploader.cdp-int.defra.cloud'
       ],
-      scriptSrc: [
-        'self',
-        'strict-dynamic',
-        'unsafe-inline',
-        'https://*.googletagmanager.com'
-      ],
+      scriptSrc: ['strict-dynamic'],
       styleSrc: ['self', 'unsafe-inline'],
       imgSrc: [
         'self',
         'data:',
-        'https://*.google-analytics.com',
-        'https://*.googletagmanager.com'
+        'https://www.google-analytics.com',
+        'https://www.googletagmanager.com'
       ],
-      workerSrc: ['self', 'blob:'],
+      workerSrc: ['blob:'],
+      formAction: ['self'],
+      frameAncestors: ['none'],
+      objectSrc: ['none'],
       generateNonces: 'script'
     })
   })

--- a/src/server/plugins/blankie.ts
+++ b/src/server/plugins/blankie.ts
@@ -4,12 +4,15 @@ import Blankie from 'blankie'
 import { config } from '~/src/config/index.js'
 
 const googleAnalyticsOptions = {
-  scriptSrc: ['https://*.googletagmanager.com'],
-  imgSrc: ['https://*.google-analytics.com', 'https://*.googletagmanager.com'],
+  imgSrc: [
+    'https://www.google-analytics.com',
+    'https://www.googletagmanager.com'
+  ],
   connectSrc: [
-    'https://*.google-analytics.com',
-    'https://*.analytics.google.com',
-    'https://*.googletagmanager.com'
+    'https://www.google-analytics.com',
+    'https://analytics.google.com',
+    'https://www.googletagmanager.com',
+    'https://region1.google-analytics.com'
   ],
   frameSrc: ['https://www.googletagmanager.com']
 }
@@ -20,33 +23,28 @@ export const configureBlankiePlugin = (): ServerRegisterPluginObject<
   const gtmContainerId = config.get('googleTagManagerContainerId')
   const uploaderUrl = config.get('uploaderUrl')
 
-  /*
-  Note that unsafe-inline is a fallback for old browsers that don't support nonces. It will be ignored by modern browsers as the nonce is provided.
-  */
   return {
     plugin: Blankie,
     options: {
       defaultSrc: ['self'],
+      baseUri: ['none'],
       fontSrc: ['self', 'data:'],
       connectSrc: [
         ['self'],
         gtmContainerId ? googleAnalyticsOptions.connectSrc : [],
         uploaderUrl ? [uploaderUrl] : []
       ].flat(),
-      scriptSrc: [
-        ['self', 'strict-dynamic', 'unsafe-inline'],
-        gtmContainerId ? googleAnalyticsOptions.scriptSrc : []
-      ].flat(),
+      scriptSrc: ['strict-dynamic'],
       styleSrc: ['self', 'unsafe-inline'],
       imgSrc: [
         ['self', 'data:'],
         gtmContainerId ? googleAnalyticsOptions.imgSrc : []
       ].flat(),
-      frameSrc: [
-        ['self', 'data:'],
-        gtmContainerId ? googleAnalyticsOptions.frameSrc : []
-      ].flat(),
-      workerSrc: ['self', 'blob:'],
+      frameSrc: gtmContainerId ? googleAnalyticsOptions.frameSrc : ['none'],
+      workerSrc: ['blob:'],
+      formAction: ['self'],
+      frameAncestors: ['none'],
+      objectSrc: ['none'],
       generateNonces: 'script'
     }
   }

--- a/src/server/views/layout.html
+++ b/src/server/views/layout.html
@@ -191,9 +191,11 @@
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
+      n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','{{ config.googleTagManagerContainerId }}');
     </script>
+    <!-- End Google Tag Manager -->
     <noscript id="gtm-noscript"><iframe title="Google Analytics tracking" src="https://www.googletagmanager.com/ns.html?id={{ config.googleTagManagerContainerId }}"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager -->


### PR DESCRIPTION
- Updated the GTM init snippet to propagate the CSP nonce
- Hardened `scriptSrc`. Scripts are now trusted by nonce only, with `'strict-dynamic'` for GA and interactive-map.
- Replaced wildcard GA/GTM origins with explicit hosts
- Tightened `frameSrc`. Only allowed when GTM is configured, else none.
- Tightened `workerSrc`, retaining `blob:` for MapLibre
- Added missing directives for `baseUri`, `formAction`, `frameAncestors`, `objectSrc`