### PR TITLE
fix/df-1063: Use exact plugin version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-sns": "^3.1079.0",
-        "@defra/forms-engine-plugin": "^5.0.0-alpha.7",
+        "@defra/forms-engine-plugin": "5.0.0-alpha.7",
         "@defra/forms-model": "^3.0.686",
         "@defra/hapi-tracing": "^1.30.0",
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -2490,13 +2490,13 @@
       }
     },
     "node_modules/@defra/forms-engine-plugin": {
-      "version": "5.0.0-alpha4",
-      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-5.0.0-alpha4.tgz",
-      "integrity": "sha512-scTXQn2R6OHDqu3lnPQq0jOw0EUMSX1El0A71R+yovUzP6X89v29/00GXmnY8TZIGQKwRFZnvm/8ZhPHEj1m1g==",
+      "version": "5.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-5.0.0-alpha.7.tgz",
+      "integrity": "sha512-f78C2Dx7AdHLoFbolTNykXYgboPlKZnR6F1QnY+Jpw0UWipzV/yI5xCjpNajss8y43N3nO+vW89WpM984jxgYw==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.687",
+        "@defra/forms-model": "^3.0.689",
         "@defra/hapi-tracing": "^1.29.0",
         "@defra/interactive-map": "^0.0.33-alpha",
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -2609,9 +2609,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.688",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.688.tgz",
-      "integrity": "sha512-g5NyU/aqfAz9WqydiAV1bvMR++CU4GbdtPOc1HoNuuv/tkpKxMhjr8idjpKDZwzr0migzgm73ARPb99EQ4jORg==",
+      "version": "3.0.690",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.690.tgz",
+      "integrity": "sha512-bZSW4zBQIq/KORPcsRbranZc581jQHJeWr+rXJX0cAIRcaRNrIsFdYh6HCENhwdgDvH9oZkEJEbkzWXUc/w98w==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@aws-sdk/client-sns": "^3.1079.0",
-    "@defra/forms-engine-plugin": "^5.0.0-alpha.7",
+    "@defra/forms-engine-plugin": "5.0.0-alpha.7",
     "@defra/forms-model": "^3.0.686",
     "@defra/hapi-tracing": "^1.30.0",
     "@elastic/ecs-pino-format": "^1.5.0",


### PR DESCRIPTION
Use exact plugin version (5.0.0-alpha.7) as opposed to using the carot (^) notation.
This is because I mistakenly created a version 5.0.0-alpha4 (without the dot), and the versioning thinks this is a higher version than 5.0.0-alpha.7