### PR TITLE
feat/df-1069: Error pages can translate, and handles Feedback form in Welsh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-sns": "^3.1079.0",
-        "@defra/forms-engine-plugin": "5.0.0-alpha.9",
-        "@defra/forms-model": "^3.0.686",
+        "@defra/forms-engine-plugin": "5.0.0-alpha.10",
+        "@defra/forms-model": "^3.0.693",
         "@defra/hapi-tracing": "^1.30.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/boom": "^10.0.1",
@@ -2490,13 +2490,13 @@
       }
     },
     "node_modules/@defra/forms-engine-plugin": {
-      "version": "5.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-5.0.0-alpha.9.tgz",
-      "integrity": "sha512-XgnSTMVBH6BxRwncQzbiPfWt4qSf3AGZhuUBXKa6ucfODXDOooMGsvACCqBjiYZh29K50An9pQ85BaUi7hLa0A==",
+      "version": "5.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-5.0.0-alpha.10.tgz",
+      "integrity": "sha512-cXWu2jyl9FEcKkg4KhVh3EkqTEKgZpMlD9APHjWsbxwsQHDh+ytFNl5Wcp4IIiEKchOtBrPPp1X8jYfiCZDSmQ==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@defra/forms-model": "^3.0.689",
+        "@defra/forms-model": "^3.0.693",
         "@defra/hapi-tracing": "^1.29.0",
         "@defra/interactive-map": "^0.0.33-alpha",
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -2610,9 +2610,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.690",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.690.tgz",
-      "integrity": "sha512-bZSW4zBQIq/KORPcsRbranZc581jQHJeWr+rXJX0cAIRcaRNrIsFdYh6HCENhwdgDvH9oZkEJEbkzWXUc/w98w==",
+      "version": "3.0.693",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.693.tgz",
+      "integrity": "sha512-qD+w+vq47rzH3TdIRgxwckL4b6a5el098Dvrk7G8MN7fTLsnZZgbc5kLqed2ugIugPICBXUWopdfpjjjxUfGAA==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",
@@ -11707,9 +11707,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
-      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@aws-sdk/client-sns": "^3.1079.0",
-    "@defra/forms-engine-plugin": "5.0.0-alpha.9",
-    "@defra/forms-model": "^3.0.686",
+    "@defra/forms-engine-plugin": "5.0.0-alpha.10",
+    "@defra/forms-model": "^3.0.693",
     "@defra/hapi-tracing": "^1.30.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/boom": "^10.0.1",

--- a/src/server/plugins/FeedbackPageController.ts
+++ b/src/server/plugins/FeedbackPageController.ts
@@ -19,16 +19,18 @@ export class FeedbackPageController extends QuestionPageController {
     request: FormContextRequest,
     context: FormContext
   ): FeedbackPageViewModel {
+    const translator = this.getTranslator(request as unknown as AnyFormRequest)
     const viewModel = super.getViewModel(
       request,
       context,
-      this.getTranslator(request as unknown as AnyFormRequest)
+      translator
     ) as FeedbackPageViewModel
     return {
       ...viewModel,
       hidePhaseBanner: true,
-      submitButtonText: 'Send feedback',
-      name: context.state.formName as string | undefined
+      submitButtonText: translator.t('common.sendFeedback'),
+      name: context.state.formName as string | undefined,
+      t: translator.t
     }
   }
 

--- a/src/server/plugins/errorPages.ts
+++ b/src/server/plugins/errorPages.ts
@@ -5,6 +5,8 @@ import {
 } from '@hapi/hapi'
 import { StatusCodes } from 'http-status-codes'
 
+import { getAllLanguages, resolveLanguage } from '~/src/server/utils/utils.js'
+
 /*
  * Add an `onPreResponse` listener to return error pages
  */
@@ -26,12 +28,24 @@ export default {
           // happening inside a "form" level request, the header
           // then displays the contextual form text and href
           const model = request.app.model
-          const viewModel = model
+          const language = resolveLanguage(request.query, request.yar)
+          const languages = getAllLanguages()
+          const viewModelBase = model
             ? {
                 name: model.name,
                 serviceUrl: `/${model.basePath}`
               }
-            : undefined
+            : {}
+          const viewModel = {
+            ...viewModelBase,
+            languages,
+            language,
+            currentPath: request.path,
+            translator: {
+              language,
+              languages
+            }
+          }
 
           // In the event of 404
           // return the `404` view

--- a/src/server/plugins/nunjucks/environment.js
+++ b/src/server/plugins/nunjucks/environment.js
@@ -1,5 +1,6 @@
 import { dirname, join } from 'node:path'
 
+import { applyUrlParam } from '@defra/forms-engine-plugin'
 import { markdownToHtml } from '@defra/forms-model'
 import nunjucks from 'nunjucks'
 import resolvePkg from 'resolve'
@@ -31,6 +32,6 @@ environment.addFilter('evaluate', (value) => value)
 environment.addFilter('markdown', (value, startingHeaderLevel = 1) =>
   markdownToHtml(value, { startingHeaderLevel })
 )
-environment.addFilter('applyUrlParam', (value) => value)
+environment.addFilter('applyUrlParam', applyUrlParam)
 
 environment.addGlobal('govukRebrand', true)

--- a/src/server/utils/utils.js
+++ b/src/server/utils/utils.js
@@ -65,6 +65,8 @@ export function isLanguageSupported(language, definition) {
  * Primarily for pages that are not form-specific e.g. error pages
  */
 export function getAllLanguages() {
+  // Passing metadata that contains a Welsh translation construct will
+  // cause both English and Welsh to be returned
   return getAvailableLanguages(
     /** @type {FormDefinition} */ (
       /** @type {unknown} */

--- a/src/server/utils/utils.js
+++ b/src/server/utils/utils.js
@@ -1,3 +1,4 @@
+import { getAvailableLanguages } from '@defra/forms-engine-plugin'
 import { getTraceId } from '@defra/hapi-tracing'
 
 import { config } from '~/src/config/index.js'
@@ -50,13 +51,26 @@ export function resolveLanguage(query, yar) {
 }
 
 /**
- *
+ * Determine if the specified language has any translations available
  * @param {string} language
  * @param { FormDefinition | undefined } definition
  */
 export function isLanguageSupported(language, definition) {
   // @ts-expect-error - dynamic language lookup
   return definition?.metadata?.translations?.[language] !== undefined
+}
+
+/**
+ * Get a list of all languages supported by the system.
+ * Primarily for pages that are not form-specific e.g. error pages
+ */
+export function getAllLanguages() {
+  return getAvailableLanguages(
+    /** @type {FormDefinition} */ (
+      /** @type {unknown} */
+      ({ metadata: { translations: { cy: {} } } })
+    )
+  )
 }
 
 /**


### PR DESCRIPTION
Error pages can translate, and handles Feedback form in Welsh

Ticket [DF-1069](https://eaflood.atlassian.net/browse/DF-1069)

Requires merge of this plugin PR https://github.com/DEFRA/forms-engine-plugin/pull/452

[DF-1069]: https://eaflood.atlassian.net/browse/DF-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ