### PR TITLE
chore(deps): bump @defra/forms-engine-plugin to ^4.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-sns": "^3.997.0",
-        "@defra/forms-engine-plugin": "^4.11.1",
+        "@defra/forms-engine-plugin": "^4.11.3",
         "@defra/forms-model": "^3.0.655",
         "@defra/hapi-tracing": "^1.30.0",
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -4043,9 +4043,9 @@
       }
     },
     "node_modules/@defra/forms-engine-plugin": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-4.11.1.tgz",
-      "integrity": "sha512-09QBk2gu2EvvJj/wW66TfvLm1I6dG+6wjDto4NiQg3TLH71ce+CnoCtAQQGrfa7zChXYtvxLav0eJD+CXOl31w==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-4.11.3.tgz",
+      "integrity": "sha512-+ywwUqRHH9iRHKbU4BFzLyFMakVs7/0e5tlu+vBSWtflO/EWTefHD4nAfkoEDgU2/y4fWBX4+Dub/rx7iHE9AA==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@aws-sdk/client-sns": "^3.997.0",
-    "@defra/forms-engine-plugin": "^4.11.1",
+    "@defra/forms-engine-plugin": "^4.11.3",
     "@defra/forms-model": "^3.0.655",
     "@defra/hapi-tracing": "^1.30.0",
     "@elastic/ecs-pino-format": "^1.5.0",


### PR DESCRIPTION
Picks up DF-952 map guidance copy update from the engine plugin.