### PR TITLE
DF-1219 Bump engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-sns": "^3.1079.0",
-        "@defra/forms-engine-plugin": "5.0.0-alpha.7",
+        "@defra/forms-engine-plugin": "5.0.0-alpha.8",
         "@defra/forms-model": "^3.0.686",
         "@defra/hapi-tracing": "^1.30.0",
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -2490,9 +2490,9 @@
       }
     },
     "node_modules/@defra/forms-engine-plugin": {
-      "version": "5.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-5.0.0-alpha.7.tgz",
-      "integrity": "sha512-f78C2Dx7AdHLoFbolTNykXYgboPlKZnR6F1QnY+Jpw0UWipzV/yI5xCjpNajss8y43N3nO+vW89WpM984jxgYw==",
+      "version": "5.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-5.0.0-alpha.8.tgz",
+      "integrity": "sha512-ypIgGpmiVjpHWDfecrMoD8YLOrfeBCMdqplAMtYJlEBIzDLxvZx0kjld+munhcydlU1enQ6Hilt2ycPKe4B+lQ==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
@@ -11706,9 +11706,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@aws-sdk/client-sns": "^3.1079.0",
-    "@defra/forms-engine-plugin": "5.0.0-alpha.7",
+    "@defra/forms-engine-plugin": "5.0.0-alpha.8",
     "@defra/forms-model": "^3.0.686",
     "@defra/hapi-tracing": "^1.30.0",
     "@elastic/ecs-pino-format": "^1.5.0",

--- a/src/client/javascripts/maps.js
+++ b/src/client/javascripts/maps.js
@@ -1,3 +1,3 @@
-import { initMaps } from '@defra/forms-engine-plugin/shared.js'
+import { initMaps } from '@defra/forms-engine-plugin/maps'
 
 initMaps()

--- a/test/client/javascripts/maps.test.js
+++ b/test/client/javascripts/maps.test.js
@@ -1,6 +1,6 @@
 const mockInitMaps = jest.fn()
 
-jest.mock('@defra/forms-engine-plugin/shared.js', () => ({
+jest.mock('@defra/forms-engine-plugin/maps', () => ({
   initMaps: mockInitMaps
 }))
 


### PR DESCRIPTION
Includes refactor to import maps from the new `forms-engine-plugin/maps` export (`forms-engine-plugin/shared.js` still does export maps but cleaner to import directly from `forms-engine-plugin/maps`)