### PR TITLE
DF-1248: Add error details when previewing a form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@aws-sdk/client-sns": "^3.1079.0",
-        "@defra/forms-engine-plugin": "5.0.0-alpha.12",
-        "@defra/forms-model": "^3.0.693",
+        "@defra/forms-engine-plugin": "^5.0.0-alpha.13",
+        "@defra/forms-model": "^3.0.694",
         "@defra/hapi-tracing": "^1.30.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@hapi/boom": "^10.0.1",
@@ -27,6 +27,7 @@
         "@hapi/wreck": "^18.1.2",
         "@hapi/yar": "^11.0.3",
         "@types/humanize-duration": "^3.27.4",
+        "accessible-autocomplete": "^3.0.1",
         "babel-plugin-transform-import-meta": "^2.3.3",
         "blankie": "^5.0.0",
         "blipp": "^4.0.2",
@@ -2490,9 +2491,9 @@
       }
     },
     "node_modules/@defra/forms-engine-plugin": {
-      "version": "5.0.0-alpha.12",
-      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-5.0.0-alpha.12.tgz",
-      "integrity": "sha512-5ZWZ29QxY3/o09hhzlZ/M+sm6LM63prTcevRWX4OcHePVST+svgWcdtnlm6LkFjZ8e8eh2GCUGvq4Kg0p1anDg==",
+      "version": "5.0.0-alpha.13",
+      "resolved": "https://registry.npmjs.org/@defra/forms-engine-plugin/-/forms-engine-plugin-5.0.0-alpha.13.tgz",
+      "integrity": "sha512-zC3eQVPYYNP5hgaMEjx/zdsiiMbj4bajSPwyAAaP9GknXIbH/p8XYchcDV0tR2pOR6yUuC5X79uecCN6/EkN1g==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
@@ -2624,9 +2625,9 @@
       }
     },
     "node_modules/@defra/forms-model": {
-      "version": "3.0.693",
-      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.693.tgz",
-      "integrity": "sha512-qD+w+vq47rzH3TdIRgxwckL4b6a5el098Dvrk7G8MN7fTLsnZZgbc5kLqed2ugIugPICBXUWopdfpjjjxUfGAA==",
+      "version": "3.0.694",
+      "resolved": "https://registry.npmjs.org/@defra/forms-model/-/forms-model-3.0.694.tgz",
+      "integrity": "sha512-YiUVGDcY/NU3h/Loifq0WMgd7pW7b8XgUXBfgDUJNpufmtqidrYKp/r0SjpNO+qYFmZJVO0AaH9OPIP//PW9+g==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@joi/date": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@hapi/wreck": "^18.1.2",
         "@hapi/yar": "^11.0.3",
         "@types/humanize-duration": "^3.27.4",
-        "accessible-autocomplete": "^3.0.1",
         "babel-plugin-transform-import-meta": "^2.3.3",
         "blankie": "^5.0.0",
         "blipp": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@hapi/wreck": "^18.1.2",
     "@hapi/yar": "^11.0.3",
     "@types/humanize-duration": "^3.27.4",
-    "accessible-autocomplete": "^3.0.1",
     "babel-plugin-transform-import-meta": "^2.3.3",
     "blankie": "^5.0.0",
     "blipp": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
     "@aws-sdk/client-sns": "^3.1079.0",
-    "@defra/forms-engine-plugin": "5.0.0-alpha.12",
-    "@defra/forms-model": "^3.0.693",
+    "@defra/forms-engine-plugin": "^5.0.0-alpha.13",
+    "@defra/forms-model": "^3.0.694",
     "@defra/hapi-tracing": "^1.30.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@hapi/boom": "^10.0.1",
@@ -62,6 +62,7 @@
     "@hapi/wreck": "^18.1.2",
     "@hapi/yar": "^11.0.3",
     "@types/humanize-duration": "^3.27.4",
+    "accessible-autocomplete": "^3.0.1",
     "babel-plugin-transform-import-meta": "^2.3.3",
     "blankie": "^5.0.0",
     "blipp": "^4.0.2",

--- a/src/client/stylesheets/_error-details.scss
+++ b/src/client/stylesheets/_error-details.scss
@@ -1,7 +1,6 @@
 @use "govuk-frontend" as *;
 
-// Technical details block on the preview error page. Mirrors the engine
-// plugin's .app-code__container styling with GOV.UK design tokens.
+// Technical details block on the preview error page
 .app-error-details__technical {
   margin: 0;
   padding: govuk-spacing(3);

--- a/src/client/stylesheets/_error-details.scss
+++ b/src/client/stylesheets/_error-details.scss
@@ -1,0 +1,11 @@
+@use "govuk-frontend" as *;
+
+// Technical details block on the preview error page. Mirrors the engine
+// plugin's .app-code__container styling with GOV.UK design tokens.
+.app-error-details__technical {
+  margin: 0;
+  padding: govuk-spacing(3);
+  overflow-x: auto;
+  border: 1px solid $govuk-border-colour;
+  background-color: govuk-colour("light-grey");
+}

--- a/src/client/stylesheets/application.scss
+++ b/src/client/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @use "pkg:@defra/forms-engine-plugin";
 @use "pkg:govuk-frontend";
+@use "error-details";
 @use "service-banner";
 @use "tag-env";

--- a/src/server/i18n/translations/en-GB.json
+++ b/src/server/i18n/translations/en-GB.json
@@ -241,7 +241,7 @@
       "tryBack": "try your browser back button as your data may be saved",
       "contact": "<a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/contact-defra\">contact the Defra Helpline</a> if you have any questions",
       "details": {
-        "summary": "What went wrong (preview only)",
+        "summary": "What went wrong",
         "intro": "This information is shown because you are previewing this form. Members of the public will not see it.",
         "technicalHeading": "Technical details"
       }

--- a/src/server/i18n/translations/en-GB.json
+++ b/src/server/i18n/translations/en-GB.json
@@ -242,9 +242,9 @@
       "contact": "<a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/contact-defra\">contact the Defra Helpline</a> if you have any questions"
     },
     "previewError": {
-      "heading": "This form cannot be previewed",
+      "heading": "This form can't be previewed",
       "summary": "What went wrong",
-      "intro": "The form contains configuration errors that need to be resolved before it can be viewed by the public.",
+      "intro": "Something in the form setup needs attention before you can preview it.",
       "technical": {
         "revealText": "Technical details",
         "support": "If you're unable to fix this error yourself, send the information below to the Defra Forms support team."

--- a/src/server/i18n/translations/en-GB.json
+++ b/src/server/i18n/translations/en-GB.json
@@ -239,7 +239,12 @@
       "heading": "Sorry, there is a problem with the service",
       "canYou": "You can:",
       "tryBack": "try your browser back button as your data may be saved",
-      "contact": "<a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/contact-defra\">contact the Defra Helpline</a> if you have any questions"
+      "contact": "<a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/contact-defra\">contact the Defra Helpline</a> if you have any questions",
+      "details": {
+        "summary": "What went wrong (preview only)",
+        "intro": "This information is shown because you are previewing this form. Members of the public will not see it.",
+        "technicalHeading": "Technical details"
+      }
     }
   },
   "errorPreview": {

--- a/src/server/i18n/translations/en-GB.json
+++ b/src/server/i18n/translations/en-GB.json
@@ -239,11 +239,15 @@
       "heading": "Sorry, there is a problem with the service",
       "canYou": "You can:",
       "tryBack": "try your browser back button as your data may be saved",
-      "contact": "<a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/contact-defra\">contact the Defra Helpline</a> if you have any questions",
-      "details": {
-        "summary": "What went wrong",
-        "intro": "This information is shown because you are previewing this form. Members of the public will not see it.",
-        "technicalHeading": "Technical details"
+      "contact": "<a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/contact-defra\">contact the Defra Helpline</a> if you have any questions"
+    },
+    "previewError": {
+      "heading": "This form cannot be previewed",
+      "summary": "What went wrong",
+      "intro": "The form contains configuration errors that need to be resolved before it can be viewed by the public.",
+      "technical": {
+        "revealText": "Technical details",
+        "support": "If you're unable to fix this error yourself, send the information below to the Defra Forms support team."
       }
     }
   },

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -39,15 +39,22 @@ function buildTechnicalText(error) {
 }
 
 /**
- * One message builder per known error type, keyed by the error's class name.
+ * One cause builder per known error type, keyed by the error's class name.
  * To support a new error type, add an entry here. Errors without an entry
  * fall back to their own message.
- * @type {Record<string, ((error: InvalidFormDefinitionError) => string) | undefined>}
+ * @type {Record<string, ((error: InvalidFormDefinitionError) => string | ErrorCause) | undefined>}
  */
 const causeBuildersByErrorName = {
   [ConditionBuildError.name]: (error) => {
     const { conditionName } = /** @type {ConditionBuildError} */ (error)
-    return `The condition '${conditionName}' is invalid. Check that it refers to the right question and answer option.`
+    return {
+      text: `The condition "${conditionName}" isn't configured correctly. Open the condition and check that:`,
+      items: [
+        'the question it refers to still exists',
+        'the correct answer option is selected',
+        'the condition has been completed and saved'
+      ]
+    }
   },
   [UnknownPageControllerError.name]: () =>
     'This form uses a page type this version of the service does not recognise.',
@@ -72,9 +79,16 @@ function buildDefinitionCauses(joiError) {
 }
 
 /**
+ * @typedef {object} ErrorCause
+ * @property {string} text - summary sentence
+ * @property {string} [itemsIntro] - optional lead-in shown before the bullets
+ * @property {string[]} [items] - optional bullet points shown under the text
+ */
+
+/**
  * Works out the human-readable reasons an error happened.
  * @param {Error} error
- * @returns {string[]}
+ * @returns {(string | ErrorCause)[]}
  */
 function buildCauses(error) {
   // Invalid form definitions arrive wrapped, with the Joi error as the cause
@@ -87,7 +101,15 @@ function buildCauses(error) {
   // field-level detail still appears in the technical block.
   if (error instanceof MetadataValidationError) {
     return [
-      "Some of the form's details are invalid. Go back to the form overview and check details such as contact information and email addresses."
+      {
+        text: "Some of the form's details are not configured correctly. Go back to the form overview and check details such as contact information and email addresses.",
+        itemsIntro: 'Check that:',
+        items: [
+          'notification email addresses are entered correctly',
+          'contact information has been completed',
+          'any recent changes to the form details have been saved'
+        ]
+      }
     ]
   }
 
@@ -103,10 +125,14 @@ function buildCauses(error) {
  * Turns an error raised while loading a form into human-readable causes plus
  * a short technical description. Used by the preview error page only.
  * @param {Error} error
- * @returns {{ causes: string[], technical: string }}
+ * @returns {{ causes: ErrorCause[], technical: string }}
  */
 export function interpretError(error) {
-  return { causes: buildCauses(error), technical: buildTechnicalText(error) }
+  const causes = buildCauses(error).map((cause) =>
+    typeof cause === 'string' ? { text: cause } : cause
+  )
+
+  return { causes, technical: buildTechnicalText(error) }
 }
 
 /**

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -87,7 +87,7 @@ function buildCauses(error) {
   // field-level detail still appears in the technical block.
   if (error instanceof MetadataValidationError) {
     return [
-      "Some of the form's overview details are invalid. Go back to the form overview and check details such as contact information and email addresses."
+      "Some of the form's details are invalid. Go back to the form overview and check details such as contact information and email addresses."
     ]
   }
 

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -96,12 +96,18 @@ export function interpretError(error) {
   /** @type {string[]} */
   const causes = []
 
-  const joiError =
-    error instanceof SchemaValidationError
-      ? /** @type {import('joi').ValidationError} */ (error.cause)
-      : isJoiError(error)
-        ? error
-        : undefined
+  /** @type {import('joi').ValidationError | undefined} */
+  let joiError
+
+  if (error instanceof SchemaValidationError) {
+    // The engine wraps definition schema failures; the raw Joi error is
+    // carried as the (typed) cause
+    joiError = error.cause
+  } else if (isJoiError(error)) {
+    // A raw Joi error can only arrive from the metadata validation in
+    // formsService, which predates the typed InvalidFormDefinitionError family
+    joiError = error
+  }
 
   if (joiError) {
     // Set-dedupe: several schema rules can share one message

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -7,11 +7,7 @@ import {
   UnknownComponentTypeError,
   UnknownPageControllerError
 } from '@defra/forms-engine-plugin/engine/errors.js'
-import {
-  FormDefinitionError,
-  FormDefinitionErrorType,
-  getErrors
-} from '@defra/forms-model'
+import { formErrorsToMessages, getErrors } from '@defra/forms-model'
 
 const MAX_TECHNICAL_LENGTH = 2000
 const MAX_CAUSE_DEPTH = 5
@@ -70,79 +66,6 @@ function isJoiError(error) {
 }
 
 /**
- * Human-readable messages for the semantic definition-error codes that
- * getErrors derives from a Joi validation failure. Codes without an entry
- * fall back to the (lightly cleaned) Joi message.
- * @type {Record<string, string | undefined>}
- */
-const messagesByCauseId = {
-  [FormDefinitionError.UniquePageId]: 'Two pages have the same ID',
-  [FormDefinitionError.UniquePagePath]: 'Two pages have the same path',
-  [FormDefinitionError.UniquePageComponentId]: 'Two questions have the same ID',
-  [FormDefinitionError.UniquePageComponentName]:
-    'Two questions have the same name',
-  [FormDefinitionError.UniqueSectionId]: 'Two sections have the same ID',
-  [FormDefinitionError.UniqueSectionName]: 'Two sections have the same name',
-  [FormDefinitionError.UniqueSectionTitle]: 'Two sections have the same title',
-  [FormDefinitionError.UniqueListId]: 'Two lists have the same ID',
-  [FormDefinitionError.UniqueListTitle]: 'Two lists have the same title',
-  [FormDefinitionError.UniqueListName]: 'Two lists have the same name',
-  [FormDefinitionError.UniqueConditionId]: 'Two conditions have the same ID',
-  [FormDefinitionError.UniqueConditionDisplayName]:
-    'Two conditions have the same name',
-  [FormDefinitionError.UniqueListItemId]: 'Two list items have the same ID',
-  [FormDefinitionError.UniqueListItemText]: 'Two list items have the same text',
-  [FormDefinitionError.UniqueListItemValue]:
-    'Two list items have the same value',
-  [FormDefinitionError.RefPageCondition]:
-    'A page refers to a condition that does not exist',
-  [FormDefinitionError.RefConditionComponentId]:
-    'A condition refers to a question that does not exist',
-  [FormDefinitionError.RefConditionListId]:
-    'A condition refers to a list that does not exist',
-  [FormDefinitionError.RefConditionItemId]:
-    'A condition refers to a list item that does not exist',
-  [FormDefinitionError.RefConditionConditionId]:
-    'A condition refers to another condition that does not exist',
-  [FormDefinitionError.RefPageComponentList]:
-    'A question refers to a list that does not exist',
-  [FormDefinitionError.IncompatibleConditionComponentType]:
-    'A condition is not compatible with the type of question it refers to',
-  [FormDefinitionError.IncompatibleQuestionRegex]:
-    "A question's answer format rule is invalid"
-}
-
-/**
- * Formats one getErrors cause as a human-readable sentence. Duplicate-value
- * causes carry the two clashing positions, reported 1-based.
- * @param {import('@defra/forms-model').FormDefinitionErrorCause} cause
- * @returns {string}
- */
-function formatJoiCause(cause) {
-  const friendly = messagesByCauseId[cause.id]
-
-  if (!friendly) {
-    return cause.message.replaceAll('"', "'")
-  }
-
-  const { detail } = cause
-
-  if (
-    cause.type === FormDefinitionErrorType.Unique &&
-    detail &&
-    'pos' in detail &&
-    typeof detail.pos === 'number' &&
-    'dupePos' in detail &&
-    typeof detail.dupePos === 'number'
-  ) {
-    const positions = [detail.dupePos + 1, detail.pos + 1].sort((a, b) => a - b)
-    return `${friendly} (entries ${positions[0]} and ${positions[1]})`
-  }
-
-  return friendly
-}
-
-/**
  * Cause builders for known InvalidFormDefinitionError subclasses,
  * keyed by error class name (each class sets `this.name` to its own name).
  * Adding a new error type means adding one entry here. Subclasses without an
@@ -181,8 +104,10 @@ export function interpretError(error) {
         : undefined
 
   if (joiError) {
-    // Set-dedupe: distinct schema rules can format to identical sentences
-    causes.push(...new Set(getErrors(joiError).map(formatJoiCause)))
+    // Set-dedupe: several schema rules can share one message
+    causes.push(
+      ...new Set(getErrors(joiError).map((c) => formErrorsToMessages[c.id]))
+    )
   } else if (error instanceof InvalidFormDefinitionError) {
     const buildCause = causeBuildersByErrorName[error.name]
     causes.push(buildCause ? buildCause(error) : error.message)

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -55,7 +55,10 @@ function buildTechnicalText(error) {
  */
 function isJoiError(error) {
   return (
-    'isJoi' in error && error.isJoi === true && Array.isArray(error.details)
+    'isJoi' in error &&
+    'details' in error &&
+    error.isJoi === true &&
+    Array.isArray(error.details)
   )
 }
 

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -99,15 +99,15 @@ function buildDefinitionCauses(joiError) {
 }
 
 /**
- * One message per validation failure in the form metadata. The metadata
- * schema has no friendly-message codes (formErrorsToMessages only covers the
- * definition), so use Joi's own messages with the quote noise removed.
- * @param {import('joi').ValidationError} joiError
+ * The metadata schema has no friendly-message codes (formErrorsToMessages
+ * only covers the definition) and its raw messages are too technical to show
+ * as causes, so point the author at the right place instead. The field-level
+ * detail still appears in the technical block.
  * @returns {string[]}
  */
-function buildMetadataCauses(joiError) {
+function buildMetadataCauses() {
   return [
-    ...new Set(joiError.details.map((d) => d.message.replaceAll('"', "'")))
+    "Some of the form's overview details are invalid. Go back to the form overview and check details such as contact information and email addresses."
   ]
 }
 
@@ -124,7 +124,7 @@ function buildCauses(error) {
 
   // Raw Joi errors only come from the metadata check in formsService
   if (isJoiError(error)) {
-    return buildMetadataCauses(error)
+    return buildMetadataCauses()
   }
 
   if (error instanceof InvalidFormDefinitionError) {

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -85,16 +85,29 @@ const causeBuildersByErrorName = {
 }
 
 /**
- * One message per Joi validation failure. A Set removes repeats, because
- * several schema rules can produce the same message.
+ * One message per validation failure in the form definition. A Set removes
+ * repeats, because several schema rules can produce the same message.
  * @param {import('joi').ValidationError} joiError
  * @returns {string[]}
  */
-function buildJoiCauses(joiError) {
+function buildDefinitionCauses(joiError) {
   return [
     ...new Set(
       getErrors(joiError).map((cause) => formErrorsToMessages[cause.id])
     )
+  ]
+}
+
+/**
+ * One message per validation failure in the form metadata. The metadata
+ * schema has no friendly-message codes (formErrorsToMessages only covers the
+ * definition), so use Joi's own messages with the quote noise removed.
+ * @param {import('joi').ValidationError} joiError
+ * @returns {string[]}
+ */
+function buildMetadataCauses(joiError) {
+  return [
+    ...new Set(joiError.details.map((d) => d.message.replaceAll('"', "'")))
   ]
 }
 
@@ -106,12 +119,12 @@ function buildJoiCauses(joiError) {
 function buildCauses(error) {
   // Invalid form definitions arrive wrapped, with the Joi error as the cause
   if (error instanceof SchemaValidationError) {
-    return buildJoiCauses(error.cause)
+    return buildDefinitionCauses(error.cause)
   }
 
   // Raw Joi errors only come from the metadata check in formsService
   if (isJoiError(error)) {
-    return buildJoiCauses(error)
+    return buildMetadataCauses(error)
   }
 
   if (error instanceof InvalidFormDefinitionError) {

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -121,3 +121,17 @@ function buildCauses(error) {
 export function interpretError(error) {
   return { causes: buildCauses(error), technical: buildTechnicalText(error) }
 }
+
+/**
+ * Whether the error is a known form-configuration problem (form definition
+ * or form metadata). Anything else — an outage, a bug — must not be
+ * presented as a problem with the form.
+ * @param {Error} error
+ * @returns {boolean}
+ */
+export function isFormConfigurationError(error) {
+  return (
+    error instanceof InvalidFormDefinitionError ||
+    error instanceof MetadataValidationError
+  )
+}

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -7,7 +7,11 @@ import {
   UnknownComponentTypeError,
   UnknownPageControllerError
 } from '@defra/forms-engine-plugin/engine/errors.js'
-import { getErrors } from '@defra/forms-model'
+import {
+  FormDefinitionError,
+  FormDefinitionErrorType,
+  getErrors
+} from '@defra/forms-model'
 
 const MAX_TECHNICAL_LENGTH = 2000
 const MAX_CAUSE_DEPTH = 5
@@ -66,6 +70,79 @@ function isJoiError(error) {
 }
 
 /**
+ * Human-readable messages for the semantic definition-error codes that
+ * getErrors derives from a Joi validation failure. Codes without an entry
+ * fall back to the (lightly cleaned) Joi message.
+ * @type {Record<string, string | undefined>}
+ */
+const messagesByCauseId = {
+  [FormDefinitionError.UniquePageId]: 'Two pages have the same ID',
+  [FormDefinitionError.UniquePagePath]: 'Two pages have the same path',
+  [FormDefinitionError.UniquePageComponentId]: 'Two questions have the same ID',
+  [FormDefinitionError.UniquePageComponentName]:
+    'Two questions have the same name',
+  [FormDefinitionError.UniqueSectionId]: 'Two sections have the same ID',
+  [FormDefinitionError.UniqueSectionName]: 'Two sections have the same name',
+  [FormDefinitionError.UniqueSectionTitle]: 'Two sections have the same title',
+  [FormDefinitionError.UniqueListId]: 'Two lists have the same ID',
+  [FormDefinitionError.UniqueListTitle]: 'Two lists have the same title',
+  [FormDefinitionError.UniqueListName]: 'Two lists have the same name',
+  [FormDefinitionError.UniqueConditionId]: 'Two conditions have the same ID',
+  [FormDefinitionError.UniqueConditionDisplayName]:
+    'Two conditions have the same name',
+  [FormDefinitionError.UniqueListItemId]: 'Two list items have the same ID',
+  [FormDefinitionError.UniqueListItemText]: 'Two list items have the same text',
+  [FormDefinitionError.UniqueListItemValue]:
+    'Two list items have the same value',
+  [FormDefinitionError.RefPageCondition]:
+    'A page refers to a condition that does not exist',
+  [FormDefinitionError.RefConditionComponentId]:
+    'A condition refers to a question that does not exist',
+  [FormDefinitionError.RefConditionListId]:
+    'A condition refers to a list that does not exist',
+  [FormDefinitionError.RefConditionItemId]:
+    'A condition refers to a list item that does not exist',
+  [FormDefinitionError.RefConditionConditionId]:
+    'A condition refers to another condition that does not exist',
+  [FormDefinitionError.RefPageComponentList]:
+    'A question refers to a list that does not exist',
+  [FormDefinitionError.IncompatibleConditionComponentType]:
+    'A condition is not compatible with the type of question it refers to',
+  [FormDefinitionError.IncompatibleQuestionRegex]:
+    "A question's answer format rule is invalid"
+}
+
+/**
+ * Formats one getErrors cause as a human-readable sentence. Duplicate-value
+ * causes carry the two clashing positions, reported 1-based.
+ * @param {import('@defra/forms-model').FormDefinitionErrorCause} cause
+ * @returns {string}
+ */
+function formatJoiCause(cause) {
+  const friendly = messagesByCauseId[cause.id]
+
+  if (!friendly) {
+    return cause.message.replaceAll('"', "'")
+  }
+
+  const { detail } = cause
+
+  if (
+    cause.type === FormDefinitionErrorType.Unique &&
+    detail &&
+    'pos' in detail &&
+    typeof detail.pos === 'number' &&
+    'dupePos' in detail &&
+    typeof detail.dupePos === 'number'
+  ) {
+    const positions = [detail.dupePos + 1, detail.pos + 1].sort((a, b) => a - b)
+    return `${friendly} (entries ${positions[0]} and ${positions[1]})`
+  }
+
+  return friendly
+}
+
+/**
  * Cause builders for known InvalidFormDefinitionError subclasses,
  * keyed by error class name (each class sets `this.name` to its own name).
  * Adding a new error type means adding one entry here. Subclasses without an
@@ -75,7 +152,7 @@ function isJoiError(error) {
 const causeBuildersByErrorName = {
   [ConditionBuildError.name]: (error) => {
     const { conditionName } = /** @type {ConditionBuildError} */ (error)
-    return `The condition '${conditionName}' could not be understood. Check that it refers to the right question and answer option.`
+    return `The condition '${conditionName}' is invalid. Check that it refers to the right question and answer option.`
   },
   [UnknownPageControllerError.name]: () =>
     'This form uses a page type this version of the service does not recognise.',
@@ -104,12 +181,8 @@ export function interpretError(error) {
         : undefined
 
   if (joiError) {
-    for (const cause of getErrors(joiError)) {
-      const path = Array.isArray(cause.detail?.path)
-        ? ` (${cause.detail.path.join(' → ')})`
-        : ''
-      causes.push(`${cause.message}${path}`)
-    }
+    // Set-dedupe: distinct schema rules can format to identical sentences
+    causes.push(...new Set(getErrors(joiError).map(formatJoiCause)))
   } else if (error instanceof InvalidFormDefinitionError) {
     const buildCause = causeBuildersByErrorName[error.name]
     causes.push(buildCause ? buildCause(error) : error.message)

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -63,13 +63,13 @@ function isJoiError(error) {
 }
 
 /**
- * Friendly cause builders for known InvalidFormDefinitionError subclasses,
+ * Cause builders for known InvalidFormDefinitionError subclasses,
  * keyed by error class name (each class sets `this.name` to its own name).
  * Adding a new error type means adding one entry here. Subclasses without an
  * entry fall back to their own message in {@link interpretError}.
  * @type {Record<string, ((error: InvalidFormDefinitionError) => string) | undefined>}
  */
-const friendlyCauseBuilders = {
+const causeBuildersByErrorName = {
   [ConditionBuildError.name]: (error) => {
     const { conditionName } = /** @type {ConditionBuildError} */ (error)
     return `The condition '${conditionName}' could not be understood. Check that it refers to the right question and answer option.`
@@ -101,7 +101,7 @@ export function interpretError(error) {
       causes.push(`${cause.message}${path}`)
     }
   } else if (error instanceof InvalidFormDefinitionError) {
-    const buildCause = friendlyCauseBuilders[error.name]
+    const buildCause = causeBuildersByErrorName[error.name]
     causes.push(buildCause ? buildCause(error) : error.message)
   }
 

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -3,6 +3,7 @@ import os from 'node:os'
 import {
   ConditionBuildError,
   InvalidFormDefinitionError,
+  SchemaValidationError,
   UnknownComponentTypeError,
   UnknownPageControllerError
 } from '@defra/forms-engine-plugin/engine/errors.js'
@@ -48,7 +49,10 @@ function buildTechnicalText(error) {
 }
 
 /**
- * Checks for a Joi validation error.
+ * Checks for a raw Joi validation error — thrown untyped by paths that
+ * predate the InvalidFormDefinitionError family (e.g. metadata validation in
+ * formsService). Definition schema failures arrive typed as
+ * SchemaValidationError instead and never need this duck-typing.
  * @param {Error} error
  * @returns {error is import('joi').ValidationError}
  */
@@ -59,26 +63,6 @@ function isJoiError(error) {
     error.isJoi === true &&
     Array.isArray(error.details)
   )
-}
-
-/**
- * Finds the Joi validation error carried by `error`: the error itself (raw
- * throws, e.g. metadata validation in formsService), or its direct `cause`
- * (the engine wraps definition schema failures in SchemaValidationError with
- * the raw Joi error as the cause).
- * @param {Error} error
- * @returns {import('joi').ValidationError | undefined}
- */
-function findJoiError(error) {
-  if (isJoiError(error)) {
-    return error
-  }
-
-  if (error.cause instanceof Error && isJoiError(error.cause)) {
-    return error.cause
-  }
-
-  return undefined
 }
 
 /**
@@ -112,7 +96,12 @@ export function interpretError(error) {
   /** @type {string[]} */
   const causes = []
 
-  const joiError = findJoiError(error)
+  const joiError =
+    error instanceof SchemaValidationError
+      ? /** @type {import('joi').ValidationError} */ (error.cause)
+      : isJoiError(error)
+        ? error
+        : undefined
 
   if (joiError) {
     for (const cause of getErrors(joiError)) {

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -1,0 +1,97 @@
+import os from 'node:os'
+
+import {
+  ConditionBuildError,
+  InvalidFormDefinitionError,
+  UnknownComponentTypeError,
+  UnknownPageControllerError
+} from '@defra/forms-engine-plugin/engine/errors.js'
+import { getErrors } from '@defra/forms-model'
+
+const MAX_TECHNICAL_LENGTH = 2000
+const MAX_CAUSE_DEPTH = 5
+
+/**
+ * Redacts known filesystem prefixes by literal replacement. Deliberately not
+ * heuristic path detection: literal replacement cannot misfire on non-path
+ * text, and it removes the sensitive part (the container's filesystem layout).
+ * @param {string} text
+ * @returns {string}
+ */
+function redactKnownPrefixes(text) {
+  return text.replaceAll(process.cwd(), '.').replaceAll(os.homedir(), '~')
+}
+
+/**
+ * Builds the sanitized technical text: the error message plus its `cause`
+ * chain. Never includes stack traces.
+ * @param {Error} error
+ * @returns {string}
+ */
+function buildTechnicalText(error) {
+  const parts = [error.message]
+
+  let cause = error.cause
+  let depth = 0
+
+  while (cause instanceof Error && depth < MAX_CAUSE_DEPTH) {
+    parts.push(`Caused by: ${cause.message}`)
+    cause = cause.cause
+    depth++
+  }
+
+  const text = redactKnownPrefixes(parts.join('\n'))
+
+  return text.length > MAX_TECHNICAL_LENGTH
+    ? `${text.slice(0, MAX_TECHNICAL_LENGTH)}… (truncated)`
+    : text
+}
+
+/**
+ * Checks for a Joi validation error (the engine throws the raw ValidationError
+ * when a definition fails schema validation).
+ * @param {Error} error
+ * @returns {error is import('joi').ValidationError}
+ */
+function isJoiError(error) {
+  return (
+    'isJoi' in error && error.isJoi === true && Array.isArray(error.details)
+  )
+}
+
+/**
+ * Interprets an error raised while loading or rendering a form into
+ * designer-friendly causes plus a sanitized technical message. Used by the
+ * error pages plugin for preview requests only.
+ * @param {Error} error
+ * @returns {{ causes: string[], technical: string }}
+ */
+export function interpretError(error) {
+  /** @type {string[]} */
+  const causes = []
+
+  if (isJoiError(error)) {
+    for (const cause of getErrors(error)) {
+      const path = Array.isArray(cause.detail?.path)
+        ? ` (${cause.detail.path.join(' → ')})`
+        : ''
+      causes.push(`${cause.message}${path}`)
+    }
+  } else if (error instanceof ConditionBuildError) {
+    causes.push(
+      `The condition '${error.conditionName}' could not be understood. Check that it refers to the right question and answer option.`
+    )
+  } else if (error instanceof UnknownPageControllerError) {
+    causes.push(
+      `This form uses a page type ('${error.controllerName}') this version of the service does not recognise.`
+    )
+  } else if (error instanceof UnknownComponentTypeError) {
+    causes.push(
+      `This form uses a question type ('${error.componentType}') this version of the service does not recognise.`
+    )
+  } else if (error instanceof InvalidFormDefinitionError) {
+    causes.push(error.message)
+  }
+
+  return { causes, technical: buildTechnicalText(error) }
+}

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -63,6 +63,26 @@ function isJoiError(error) {
 }
 
 /**
+ * Friendly cause builders for known InvalidFormDefinitionError subclasses,
+ * keyed by error class name (each class sets `this.name` to its own name).
+ * Adding a new error type means adding one entry here. Subclasses without an
+ * entry fall back to their own message in {@link interpretError}.
+ * @type {Record<string, ((error: InvalidFormDefinitionError) => string) | undefined>}
+ */
+const friendlyCauseBuilders = {
+  [ConditionBuildError.name]: (error) => {
+    const { conditionName } = /** @type {ConditionBuildError} */ (error)
+    return `The condition '${conditionName}' could not be understood. Check that it refers to the right question and answer option.`
+  },
+  [UnknownPageControllerError.name]: () =>
+    'This form uses a page type this version of the service does not recognise.',
+  [UnknownComponentTypeError.name]: (error) => {
+    const { componentType } = /** @type {UnknownComponentTypeError} */ (error)
+    return `This form uses a question type ('${componentType}') this version of the service does not recognise.`
+  }
+}
+
+/**
  * Interprets an error raised while loading or rendering a form into
  * designer-friendly causes plus a sanitized technical message. Used by the
  * error pages plugin for preview requests only.
@@ -80,20 +100,9 @@ export function interpretError(error) {
         : ''
       causes.push(`${cause.message}${path}`)
     }
-  } else if (error instanceof ConditionBuildError) {
-    causes.push(
-      `The condition '${error.conditionName}' could not be understood. Check that it refers to the right question and answer option.`
-    )
-  } else if (error instanceof UnknownPageControllerError) {
-    causes.push(
-      'This form uses a page type this version of the service does not recognise.'
-    )
-  } else if (error instanceof UnknownComponentTypeError) {
-    causes.push(
-      `This form uses a question type ('${error.componentType}') this version of the service does not recognise.`
-    )
   } else if (error instanceof InvalidFormDefinitionError) {
-    causes.push(error.message)
+    const buildCause = friendlyCauseBuilders[error.name]
+    causes.push(buildCause ? buildCause(error) : error.message)
   }
 
   return { causes, technical: buildTechnicalText(error) }

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -86,7 +86,7 @@ export function interpretError(error) {
     )
   } else if (error instanceof UnknownPageControllerError) {
     causes.push(
-      `This form uses a page type ('${error.controllerName}') this version of the service does not recognise.`
+      'This form uses a page type this version of the service does not recognise.'
     )
   } else if (error instanceof UnknownComponentTypeError) {
     causes.push(

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -48,8 +48,7 @@ function buildTechnicalText(error) {
 }
 
 /**
- * Checks for a Joi validation error (the engine throws the raw ValidationError
- * when a definition fails schema validation).
+ * Checks for a Joi validation error.
  * @param {Error} error
  * @returns {error is import('joi').ValidationError}
  */
@@ -60,6 +59,26 @@ function isJoiError(error) {
     error.isJoi === true &&
     Array.isArray(error.details)
   )
+}
+
+/**
+ * Finds the Joi validation error carried by `error`: the error itself (raw
+ * throws, e.g. metadata validation in formsService), or its direct `cause`
+ * (the engine wraps definition schema failures in SchemaValidationError with
+ * the raw Joi error as the cause).
+ * @param {Error} error
+ * @returns {import('joi').ValidationError | undefined}
+ */
+function findJoiError(error) {
+  if (isJoiError(error)) {
+    return error
+  }
+
+  if (error.cause instanceof Error && isJoiError(error.cause)) {
+    return error.cause
+  }
+
+  return undefined
 }
 
 /**
@@ -93,8 +112,10 @@ export function interpretError(error) {
   /** @type {string[]} */
   const causes = []
 
-  if (isJoiError(error)) {
-    for (const cause of getErrors(error)) {
+  const joiError = findJoiError(error)
+
+  if (joiError) {
+    for (const cause of getErrors(joiError)) {
       const path = Array.isArray(cause.detail?.path)
         ? ` (${cause.detail.path.join(' → ')})`
         : ''

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -13,9 +13,9 @@ const MAX_TECHNICAL_LENGTH = 2000
 const MAX_CAUSE_DEPTH = 5
 
 /**
- * Redacts known filesystem prefixes by literal replacement. Deliberately not
- * heuristic path detection: literal replacement cannot misfire on non-path
- * text, and it removes the sensitive part (the container's filesystem layout).
+ * Hides server file paths. Only the two prefixes we know about are replaced
+ * (the app directory and the home directory) — plain text substitution, so
+ * text that is not a path is never touched.
  * @param {string} text
  * @returns {string}
  */
@@ -24,8 +24,9 @@ function redactKnownPrefixes(text) {
 }
 
 /**
- * Builds the sanitized technical text: the error message plus its `cause`
- * chain. Never includes stack traces.
+ * Builds the text for the "Technical details" block: the error message,
+ * followed by the messages of the errors that caused it. Never includes
+ * stack traces.
  * @param {Error} error
  * @returns {string}
  */
@@ -49,10 +50,9 @@ function buildTechnicalText(error) {
 }
 
 /**
- * Checks for a raw Joi validation error — thrown untyped by paths that
- * predate the InvalidFormDefinitionError family (e.g. metadata validation in
- * formsService). Definition schema failures arrive typed as
- * SchemaValidationError instead and never need this duck-typing.
+ * Checks whether an error is a raw Joi validation error. Only the metadata
+ * check in formsService still throws these — invalid form definitions arrive
+ * as SchemaValidationError instead.
  * @param {Error} error
  * @returns {error is import('joi').ValidationError}
  */
@@ -66,10 +66,9 @@ function isJoiError(error) {
 }
 
 /**
- * Cause builders for known InvalidFormDefinitionError subclasses,
- * keyed by error class name (each class sets `this.name` to its own name).
- * Adding a new error type means adding one entry here. Subclasses without an
- * entry fall back to their own message in {@link interpretError}.
+ * One message builder per known error type, keyed by the error's class name.
+ * To support a new error type, add an entry here. Errors without an entry
+ * fall back to their own message.
  * @type {Record<string, ((error: InvalidFormDefinitionError) => string) | undefined>}
  */
 const causeBuildersByErrorName = {
@@ -86,38 +85,49 @@ const causeBuildersByErrorName = {
 }
 
 /**
- * Interprets an error raised while loading or rendering a form into
- * designer-friendly causes plus a sanitized technical message. Used by the
- * error pages plugin for preview requests only.
+ * One message per Joi validation failure. A Set removes repeats, because
+ * several schema rules can produce the same message.
+ * @param {import('joi').ValidationError} joiError
+ * @returns {string[]}
+ */
+function buildJoiCauses(joiError) {
+  return [
+    ...new Set(
+      getErrors(joiError).map((cause) => formErrorsToMessages[cause.id])
+    )
+  ]
+}
+
+/**
+ * Works out the human-readable reasons an error happened.
+ * @param {Error} error
+ * @returns {string[]}
+ */
+function buildCauses(error) {
+  // Invalid form definitions arrive wrapped, with the Joi error as the cause
+  if (error instanceof SchemaValidationError) {
+    return buildJoiCauses(error.cause)
+  }
+
+  // Raw Joi errors only come from the metadata check in formsService
+  if (isJoiError(error)) {
+    return buildJoiCauses(error)
+  }
+
+  if (error instanceof InvalidFormDefinitionError) {
+    const buildCause = causeBuildersByErrorName[error.name]
+    return [buildCause ? buildCause(error) : error.message]
+  }
+
+  return []
+}
+
+/**
+ * Turns an error raised while loading a form into human-readable causes plus
+ * a short technical description. Used by the preview error page only.
  * @param {Error} error
  * @returns {{ causes: string[], technical: string }}
  */
 export function interpretError(error) {
-  /** @type {string[]} */
-  const causes = []
-
-  /** @type {import('joi').ValidationError | undefined} */
-  let joiError
-
-  if (error instanceof SchemaValidationError) {
-    // The engine wraps definition schema failures; the raw Joi error is
-    // carried as the (typed) cause
-    joiError = error.cause
-  } else if (isJoiError(error)) {
-    // A raw Joi error can only arrive from the metadata validation in
-    // formsService, which predates the typed InvalidFormDefinitionError family
-    joiError = error
-  }
-
-  if (joiError) {
-    // Set-dedupe: several schema rules can share one message
-    causes.push(
-      ...new Set(getErrors(joiError).map((c) => formErrorsToMessages[c.id]))
-    )
-  } else if (error instanceof InvalidFormDefinitionError) {
-    const buildCause = causeBuildersByErrorName[error.name]
-    causes.push(buildCause ? buildCause(error) : error.message)
-  }
-
-  return { causes, technical: buildTechnicalText(error) }
+  return { causes: buildCauses(error), technical: buildTechnicalText(error) }
 }

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -9,6 +9,8 @@ import {
 } from '@defra/forms-engine-plugin/engine/errors.js'
 import { formErrorsToMessages, getErrors } from '@defra/forms-model'
 
+import { MetadataValidationError } from '~/src/server/services/errors.js'
+
 const MAX_TECHNICAL_LENGTH = 2000
 const MAX_CAUSE_DEPTH = 5
 
@@ -19,7 +21,7 @@ const MAX_CAUSE_DEPTH = 5
  * @param {string} text
  * @returns {string}
  */
-function redactKnownPrefixes(text) {
+function redactBasePaths(text) {
   return text.replaceAll(process.cwd(), '.').replaceAll(os.homedir(), '~')
 }
 
@@ -42,27 +44,11 @@ function buildTechnicalText(error) {
     depth++
   }
 
-  const text = redactKnownPrefixes(parts.join('\n'))
+  const text = redactBasePaths(parts.join('\n'))
 
   return text.length > MAX_TECHNICAL_LENGTH
     ? `${text.slice(0, MAX_TECHNICAL_LENGTH)}… (truncated)`
     : text
-}
-
-/**
- * Checks whether an error is a raw Joi validation error. Only the metadata
- * check in formsService still throws these — invalid form definitions arrive
- * as SchemaValidationError instead.
- * @param {Error} error
- * @returns {error is import('joi').ValidationError}
- */
-function isJoiError(error) {
-  return (
-    'isJoi' in error &&
-    'details' in error &&
-    error.isJoi === true &&
-    Array.isArray(error.details)
-  )
 }
 
 /**
@@ -99,19 +85,6 @@ function buildDefinitionCauses(joiError) {
 }
 
 /**
- * The metadata schema has no friendly-message codes (formErrorsToMessages
- * only covers the definition) and its raw messages are too technical to show
- * as causes, so point the author at the right place instead. The field-level
- * detail still appears in the technical block.
- * @returns {string[]}
- */
-function buildMetadataCauses() {
-  return [
-    "Some of the form's overview details are invalid. Go back to the form overview and check details such as contact information and email addresses."
-  ]
-}
-
-/**
  * Works out the human-readable reasons an error happened.
  * @param {Error} error
  * @returns {string[]}
@@ -122,9 +95,13 @@ function buildCauses(error) {
     return buildDefinitionCauses(error.cause)
   }
 
-  // Raw Joi errors only come from the metadata check in formsService
-  if (isJoiError(error)) {
-    return buildMetadataCauses()
+  // The metadata check in formsService throws this; the raw messages are too
+  // technical to show as causes, so point the author at the right place. The
+  // field-level detail still appears in the technical block.
+  if (error instanceof MetadataValidationError) {
+    return [
+      "Some of the form's overview details are invalid. Go back to the form overview and check details such as contact information and email addresses."
+    ]
   }
 
   if (error instanceof InvalidFormDefinitionError) {

--- a/src/server/plugins/errorInterpretation.js
+++ b/src/server/plugins/errorInterpretation.js
@@ -1,5 +1,3 @@
-import os from 'node:os'
-
 import {
   ConditionBuildError,
   InvalidFormDefinitionError,
@@ -13,17 +11,6 @@ import { MetadataValidationError } from '~/src/server/services/errors.js'
 
 const MAX_TECHNICAL_LENGTH = 2000
 const MAX_CAUSE_DEPTH = 5
-
-/**
- * Hides server file paths. Only the two prefixes we know about are replaced
- * (the app directory and the home directory) — plain text substitution, so
- * text that is not a path is never touched.
- * @param {string} text
- * @returns {string}
- */
-function redactBasePaths(text) {
-  return text.replaceAll(process.cwd(), '.').replaceAll(os.homedir(), '~')
-}
 
 /**
  * Builds the text for the "Technical details" block: the error message,
@@ -44,7 +31,7 @@ function buildTechnicalText(error) {
     depth++
   }
 
-  const text = redactBasePaths(parts.join('\n'))
+  const text = parts.join('\n')
 
   return text.length > MAX_TECHNICAL_LENGTH
     ? `${text.slice(0, MAX_TECHNICAL_LENGTH)}… (truncated)`

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -10,13 +10,14 @@ import {
 import { formDefinitionV2Schema, formMetadataSchema } from '@defra/forms-model'
 
 import { interpretError } from '~/src/server/plugins/errorInterpretation.js'
+import { MetadataValidationError } from '~/src/server/services/errors.js'
 
 describe('interpretError', () => {
   test('metadata validation errors point the author at the form overview', () => {
     const { error } = formMetadataSchema.validate({}, { abortEarly: false })
     if (!error) throw new Error('expected validation error')
 
-    const result = interpretError(error)
+    const result = interpretError(new MetadataValidationError(error))
 
     expect(result.causes).toEqual([
       "Some of the form's overview details are invalid. Go back to the form overview and check details such as contact information and email addresses."

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -13,6 +13,7 @@ import { interpretError } from '~/src/server/plugins/errorInterpretation.js'
 describe('interpretError', () => {
   test('Joi definition validation errors produce getErrors-derived causes', () => {
     const { error } = formDefinitionV2Schema.validate({}, { abortEarly: false })
+    if (!error) throw new Error('expected validation error')
 
     const result = interpretError(error)
 

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -1,5 +1,3 @@
-import os from 'node:os'
-
 import {
   ConditionBuildError,
   InvalidFormDefinitionError,
@@ -165,24 +163,6 @@ describe('interpretError', () => {
 
     expect(result.causes).toEqual([])
     expect(result.technical).toBe('something else entirely')
-  })
-
-  test('cwd and homedir are redacted by literal replacement', () => {
-    const error = new Error(
-      `Cannot find module '${process.cwd()}/node_modules/x' from '${os.homedir()}/y'`
-    )
-
-    const result = interpretError(error)
-
-    expect(result.technical).toBe(
-      "Cannot find module './node_modules/x' from '~/y'"
-    )
-  })
-
-  test('path-like text outside the known prefixes is left untouched', () => {
-    const result = interpretError(new Error('open /etc/whatever failed'))
-
-    expect(result.technical).toBe('open /etc/whatever failed')
   })
 
   test('long technical text is truncated at 2000 characters', () => {

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -21,12 +21,22 @@ describe('interpretError', () => {
     const result = interpretError(new MetadataValidationError(error))
 
     expect(result.causes).toEqual([
-      "Some of the form's details are invalid. Go back to the form overview and check details such as contact information and email addresses."
+      {
+        text: "Some of the form's details are not configured correctly. Go back to the form overview and check details such as contact information and email addresses.",
+        itemsIntro: 'Check that:',
+        items: [
+          'notification email addresses are entered correctly',
+          'contact information has been completed',
+          'any recent changes to the form details have been saved'
+        ]
+      }
     ])
     // the field-level detail still appears in the technical text
     expect(result.technical).toContain('"title" is required')
     // metadata failures must not claim the form definition is broken
-    expect(result.causes.join(' ')).not.toContain('form definition')
+    expect(result.causes.map((cause) => cause.text).join(' ')).not.toContain(
+      'form definition'
+    )
   })
 
   test('definition validation errors produce coded causes', () => {
@@ -36,7 +46,9 @@ describe('interpretError', () => {
     const result = interpretError(new SchemaValidationError(error))
 
     expect(result.causes).toEqual([
-      'There is a problem with the form definition. Check your changes and try again.'
+      {
+        text: 'There is a problem with the form definition. Check your changes and try again.'
+      }
     ])
     expect(result.technical).toContain('Invalid form definition:')
   })
@@ -77,8 +89,12 @@ describe('interpretError', () => {
     const result = interpretError(new SchemaValidationError(error))
 
     expect(result.causes).toEqual([
-      'Each page must have a unique ID. Change the page ID to one that is not already used.',
-      'Each page must have a unique path. Change the page path to one that is not already used.'
+      {
+        text: 'Each page must have a unique ID. Change the page ID to one that is not already used.'
+      },
+      {
+        text: 'Each page must have a unique path. Change the page path to one that is not already used.'
+      }
     ])
   })
 
@@ -109,7 +125,7 @@ describe('interpretError', () => {
     )
 
     expect(result.causes).toEqual([
-      'Remove the condition before deleting this page'
+      { text: 'Remove the condition before deleting this page' }
     ])
   })
 
@@ -121,7 +137,14 @@ describe('interpretError', () => {
     const result = interpretError(error)
 
     expect(result.causes).toEqual([
-      "The condition 'Existing user' is invalid. Check that it refers to the right question and answer option."
+      {
+        text: `The condition "Existing user" isn't configured correctly. Open the condition and check that:`,
+        items: [
+          'the question it refers to still exists',
+          'the correct answer option is selected',
+          'the condition has been completed and saved'
+        ]
+      }
     ])
     expect(result.technical).toContain(
       "Failed to build condition 'Existing user'"
@@ -137,7 +160,9 @@ describe('interpretError', () => {
     )
 
     expect(result.causes).toEqual([
-      'This form uses a page type this version of the service does not recognise.'
+      {
+        text: 'This form uses a page type this version of the service does not recognise.'
+      }
     ])
   })
 
@@ -145,7 +170,9 @@ describe('interpretError', () => {
     const result = interpretError(new UnknownComponentTypeError('NopeField'))
 
     expect(result.causes).toEqual([
-      "This form uses a question type ('NopeField') this version of the service does not recognise."
+      {
+        text: "This form uses a question type ('NopeField') this version of the service does not recognise."
+      }
     ])
   })
 
@@ -155,7 +182,7 @@ describe('interpretError', () => {
       new FutureDefinitionError('a future failure mode')
     )
 
-    expect(result.causes).toEqual(['a future failure mode'])
+    expect(result.causes).toEqual([{ text: 'a future failure mode' }])
   })
 
   test('unknown errors produce no causes, technical only', () => {

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -7,30 +7,32 @@ import {
   UnknownComponentTypeError,
   UnknownPageControllerError
 } from '@defra/forms-engine-plugin/engine/errors.js'
-import { formDefinitionV2Schema } from '@defra/forms-model'
+import { formDefinitionV2Schema, formMetadataSchema } from '@defra/forms-model'
 
 import { interpretError } from '~/src/server/plugins/errorInterpretation.js'
 
 describe('interpretError', () => {
-  test('Joi definition validation errors produce getErrors-derived causes', () => {
-    const { error } = formDefinitionV2Schema.validate({}, { abortEarly: false })
+  test("metadata validation errors use Joi's own messages", () => {
+    const { error } = formMetadataSchema.validate({}, { abortEarly: false })
     if (!error) throw new Error('expected validation error')
 
     const result = interpretError(error)
 
-    expect(result.causes.length).toBeGreaterThan(0)
-    expect(result.technical).toContain('required')
+    expect(result.causes).toContain("'title' is required")
+    // metadata failures must not claim the form definition is broken
+    expect(result.causes.join(' ')).not.toContain('form definition')
   })
 
-  test('SchemaValidationError-wrapped Joi errors produce the same causes as raw ones', () => {
+  test('definition validation errors produce coded causes', () => {
     const { error } = formDefinitionV2Schema.validate({}, { abortEarly: false })
     if (!error) throw new Error('expected validation error')
 
-    const raw = interpretError(error)
-    const wrapped = interpretError(new SchemaValidationError(error))
+    const result = interpretError(new SchemaValidationError(error))
 
-    expect(wrapped.causes).toEqual(raw.causes)
-    expect(wrapped.technical).toContain('Invalid form definition:')
+    expect(result.causes).toEqual([
+      'There is a problem with the form definition. Check your changes and try again.'
+    ])
+    expect(result.technical).toContain('Invalid form definition:')
   })
 
   test('duplicate-value schema errors become distinct friendly causes with positions', () => {
@@ -66,7 +68,7 @@ describe('interpretError', () => {
     })
     if (!error) throw new Error('expected validation error')
 
-    const result = interpretError(error)
+    const result = interpretError(new SchemaValidationError(error))
 
     expect(result.causes).toEqual([
       'Each page must have a unique ID. Change the page ID to one that is not already used.',
@@ -93,25 +95,15 @@ describe('interpretError', () => {
     }
 
     const result = interpretError(
-      /** @type {import('joi').ValidationError} */ (
-        /** @type {unknown} */ (joiLikeCause)
+      new SchemaValidationError(
+        /** @type {import('joi').ValidationError} */ (
+          /** @type {unknown} */ (joiLikeCause)
+        )
       )
     )
 
     expect(result.causes).toEqual([
       'Remove the condition before deleting this page'
-    ])
-  })
-
-  test('uncoded schema errors collapse to a single generic cause', () => {
-    // an empty object fails several rules that all map to the Other code
-    const { error } = formDefinitionV2Schema.validate({}, { abortEarly: false })
-    if (!error) throw new Error('expected validation error')
-
-    const result = interpretError(error)
-
-    expect(result.causes).toEqual([
-      'There is a problem with the form definition. Check your changes and try again.'
     ])
   })
 

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -21,7 +21,7 @@ describe('interpretError', () => {
     const result = interpretError(new MetadataValidationError(error))
 
     expect(result.causes).toEqual([
-      "Some of the form's overview details are invalid. Go back to the form overview and check details such as contact information and email addresses."
+      "Some of the form's details are invalid. Go back to the form overview and check details such as contact information and email addresses."
     ])
     // the field-level detail still appears in the technical text
     expect(result.technical).toContain('"title" is required')

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -1,0 +1,107 @@
+import os from 'node:os'
+
+import {
+  ConditionBuildError,
+  InvalidFormDefinitionError,
+  UnknownComponentTypeError,
+  UnknownPageControllerError
+} from '@defra/forms-engine-plugin/engine/errors.js'
+import { formDefinitionV2Schema } from '@defra/forms-model'
+
+import { interpretError } from '~/src/server/plugins/errorInterpretation.js'
+
+describe('interpretError', () => {
+  test('Joi definition validation errors produce getErrors-derived causes', () => {
+    const { error } = formDefinitionV2Schema.validate({}, { abortEarly: false })
+
+    const result = interpretError(error)
+
+    expect(result.causes.length).toBeGreaterThan(0)
+    expect(result.technical).toContain('required')
+  })
+
+  test('ConditionBuildError names the condition', () => {
+    const error = new ConditionBuildError('Existing user', {
+      cause: new Error('parse error [1:24]: Expected EOF')
+    })
+
+    const result = interpretError(error)
+
+    expect(result.causes).toEqual([
+      "The condition 'Existing user' could not be understood. Check that it refers to the right question and answer option."
+    ])
+    expect(result.technical).toContain(
+      "Failed to build condition 'Existing user'"
+    )
+    expect(result.technical).toContain(
+      'Caused by: parse error [1:24]: Expected EOF'
+    )
+  })
+
+  test('UnknownPageControllerError names the controller', () => {
+    const result = interpretError(
+      new UnknownPageControllerError('NoSuchPageController')
+    )
+
+    expect(result.causes).toEqual([
+      "This form uses a page type ('NoSuchPageController') this version of the service does not recognise."
+    ])
+  })
+
+  test('UnknownComponentTypeError names the component type', () => {
+    const result = interpretError(new UnknownComponentTypeError('NopeField'))
+
+    expect(result.causes).toEqual([
+      "This form uses a question type ('NopeField') this version of the service does not recognise."
+    ])
+  })
+
+  test('unrecognised InvalidFormDefinitionError subclasses fall back to their message', () => {
+    class FutureDefinitionError extends InvalidFormDefinitionError {}
+    const result = interpretError(
+      new FutureDefinitionError('a future failure mode')
+    )
+
+    expect(result.causes).toEqual(['a future failure mode'])
+  })
+
+  test('unknown errors produce no causes, technical only', () => {
+    const result = interpretError(new Error('something else entirely'))
+
+    expect(result.causes).toEqual([])
+    expect(result.technical).toBe('something else entirely')
+  })
+
+  test('cwd and homedir are redacted by literal replacement', () => {
+    const error = new Error(
+      `Cannot find module '${process.cwd()}/node_modules/x' from '${os.homedir()}/y'`
+    )
+
+    const result = interpretError(error)
+
+    expect(result.technical).toBe(
+      "Cannot find module './node_modules/x' from '~/y'"
+    )
+  })
+
+  test('path-like text outside the known prefixes is left untouched', () => {
+    const result = interpretError(new Error('open /etc/whatever failed'))
+
+    expect(result.technical).toBe('open /etc/whatever failed')
+  })
+
+  test('long technical text is truncated at 2000 characters', () => {
+    const result = interpretError(new Error('x'.repeat(3000)))
+
+    expect(result.technical).toHaveLength(2000 + '… (truncated)'.length)
+    expect(result.technical.endsWith('… (truncated)')).toBe(true)
+  })
+
+  test('stack content never appears in technical text', () => {
+    const error = new Error('boom')
+
+    const result = interpretError(error)
+
+    expect(result.technical).not.toContain('at ')
+  })
+})

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -12,13 +12,17 @@ import { formDefinitionV2Schema, formMetadataSchema } from '@defra/forms-model'
 import { interpretError } from '~/src/server/plugins/errorInterpretation.js'
 
 describe('interpretError', () => {
-  test("metadata validation errors use Joi's own messages", () => {
+  test('metadata validation errors point the author at the form overview', () => {
     const { error } = formMetadataSchema.validate({}, { abortEarly: false })
     if (!error) throw new Error('expected validation error')
 
     const result = interpretError(error)
 
-    expect(result.causes).toContain("'title' is required")
+    expect(result.causes).toEqual([
+      "Some of the form's overview details are invalid. Go back to the form overview and check details such as contact information and email addresses."
+    ])
+    // the field-level detail still appears in the technical text
+    expect(result.technical).toContain('"title" is required')
     // metadata failures must not claim the form definition is broken
     expect(result.causes.join(' ')).not.toContain('form definition')
   })

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -33,6 +33,87 @@ describe('interpretError', () => {
     expect(wrapped.technical).toContain('Invalid form definition:')
   })
 
+  test('duplicate-value schema errors become distinct friendly causes with positions', () => {
+    const definition = {
+      name: 'x',
+      engine: 'V2',
+      schema: 2,
+      startPage: '/summary',
+      pages: [
+        {
+          id: '449c053b-9201-4312-9a75-187afc6ba48b',
+          path: '/one',
+          title: 'One',
+          components: [],
+          next: []
+        },
+        {
+          id: '449c053b-9201-4312-9a75-187afc6ba48c',
+          path: '/summary',
+          title: 'Summary',
+          controller: 'SummaryPageController',
+          components: []
+        }
+      ],
+      lists: [],
+      sections: [],
+      conditions: []
+    }
+    definition.pages.push(structuredClone(definition.pages[0]))
+
+    const { error } = formDefinitionV2Schema.validate(definition, {
+      abortEarly: false
+    })
+    if (!error) throw new Error('expected validation error')
+
+    const result = interpretError(error)
+
+    expect(result.causes).toEqual([
+      'Two pages have the same ID (entries 1 and 3)',
+      'Two pages have the same path (entries 1 and 3)'
+    ])
+  })
+
+  test('reference schema errors become friendly causes', () => {
+    const joiLikeCause = {
+      isJoi: true,
+      message: 'x',
+      details: [
+        {
+          message:
+            '"conditions[0].items[0].componentId" must be [ref:root:pages]',
+          path: ['conditions', 0, 'items', 0, 'componentId'],
+          context: {
+            errorType: 'ref',
+            errorCode: 'ref_condition_component_id',
+            key: 'componentId'
+          }
+        }
+      ]
+    }
+
+    const result = interpretError(
+      /** @type {import('joi').ValidationError} */ (
+        /** @type {unknown} */ (joiLikeCause)
+      )
+    )
+
+    expect(result.causes).toEqual([
+      'A condition refers to a question that does not exist'
+    ])
+  })
+
+  test('unmapped schema errors fall back to the cleaned Joi message, deduplicated', () => {
+    const { error } = formDefinitionV2Schema.validate({}, { abortEarly: false })
+    if (!error) throw new Error('expected validation error')
+
+    const result = interpretError(error)
+
+    expect(result.causes).toContain("'pages' is required")
+    expect(result.causes).not.toContain('"pages" is required')
+    expect(new Set(result.causes).size).toBe(result.causes.length)
+  })
+
   test('ConditionBuildError names the condition', () => {
     const error = new ConditionBuildError('Existing user', {
       cause: new Error('parse error [1:24]: Expected EOF')
@@ -41,7 +122,7 @@ describe('interpretError', () => {
     const result = interpretError(error)
 
     expect(result.causes).toEqual([
-      "The condition 'Existing user' could not be understood. Check that it refers to the right question and answer option."
+      "The condition 'Existing user' is invalid. Check that it refers to the right question and answer option."
     ])
     expect(result.technical).toContain(
       "Failed to build condition 'Existing user'"

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -69,8 +69,8 @@ describe('interpretError', () => {
     const result = interpretError(error)
 
     expect(result.causes).toEqual([
-      'Two pages have the same ID (entries 1 and 3)',
-      'Two pages have the same path (entries 1 and 3)'
+      'Each page must have a unique ID. Change the page ID to one that is not already used.',
+      'Each page must have a unique path. Change the page path to one that is not already used.'
     ])
   })
 
@@ -99,19 +99,20 @@ describe('interpretError', () => {
     )
 
     expect(result.causes).toEqual([
-      'A condition refers to a question that does not exist'
+      'Remove the condition before deleting this page'
     ])
   })
 
-  test('unmapped schema errors fall back to the cleaned Joi message, deduplicated', () => {
+  test('uncoded schema errors collapse to a single generic cause', () => {
+    // an empty object fails several rules that all map to the Other code
     const { error } = formDefinitionV2Schema.validate({}, { abortEarly: false })
     if (!error) throw new Error('expected validation error')
 
     const result = interpretError(error)
 
-    expect(result.causes).toContain("'pages' is required")
-    expect(result.causes).not.toContain('"pages" is required')
-    expect(new Set(result.causes).size).toBe(result.causes.length)
+    expect(result.causes).toEqual([
+      'There is a problem with the form definition. Check your changes and try again.'
+    ])
   })
 
   test('ConditionBuildError names the condition', () => {

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -9,7 +9,10 @@ import {
 } from '@defra/forms-engine-plugin/engine/errors.js'
 import { formDefinitionV2Schema, formMetadataSchema } from '@defra/forms-model'
 
-import { interpretError } from '~/src/server/plugins/errorInterpretation.js'
+import {
+  interpretError,
+  isFormConfigurationError
+} from '~/src/server/plugins/errorInterpretation.js'
 import { MetadataValidationError } from '~/src/server/services/errors.js'
 
 describe('interpretError', () => {
@@ -195,5 +198,26 @@ describe('interpretError', () => {
     const result = interpretError(error)
 
     expect(result.technical).not.toContain('at ')
+  })
+})
+
+describe('isFormConfigurationError', () => {
+  test('recognises definition, engine and metadata errors', () => {
+    const { error } = formMetadataSchema.validate({}, { abortEarly: false })
+    if (!error) throw new Error('expected validation error')
+
+    expect(isFormConfigurationError(new SchemaValidationError(error))).toBe(
+      true
+    )
+    expect(
+      isFormConfigurationError(new UnknownPageControllerError('Nope'))
+    ).toBe(true)
+    expect(isFormConfigurationError(new MetadataValidationError(error))).toBe(
+      true
+    )
+  })
+
+  test('rejects generic errors, such as an outage', () => {
+    expect(isFormConfigurationError(new Error('socket hang up'))).toBe(false)
   })
 })

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -3,6 +3,7 @@ import os from 'node:os'
 import {
   ConditionBuildError,
   InvalidFormDefinitionError,
+  SchemaValidationError,
   UnknownComponentTypeError,
   UnknownPageControllerError
 } from '@defra/forms-engine-plugin/engine/errors.js'
@@ -19,6 +20,17 @@ describe('interpretError', () => {
 
     expect(result.causes.length).toBeGreaterThan(0)
     expect(result.technical).toContain('required')
+  })
+
+  test('SchemaValidationError-wrapped Joi errors produce the same causes as raw ones', () => {
+    const { error } = formDefinitionV2Schema.validate({}, { abortEarly: false })
+    if (!error) throw new Error('expected validation error')
+
+    const raw = interpretError(error)
+    const wrapped = interpretError(new SchemaValidationError(error))
+
+    expect(wrapped.causes).toEqual(raw.causes)
+    expect(wrapped.technical).toContain('Invalid form definition:')
   })
 
   test('ConditionBuildError names the condition', () => {

--- a/src/server/plugins/errorInterpretation.test.js
+++ b/src/server/plugins/errorInterpretation.test.js
@@ -45,7 +45,7 @@ describe('interpretError', () => {
     )
 
     expect(result.causes).toEqual([
-      "This form uses a page type ('NoSuchPageController') this version of the service does not recognise."
+      'This form uses a page type this version of the service does not recognise.'
     ])
   })
 

--- a/src/server/plugins/errorPages.ts
+++ b/src/server/plugins/errorPages.ts
@@ -1,3 +1,4 @@
+import { checkFormStatus } from '@defra/forms-engine-plugin/engine/helpers.js'
 import {
   type Request,
   type ResponseToolkit,
@@ -5,6 +6,7 @@ import {
 } from '@hapi/hapi'
 import { StatusCodes } from 'http-status-codes'
 
+import { interpretError } from '~/src/server/plugins/errorInterpretation.js'
 import { getAllLanguages, resolveLanguage } from '~/src/server/utils/utils.js'
 
 /*
@@ -62,8 +64,18 @@ export default {
             `[httpError] HTTP ${statusCode} error occurred - ${response.message} - path: ${request.path} - method: ${request.method}`
           )
 
+          const { isPreview } = checkFormStatus(
+            request.params as Parameters<typeof checkFormStatus>[0]
+          )
+
+          const errorDetails =
+            isPreview &&
+            statusCode >= StatusCodes.INTERNAL_SERVER_ERROR.valueOf()
+              ? interpretError(response)
+              : undefined
+
           // The return the `500` view
-          return h.view('500', viewModel).code(statusCode)
+          return h.view('500', { ...viewModel, errorDetails }).code(statusCode)
         }
         return h.continue
       })

--- a/src/server/plugins/errorPages.ts
+++ b/src/server/plugins/errorPages.ts
@@ -1,4 +1,5 @@
 import { checkFormStatus } from '@defra/forms-engine-plugin/engine/helpers.js'
+import { type FormParams } from '@defra/forms-engine-plugin/types'
 import {
   type Request,
   type ResponseToolkit,
@@ -64,18 +65,20 @@ export default {
             `[httpError] HTTP ${statusCode} error occurred - ${response.message} - path: ${request.path} - method: ${request.method}`
           )
 
-          const { isPreview } = checkFormStatus(
-            request.params as Parameters<typeof checkFormStatus>[0]
-          )
-
-          const errorDetails =
-            isPreview &&
-            statusCode >= StatusCodes.INTERNAL_SERVER_ERROR.valueOf()
-              ? interpretError(response)
-              : undefined
+          const { isPreview } = checkFormStatus(request.params as FormParams)
 
           // The return the `500` view
-          return h.view('500', { ...viewModel, errorDetails }).code(statusCode)
+          if (isPreview) {
+            const errorDetails =
+              statusCode >= StatusCodes.INTERNAL_SERVER_ERROR.valueOf()
+                ? interpretError(response)
+                : undefined
+            return h
+              .view('500-preview', { ...viewModel, errorDetails })
+              .code(statusCode)
+          }
+
+          return h.view('500', { ...viewModel }).code(statusCode)
         }
         return h.continue
       })

--- a/src/server/plugins/errorPages.ts
+++ b/src/server/plugins/errorPages.ts
@@ -78,10 +78,13 @@ export default {
             statusCode >= StatusCodes.INTERNAL_SERVER_ERROR.valueOf() &&
             isFormConfigurationError(response)
           ) {
+            // This page is English-only, so hide the language toggle
             return h
               .view('500-preview', {
                 ...viewModel,
-                errorDetails: interpretError(response)
+                errorDetails: interpretError(response),
+                languages: [],
+                translator: undefined
               })
               .code(statusCode)
           }

--- a/src/server/plugins/errorPages.ts
+++ b/src/server/plugins/errorPages.ts
@@ -7,7 +7,10 @@ import {
 } from '@hapi/hapi'
 import { StatusCodes } from 'http-status-codes'
 
-import { interpretError } from '~/src/server/plugins/errorInterpretation.js'
+import {
+  interpretError,
+  isFormConfigurationError
+} from '~/src/server/plugins/errorInterpretation.js'
 import { getAllLanguages, resolveLanguage } from '~/src/server/utils/utils.js'
 
 /*
@@ -67,14 +70,19 @@ export default {
 
           const { isPreview } = checkFormStatus(request.params as FormParams)
 
-          // The return the `500` view
-          if (isPreview) {
-            const errorDetails =
-              statusCode >= StatusCodes.INTERNAL_SERVER_ERROR.valueOf()
-                ? interpretError(response)
-                : undefined
+          // Only show the preview error page for known form-configuration
+          // problems. A generic failure (an outage, a bug) must not be
+          // dressed up as a problem with the form.
+          if (
+            isPreview &&
+            statusCode >= StatusCodes.INTERNAL_SERVER_ERROR.valueOf() &&
+            isFormConfigurationError(response)
+          ) {
             return h
-              .view('500-preview', { ...viewModel, errorDetails })
+              .view('500-preview', {
+                ...viewModel,
+                errorDetails: interpretError(response)
+              })
               .code(statusCode)
           }
 

--- a/src/server/plugins/errorPages.ts
+++ b/src/server/plugins/errorPages.ts
@@ -78,7 +78,7 @@ export default {
               .code(statusCode)
           }
 
-          return h.view('500', { ...viewModel }).code(statusCode)
+          return h.view('500', viewModel).code(statusCode)
         }
         return h.continue
       })

--- a/src/server/services/errors.js
+++ b/src/server/services/errors.js
@@ -1,0 +1,14 @@
+/**
+ * Thrown when form metadata returned by the manager fails schema validation.
+ * The raw Joi error is kept as `cause`; the message carries Joi's own summary
+ * so log lines still say which fields are wrong.
+ */
+export class MetadataValidationError extends Error {
+  /**
+   * @param {import('joi').ValidationError} cause
+   */
+  constructor(cause) {
+    super(`Invalid form metadata: ${cause.message}`, { cause })
+    this.name = 'MetadataValidationError'
+  }
+}

--- a/src/server/services/formsService.js
+++ b/src/server/services/formsService.js
@@ -2,6 +2,7 @@ import { FormStatus } from '@defra/forms-engine-plugin/types'
 import { formMetadataSchema } from '@defra/forms-model'
 
 import { config } from '~/src/config/index.js'
+import { MetadataValidationError } from '~/src/server/services/errors.js'
 import { decryptSecret } from '~/src/server/services/helpers/crypto.js'
 import { getJson, postJson } from '~/src/server/services/httpService.js'
 
@@ -23,7 +24,7 @@ export async function getFormMetadata(slug) {
   const result = formMetadataSchema.validate(metadata, { allowUnknown: true })
 
   if (result.error) {
-    throw result.error
+    throw new MetadataValidationError(result.error)
   }
 
   return result.value
@@ -44,7 +45,7 @@ export async function getFormMetadataById(formId) {
   const result = formMetadataSchema.validate(metadata, { allowUnknown: true })
 
   if (result.error) {
-    throw result.error
+    throw new MetadataValidationError(result.error)
   }
 
   return result.value

--- a/src/server/views/404.html
+++ b/src/server/views/404.html
@@ -1,5 +1,7 @@
 {% extends 'layout.html' %}
 
+{% set pageTitle = tR('errors.notFound.heading') %}
+
 {% block content %}
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">

--- a/src/server/views/500-preview.html
+++ b/src/server/views/500-preview.html
@@ -68,3 +68,4 @@
   </div>
 </div>
 {% endblock %}
+

--- a/src/server/views/500-preview.html
+++ b/src/server/views/500-preview.html
@@ -1,5 +1,7 @@
 {% extends 'layout.html' %}
 
+{% set pageTitle = tR('errors.previewError.heading') %}
+
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set technicalDetails %}

--- a/src/server/views/500-preview.html
+++ b/src/server/views/500-preview.html
@@ -9,10 +9,33 @@
 <pre class="app-error-details__technical"><code class="govuk-!-font-size-16">{{ errorDetails.technical }}</code></pre>
 {% endset %}
 
+{% set causeItems %}
+{% if errorDetails.causes[0].itemsIntro %}
+<p class="govuk-body">{{ errorDetails.causes[0].itemsIntro }}</p>
+{% endif %}
+{% if errorDetails.causes[0].items | length %}
+<ul class="govuk-list govuk-list--bullet">
+  {% for item in errorDetails.causes[0].items %}
+  <li>{{ item }}</li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endset %}
+
 {% set multipleCauses %}
 <ul class="govuk-list govuk-list--bullet">
   {% for cause in errorDetails.causes %}
-  <li>{{ cause }}</li>
+  <li>
+    {{ cause.text }}
+    {% if cause.itemsIntro %}<p class="govuk-body">{{ cause.itemsIntro }}</p>{% endif %}
+    {% if cause.items | length %}
+    <ul class="govuk-list govuk-list--bullet">
+      {% for item in cause.items %}
+      <li>{{ item }}</li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+  </li>
   {% endfor %}
 </ul>
 {% endset %}
@@ -31,7 +54,8 @@
           {% if errorDetails.causes | length > 1 %}
             {{ multipleCauses | safe }}
           {% else %}
-            <p class="govuk-body">{{ errorDetails.causes[0] }}</p>
+            <p class="govuk-body">{{ errorDetails.causes[0].text }}</p>
+            {{ causeItems | safe }}
           {% endif %}
         {% endif %}
 

--- a/src/server/views/500-preview.html
+++ b/src/server/views/500-preview.html
@@ -6,8 +6,7 @@
 
 {% set technicalDetails %}
 <p>{{ tR('errors.previewError.technical.support') }}</p>
-<pre
-  style="background-color: #f3f2f1; border: 1px solid #b1b4b6; padding: 15px; overflow-x: auto;"><code class="govuk-!-font-size-16">{{ errorDetails.technical }}</code></pre>
+<pre class="app-error-details__technical"><code class="govuk-!-font-size-16">{{ errorDetails.technical }}</code></pre>
 {% endset %}
 
 {% set multipleCauses %}

--- a/src/server/views/500-preview.html
+++ b/src/server/views/500-preview.html
@@ -1,0 +1,45 @@
+{% extends 'layout.html' %}
+
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% set technicalDetails %}
+<p>{{ tR('errors.previewError.technical.support') }}</p>
+<pre
+  style="background-color: #f3f2f1; border: 1px solid #b1b4b6; padding: 15px; overflow-x: auto;"><code class="govuk-!-font-size-16">{{ errorDetails.technical }}</code></pre>
+{% endset %}
+
+{% set multipleCauses %}
+<ul class="govuk-list govuk-list--bullet">
+  {% for cause in errorDetails.causes %}
+  <li>{{ cause }}</li>
+  {% endfor %}
+</ul>
+{% endset %}
+
+{% block content %}
+<div class="govuk-width-container">
+  <div class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">{{ tR('errors.previewError.heading') }}</h1>
+
+        <p class="govuk-body">{{ tR('errors.previewError.intro') }}</p>
+
+        {% if errorDetails.causes | length %}
+        <h2 class="govuk-heading-m">{{ tR('errors.previewError.summary') }}</h2>
+          {% if errorDetails.causes | length > 1 %}
+            {{ multipleCauses | safe }}
+          {% else %}
+            <p class="govuk-body">{{ errorDetails.causes[0] }}</p>
+          {% endif %}
+        {% endif %}
+
+        {{ govukDetails({
+        summaryText: tR('errors.previewError.technical.revealText'),
+        html: technicalDetails
+        }) }}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/server/views/500.html
+++ b/src/server/views/500.html
@@ -1,7 +1,5 @@
 {% extends 'layout.html' %}
 
-{% from "govuk/components/details/macro.njk" import govukDetails %}
-
 {% block content %}
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">
@@ -13,25 +11,6 @@
             <li>{{ tR('errors.serverError.tryBack') }}</li>
             <li>{{ tR('errors.serverError.contact') | safe }}</li>
           </ul>
-
-          {% if errorDetails %}
-            {% set errorDetailsHtml %}
-              <p class="govuk-body">{{ tR('errors.serverError.details.intro') }}</p>
-              {% if errorDetails.causes | length %}
-                <ul class="govuk-list govuk-list--bullet">
-                  {% for cause in errorDetails.causes %}
-                    <li>{{ cause }}</li>
-                  {% endfor %}
-                </ul>
-              {% endif %}
-              <h2 class="govuk-heading-s">{{ tR('errors.serverError.details.technicalHeading') }}</h2>
-              <pre style="background-color: #f3f2f1; border: 1px solid #b1b4b6; padding: 15px; overflow-x: auto;"><code class="govuk-!-font-size-16">{{ errorDetails.technical }}</code></pre>
-            {% endset %}
-            {{ govukDetails({
-              summaryText: tR('errors.serverError.details.summary'),
-              html: errorDetailsHtml
-            }) }}
-          {% endif %}
         </div>
       </div>
     </div>

--- a/src/server/views/500.html
+++ b/src/server/views/500.html
@@ -1,5 +1,7 @@
 {% extends 'layout.html' %}
 
+{% set pageTitle = tR('errors.serverError.heading') %}
+
 {% block content %}
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">

--- a/src/server/views/500.html
+++ b/src/server/views/500.html
@@ -1,5 +1,7 @@
 {% extends 'layout.html' %}
 
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
 {% block content %}
   <div class="govuk-width-container">
     <div class="govuk-main-wrapper">
@@ -11,6 +13,25 @@
             <li>{{ tR('errors.serverError.tryBack') }}</li>
             <li>{{ tR('errors.serverError.contact') | safe }}</li>
           </ul>
+
+          {% if errorDetails %}
+            {% set errorDetailsHtml %}
+              <p class="govuk-body-s">{{ tR('errors.serverError.details.intro') }}</p>
+              {% if errorDetails.causes | length %}
+                <ul class="govuk-list govuk-list--bullet">
+                  {% for cause in errorDetails.causes %}
+                    <li>{{ cause }}</li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+              <h2 class="govuk-heading-s">{{ tR('errors.serverError.details.technicalHeading') }}</h2>
+              <pre><code class="govuk-!-font-size-16">{{ errorDetails.technical }}</code></pre>
+            {% endset %}
+            {{ govukDetails({
+              summaryText: tR('errors.serverError.details.summary'),
+              html: errorDetailsHtml
+            }) }}
+          {% endif %}
         </div>
       </div>
     </div>

--- a/src/server/views/500.html
+++ b/src/server/views/500.html
@@ -16,7 +16,7 @@
 
           {% if errorDetails %}
             {% set errorDetailsHtml %}
-              <p class="govuk-body-s">{{ tR('errors.serverError.details.intro') }}</p>
+              <p class="govuk-body">{{ tR('errors.serverError.details.intro') }}</p>
               {% if errorDetails.causes | length %}
                 <ul class="govuk-list govuk-list--bullet">
                   {% for cause in errorDetails.causes %}
@@ -25,7 +25,7 @@
                 </ul>
               {% endif %}
               <h2 class="govuk-heading-s">{{ tR('errors.serverError.details.technicalHeading') }}</h2>
-              <pre><code class="govuk-!-font-size-16">{{ errorDetails.technical }}</code></pre>
+              <pre style="background-color: #f3f2f1; border: 1px solid #b1b4b6; padding: 15px; overflow-x: auto;"><code class="govuk-!-font-size-16">{{ errorDetails.technical }}</code></pre>
             {% endset %}
             {{ govukDetails({
               summaryText: tR('errors.serverError.details.summary'),

--- a/test/fixtures/definitions.js
+++ b/test/fixtures/definitions.js
@@ -131,6 +131,23 @@ export function buildUnknownControllerDefinition() {
 }
 
 /**
+ * Schema-valid (component types are free strings in the schema), but the
+ * question uses a type the engine has no component class for.
+ * @returns {FormDefinition}
+ */
+export function buildUnknownComponentDefinition() {
+  const definition = buildDefinition()
+
+  definition.name = 'Unknown component fixture'
+  const questionPage = /** @type {PageQuestion} */ (definition.pages[0])
+  questionPage.components[0].type = /** @type {ComponentType} */ (
+    'MyUnknownField'
+  )
+
+  return definition
+}
+
+/**
  * Fails schema validation: the question page appears twice, violating the
  * pages uniqueness rules.
  * @returns {FormDefinition}
@@ -145,5 +162,5 @@ export function buildSchemaInvalidDefinition() {
 }
 
 /**
- * @import { ConditionType, ControllerType, FormDefinition, OperatorName, PageQuestion } from '@defra/forms-model'
+ * @import { ComponentType, ConditionType, ControllerType, FormDefinition, OperatorName, PageQuestion } from '@defra/forms-model'
  */

--- a/test/fixtures/definitions.js
+++ b/test/fixtures/definitions.js
@@ -1,0 +1,149 @@
+/**
+ * Broken form definitions for error-page tests. Each builder returns a fresh
+ * object, so tests can mutate their copy freely without affecting each other.
+ * Mirrors the engine plugin's `__stubs__/definitions.ts`.
+ */
+
+const USER_TYPE_LIST_ID = '4fa26e9c-07cf-47cd-a9dd-5cec0dd3f544'
+const YES_NO_COMPONENT_ID = 'a7c0242f-2a31-45b2-8c71-ff2ac7f53288'
+const EXISTING_USER_ITEM_ID = '55fe0067-d011-4d33-886c-e1aa266637c3'
+
+/**
+ * A minimal, schema-valid V2 definition: one YesNo question page and a
+ * summary page.
+ * @returns {FormDefinition}
+ */
+export function buildDefinition() {
+  return /** @type {FormDefinition} */ (
+    /** @type {unknown} */ ({
+      name: 'Stub definition',
+      engine: 'V2',
+      schema: 2,
+      startPage: '/summary',
+      pages: [
+        {
+          id: '449c053b-9201-4312-9a75-187afc6ba48b',
+          path: '/licence',
+          title: 'Licence',
+          components: [
+            {
+              id: YES_NO_COMPONENT_ID,
+              name: 'xVrYaJ',
+              type: 'YesNoField',
+              title: 'Do you have a licence?',
+              shortDescription: 'Licence',
+              options: { required: true },
+              schema: {}
+            }
+          ],
+          next: []
+        },
+        {
+          id: '449c053b-9201-4312-9a75-187afc6ba48c',
+          path: '/summary',
+          title: 'Summary',
+          controller: 'SummaryPageController',
+          components: [],
+          next: []
+        }
+      ],
+      lists: [],
+      sections: [],
+      conditions: []
+    })
+  )
+}
+
+/**
+ * Passes schema validation but cannot be used by the engine: a ListItemRef
+ * condition points at the YesNoField (boolean), so the condition cannot be
+ * built. Distilled from a real production incident.
+ * @returns {FormDefinition}
+ */
+export function buildBrokenConditionDefinition() {
+  const definition = buildDefinition()
+
+  definition.name = 'Broken condition fixture'
+
+  const questionPage = /** @type {PageQuestion} */ (definition.pages[0])
+  // A YesNoField cannot legitimately carry a custom list — that is the
+  // corruption this fixture models — so the types have no `list` property
+  // here and a cast is required.
+  const component = /** @type {{ list?: string }} */ (
+    questionPage.components[0]
+  )
+  component.list = USER_TYPE_LIST_ID
+  definition.lists = [
+    {
+      id: USER_TYPE_LIST_ID,
+      name: 'XtfRYR',
+      title: 'User type list',
+      type: 'string',
+      items: [
+        {
+          id: EXISTING_USER_ITEM_ID,
+          text: 'existing user',
+          value: 'existing user'
+        },
+        {
+          id: '2277c7e5-7fef-46c6-993b-d294116d6d6b',
+          text: 'new user',
+          value: 'new user'
+        }
+      ]
+    }
+  ]
+  definition.conditions = [
+    {
+      id: '3f9d3a35-6dee-4706-806c-3f776129f631',
+      displayName: 'Existing user',
+      items: [
+        {
+          id: '7d7f58ee-c860-4d24-8a13-de5cb9af53d8',
+          componentId: YES_NO_COMPONENT_ID,
+          operator: /** @type {OperatorName} */ ('is'),
+          type: /** @type {ConditionType} */ ('ListItemRef'),
+          value: {
+            listId: USER_TYPE_LIST_ID,
+            itemId: [EXISTING_USER_ITEM_ID]
+          }
+        }
+      ]
+    }
+  ]
+
+  return definition
+}
+
+/**
+ * Schema-valid, but the first page names a controller that does not exist.
+ * @returns {FormDefinition}
+ */
+export function buildUnknownControllerDefinition() {
+  const definition = buildDefinition()
+
+  definition.name = 'Unknown controller fixture'
+  definition.pages[0].controller = /** @type {ControllerType} */ (
+    'NoSuchPageController'
+  )
+
+  return definition
+}
+
+/**
+ * Fails schema validation: the question page appears twice, violating the
+ * pages uniqueness rules.
+ * @returns {FormDefinition}
+ */
+export function buildSchemaInvalidDefinition() {
+  const definition = buildDefinition()
+
+  definition.name = 'Schema invalid fixture'
+  definition.pages.push(buildDefinition().pages[0])
+
+  return definition
+}
+
+/**
+ * @import { ConditionType, ControllerType, FormDefinition, OperatorName, PageQuestion } from '@defra/forms-model'
+ */

--- a/test/form/error-pages.test.js
+++ b/test/form/error-pages.test.js
@@ -168,10 +168,20 @@ describe('Server error pages', () => {
         .mocked(getFormDefinition)
         .mockResolvedValue(buildBrokenConditionDefinition())
 
-      const { container } = await renderResponse(server, {
+      const { container, response } = await renderResponse(server, {
         method: 'GET',
         url: PREVIEW_URL
       })
+
+      // anchor on the preview error page itself, so the absence assertions
+      // below cannot pass against some other page
+      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(
+        container.getByRole('heading', {
+          name: "This form can't be previewed",
+          level: 1
+        })
+      ).toBeInTheDocument()
 
       expect(
         container.queryByRole('link', { name: 'Cymraeg' })
@@ -190,6 +200,12 @@ describe('Server error pages', () => {
       })
 
       expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(
+        container.getByRole('heading', {
+          name: "This form can't be previewed",
+          level: 1
+        })
+      ).toBeInTheDocument()
 
       const causes = container
         .getAllByRole('listitem')
@@ -208,10 +224,18 @@ describe('Server error pages', () => {
         .mocked(getFormDefinition)
         .mockResolvedValue(buildBrokenConditionDefinition())
 
-      const { container } = await renderResponse(server, {
+      const { container, response } = await renderResponse(server, {
         method: 'GET',
         url: PREVIEW_URL
       })
+
+      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(
+        container.getByRole('heading', {
+          name: "This form can't be previewed",
+          level: 1
+        })
+      ).toBeInTheDocument()
 
       const $reveal = container.getByText('Technical details')
       expect($reveal).toBeInTheDocument()
@@ -267,6 +291,12 @@ describe('Server error pages', () => {
       })
 
       expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(
+        container.getByRole('heading', {
+          name: "This form can't be previewed",
+          level: 1
+        })
+      ).toBeInTheDocument()
 
       const $cause = container.getByText(
         "Some of the form's details are not configured correctly. Go back to the form overview and check details such as contact information and email addresses."

--- a/test/form/error-pages.test.js
+++ b/test/form/error-pages.test.js
@@ -71,6 +71,11 @@ describe('Server error pages', () => {
       })
       expect($heading).toBeInTheDocument()
 
+      // the <title> lives in <head>, which renderResponse does not mount
+      expect(response.result).toContain(
+        '<title>Sorry, there is a problem with the service - '
+      )
+
       expect(
         container.queryByRole('heading', { name: 'What went wrong' })
       ).not.toBeInTheDocument()
@@ -123,6 +128,11 @@ describe('Server error pages', () => {
         level: 1
       })
       expect($heading).toBeInTheDocument()
+
+      // the <title> lives in <head>, which renderResponse does not mount
+      expect(response.result).toContain(
+        '<title>This form cannot be previewed - '
+      )
 
       const $causesHeading = container.getByRole('heading', {
         name: 'What went wrong',

--- a/test/form/error-pages.test.js
+++ b/test/form/error-pages.test.js
@@ -103,7 +103,7 @@ describe('Server error pages', () => {
 
       expect(
         container.queryByRole('heading', {
-          name: 'This form cannot be previewed'
+          name: "This form can't be previewed"
         })
       ).not.toBeInTheDocument()
       expect(container.queryByText('Technical details')).not.toBeInTheDocument()
@@ -124,14 +124,14 @@ describe('Server error pages', () => {
       expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
 
       const $heading = container.getByRole('heading', {
-        name: 'This form cannot be previewed',
+        name: "This form can't be previewed",
         level: 1
       })
       expect($heading).toBeInTheDocument()
 
       // the <title> lives in <head>, which renderResponse does not mount
       expect(response.result).toContain(
-        '<title>This form cannot be previewed - '
+        '<title>This form can&#39;t be previewed - '
       )
 
       const $causesHeading = container.getByRole('heading', {
@@ -141,10 +141,21 @@ describe('Server error pages', () => {
       expect($causesHeading).toBeInTheDocument()
 
       const $cause = container.getByText(
-        "The condition 'Existing user' is invalid. Check that it refers to the right question and answer option."
+        `The condition "Existing user" isn't configured correctly. Open the condition and check that:`
       )
       expect($cause).toBeInTheDocument()
       expect($cause.tagName).toBe('P')
+
+      const checks = container
+        .getAllByRole('listitem')
+        .map(($item) => $item.textContent.trim())
+      expect(checks).toEqual(
+        expect.arrayContaining([
+          'the question it refers to still exists',
+          'the correct answer option is selected',
+          'the condition has been completed and saved'
+        ])
+      )
     })
 
     it('shows multiple causes as a bulleted list', async () => {
@@ -212,7 +223,7 @@ describe('Server error pages', () => {
 
       expect(
         container.queryByRole('heading', {
-          name: 'This form cannot be previewed'
+          name: "This form can't be previewed"
         })
       ).not.toBeInTheDocument()
       expect(container.queryByText('Technical details')).not.toBeInTheDocument()
@@ -237,9 +248,21 @@ describe('Server error pages', () => {
       expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
 
       const $cause = container.getByText(
-        "Some of the form's details are invalid. Go back to the form overview and check details such as contact information and email addresses."
+        "Some of the form's details are not configured correctly. Go back to the form overview and check details such as contact information and email addresses."
       )
       expect($cause).toBeInTheDocument()
+
+      expect(container.getByText('Check that:')).toBeInTheDocument()
+      const checks = container
+        .getAllByRole('listitem')
+        .map(($item) => $item.textContent.trim())
+      expect(checks).toEqual(
+        expect.arrayContaining([
+          'notification email addresses are entered correctly',
+          'contact information has been completed',
+          'any recent changes to the form details have been saved'
+        ])
+      )
 
       const $technical = container.getByText(
         /"notificationEmail" must be a valid email/

--- a/test/form/error-pages.test.js
+++ b/test/form/error-pages.test.js
@@ -76,6 +76,33 @@ describe('Server error pages', () => {
       ).not.toBeInTheDocument()
       expect(container.queryByText('Technical details')).not.toBeInTheDocument()
     })
+
+    it('shows the generic error page for generic failures too', async () => {
+      // e.g. a backend outage while fetching the definition
+      jest
+        .mocked(getFormDefinition)
+        .mockRejectedValue(new Error('socket hang up'))
+
+      const { container, response } = await renderResponse(server, {
+        method: 'GET',
+        url: `${FORM_PREFIX}/${SLUG}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+
+      const $heading = container.getByRole('heading', {
+        name: 'Sorry, there is a problem with the service',
+        level: 1
+      })
+      expect($heading).toBeInTheDocument()
+
+      expect(
+        container.queryByRole('heading', {
+          name: 'This form cannot be previewed'
+        })
+      ).not.toBeInTheDocument()
+      expect(container.queryByText('Technical details')).not.toBeInTheDocument()
+    })
   })
 
   describe('Preview 500 page', () => {

--- a/test/form/error-pages.test.js
+++ b/test/form/error-pages.test.js
@@ -80,6 +80,11 @@ describe('Server error pages', () => {
         container.queryByRole('heading', { name: 'What went wrong' })
       ).not.toBeInTheDocument()
       expect(container.queryByText('Technical details')).not.toBeInTheDocument()
+
+      // the language toggle stays on public error pages
+      expect(
+        container.getByRole('link', { name: 'Cymraeg' })
+      ).toBeInTheDocument()
     })
 
     it('shows the generic error page for generic failures too', async () => {
@@ -156,6 +161,22 @@ describe('Server error pages', () => {
           'the condition has been completed and saved'
         ])
       )
+    })
+
+    it('hides the language toggle (the page is English-only)', async () => {
+      jest
+        .mocked(getFormDefinition)
+        .mockResolvedValue(buildBrokenConditionDefinition())
+
+      const { container } = await renderResponse(server, {
+        method: 'GET',
+        url: PREVIEW_URL
+      })
+
+      expect(
+        container.queryByRole('link', { name: 'Cymraeg' })
+      ).not.toBeInTheDocument()
+      expect(container.queryByText('English')).not.toBeInTheDocument()
     })
 
     it('shows multiple causes as a bulleted list', async () => {

--- a/test/form/error-pages.test.js
+++ b/test/form/error-pages.test.js
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
+import { MetadataValidationError } from '~/src/server/services/errors.js'
 import {
   getFormDefinition,
   getFormMetadata
@@ -160,7 +161,9 @@ describe('Server error pages', () => {
       )
       if (!error) throw new Error('expected metadata validation error')
 
-      jest.mocked(getFormMetadata).mockRejectedValue(error)
+      jest
+        .mocked(getFormMetadata)
+        .mockRejectedValue(new MetadataValidationError(error))
 
       const { container, response } = await renderResponse(server, {
         method: 'GET',

--- a/test/form/error-pages.test.js
+++ b/test/form/error-pages.test.js
@@ -154,6 +154,33 @@ describe('Server error pages', () => {
       expect($technical.closest('details')).not.toBeNull()
     })
 
+    it('shows the generic error page when the failure is not form configuration', async () => {
+      // e.g. a backend outage while fetching the definition
+      jest
+        .mocked(getFormDefinition)
+        .mockRejectedValue(new Error('socket hang up'))
+
+      const { container, response } = await renderResponse(server, {
+        method: 'GET',
+        url: PREVIEW_URL
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+
+      const $heading = container.getByRole('heading', {
+        name: 'Sorry, there is a problem with the service',
+        level: 1
+      })
+      expect($heading).toBeInTheDocument()
+
+      expect(
+        container.queryByRole('heading', {
+          name: 'This form cannot be previewed'
+        })
+      ).not.toBeInTheDocument()
+      expect(container.queryByText('Technical details')).not.toBeInTheDocument()
+    })
+
     it('points the author at the form overview when metadata is invalid', async () => {
       const { error } = formMetadataSchema.validate(
         { ...fixtures.form.metadata, notificationEmail: 'not-an-email' },

--- a/test/form/error-pages.test.js
+++ b/test/form/error-pages.test.js
@@ -237,7 +237,7 @@ describe('Server error pages', () => {
       expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
 
       const $cause = container.getByText(
-        "Some of the form's overview details are invalid. Go back to the form overview and check details such as contact information and email addresses."
+        "Some of the form's details are invalid. Go back to the form overview and check details such as contact information and email addresses."
       )
       expect($cause).toBeInTheDocument()
 

--- a/test/form/error-pages.test.js
+++ b/test/form/error-pages.test.js
@@ -1,0 +1,187 @@
+import { formMetadataSchema } from '@defra/forms-model'
+import { StatusCodes } from 'http-status-codes'
+
+import { FORM_PREFIX } from '~/src/server/constants.js'
+import { createServer } from '~/src/server/index.js'
+import {
+  getFormDefinition,
+  getFormMetadata
+} from '~/src/server/services/formsService.js'
+import {
+  buildBrokenConditionDefinition,
+  buildSchemaInvalidDefinition
+} from '~/test/fixtures/definitions.js'
+import * as fixtures from '~/test/fixtures/index.js'
+import { renderResponse } from '~/test/helpers/component-helpers.js'
+
+jest.mock('~/src/server/services/formsService.js')
+
+const now = new Date()
+const author = { id: 'test-author', displayName: 'Test author' }
+const stateStamp = {
+  createdAt: now,
+  createdBy: author,
+  updatedAt: now,
+  updatedBy: author
+}
+
+const metadata = {
+  ...fixtures.form.metadata,
+  draft: stateStamp,
+  live: stateStamp
+}
+
+const SLUG = fixtures.form.metadata.slug
+const PREVIEW_URL = `${FORM_PREFIX}/preview/draft/${SLUG}`
+
+describe('Server error pages', () => {
+  /** @type {Server} */
+  let server
+
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  beforeEach(() => {
+    jest.mocked(getFormMetadata).mockResolvedValue(metadata)
+  })
+
+  describe('Public 500 page', () => {
+    it('shows the generic error page with no diagnostics', async () => {
+      jest
+        .mocked(getFormDefinition)
+        .mockResolvedValue(buildBrokenConditionDefinition())
+
+      const { container, response } = await renderResponse(server, {
+        method: 'GET',
+        url: `${FORM_PREFIX}/${SLUG}`
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+
+      const $heading = container.getByRole('heading', {
+        name: 'Sorry, there is a problem with the service',
+        level: 1
+      })
+      expect($heading).toBeInTheDocument()
+
+      expect(
+        container.queryByRole('heading', { name: 'What went wrong' })
+      ).not.toBeInTheDocument()
+      expect(container.queryByText('Technical details')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Preview 500 page', () => {
+    it('shows a single cause as body text', async () => {
+      jest
+        .mocked(getFormDefinition)
+        .mockResolvedValue(buildBrokenConditionDefinition())
+
+      const { container, response } = await renderResponse(server, {
+        method: 'GET',
+        url: PREVIEW_URL
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+
+      const $heading = container.getByRole('heading', {
+        name: 'This form cannot be previewed',
+        level: 1
+      })
+      expect($heading).toBeInTheDocument()
+
+      const $causesHeading = container.getByRole('heading', {
+        name: 'What went wrong',
+        level: 2
+      })
+      expect($causesHeading).toBeInTheDocument()
+
+      const $cause = container.getByText(
+        "The condition 'Existing user' is invalid. Check that it refers to the right question and answer option."
+      )
+      expect($cause).toBeInTheDocument()
+      expect($cause.tagName).toBe('P')
+    })
+
+    it('shows multiple causes as a bulleted list', async () => {
+      jest
+        .mocked(getFormDefinition)
+        .mockResolvedValue(buildSchemaInvalidDefinition())
+
+      const { container, response } = await renderResponse(server, {
+        method: 'GET',
+        url: PREVIEW_URL
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+
+      const causes = container
+        .getAllByRole('listitem')
+        .map(($item) => $item.textContent.trim())
+
+      expect(causes).toEqual(
+        expect.arrayContaining([
+          'Each page must have a unique ID. Change the page ID to one that is not already used.',
+          'Each page must have a unique path. Change the page path to one that is not already used.'
+        ])
+      )
+    })
+
+    it('reveals the technical detail for support', async () => {
+      jest
+        .mocked(getFormDefinition)
+        .mockResolvedValue(buildBrokenConditionDefinition())
+
+      const { container } = await renderResponse(server, {
+        method: 'GET',
+        url: PREVIEW_URL
+      })
+
+      const $reveal = container.getByText('Technical details')
+      expect($reveal).toBeInTheDocument()
+      expect($reveal.closest('details')).not.toBeNull()
+
+      const $technical = container.getByText(
+        /Failed to build condition 'Existing user'/
+      )
+      expect($technical.closest('details')).not.toBeNull()
+    })
+
+    it('points the author at the form overview when metadata is invalid', async () => {
+      const { error } = formMetadataSchema.validate(
+        { ...fixtures.form.metadata, notificationEmail: 'not-an-email' },
+        { abortEarly: false }
+      )
+      if (!error) throw new Error('expected metadata validation error')
+
+      jest.mocked(getFormMetadata).mockRejectedValue(error)
+
+      const { container, response } = await renderResponse(server, {
+        method: 'GET',
+        url: PREVIEW_URL
+      })
+
+      expect(response.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+
+      const $cause = container.getByText(
+        "Some of the form's overview details are invalid. Go back to the form overview and check details such as contact information and email addresses."
+      )
+      expect($cause).toBeInTheDocument()
+
+      const $technical = container.getByText(
+        /"notificationEmail" must be a valid email/
+      )
+      expect($technical.closest('details')).not.toBeNull()
+    })
+  })
+})
+
+/**
+ * @import { Server } from '@hapi/hapi'
+ */

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -135,18 +135,14 @@ describe('preview error details (drift canary)', () => {
     [
       'broken condition',
       brokenConditionDef,
-      'The condition &#39;Existing user&#39; could not be understood'
+      'The condition &#39;Existing user&#39; is invalid'
     ],
     [
       'unknown page controller',
       unknownControllerDef,
       'uses a page type this version of the service does not recognise'
     ],
-    [
-      'schema-invalid definition',
-      schemaInvalidDef,
-      'contains a duplicate value'
-    ]
+    ['schema-invalid definition', schemaInvalidDef, 'Two pages have the same']
   ])(
     'preview URL renders details for a %s',
     async (_label, definition, expectedText) => {

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -138,7 +138,11 @@ describe('preview error details (drift canary)', () => {
       'The condition &#39;Existing user&#39; could not be understood'
     ],
     ['unknown page controller', unknownControllerDef, 'NoSuchPageController'],
-    ['schema-invalid definition', schemaInvalidDef, 'Technical details']
+    [
+      'schema-invalid definition',
+      schemaInvalidDef,
+      'contains a duplicate value'
+    ]
   ])(
     'preview URL renders details for a %s',
     async (_label, definition, expectedText) => {

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -7,6 +7,11 @@ import {
   getFormDefinition,
   getFormMetadata
 } from '~/src/server/services/formsService.js'
+import {
+  buildBrokenConditionDefinition,
+  buildSchemaInvalidDefinition,
+  buildUnknownControllerDefinition
+} from '~/test/fixtures/definitions.js'
 import * as fixtures from '~/test/fixtures/index.js'
 
 jest.mock('~/src/server/services/formsService.js')
@@ -26,91 +31,6 @@ const metadata = {
   draft: stateStamp,
   live: stateStamp
 }
-
-const brokenConditionDef = {
-  name: 'Broken condition fixture',
-  engine: 'V2',
-  schema: 2,
-  startPage: '/summary',
-  pages: [
-    {
-      id: '449c053b-9201-4312-9a75-187afc6ba48b',
-      path: '/licence',
-      title: 'Licence',
-      components: [
-        {
-          id: 'a7c0242f-2a31-45b2-8c71-ff2ac7f53288',
-          name: 'xVrYaJ',
-          type: 'YesNoField',
-          title: 'Do you have a licence?',
-          shortDescription: 'Licence',
-          options: { required: true },
-          schema: {},
-          list: '4fa26e9c-07cf-47cd-a9dd-5cec0dd3f544'
-        }
-      ],
-      next: []
-    },
-    {
-      id: '449c053b-9201-4312-9a75-187afc6ba48c',
-      path: '/summary',
-      title: 'Summary',
-      controller: 'SummaryPageController',
-      components: [],
-      next: []
-    }
-  ],
-  lists: [
-    {
-      id: '4fa26e9c-07cf-47cd-a9dd-5cec0dd3f544',
-      name: 'XtfRYR',
-      title: 'User type list',
-      type: 'string',
-      items: [
-        {
-          id: '55fe0067-d011-4d33-886c-e1aa266637c3',
-          text: 'existing user',
-          value: 'existing user'
-        },
-        {
-          id: '2277c7e5-7fef-46c6-993b-d294116d6d6b',
-          text: 'new user',
-          value: 'new user'
-        }
-      ]
-    }
-  ],
-  sections: [],
-  conditions: [
-    {
-      id: '3f9d3a35-6dee-4706-806c-3f776129f631',
-      displayName: 'Existing user',
-      items: [
-        {
-          id: '7d7f58ee-c860-4d24-8a13-de5cb9af53d8',
-          componentId: 'a7c0242f-2a31-45b2-8c71-ff2ac7f53288',
-          operator: 'is',
-          type: 'ListItemRef',
-          value: {
-            listId: '4fa26e9c-07cf-47cd-a9dd-5cec0dd3f544',
-            itemId: ['55fe0067-d011-4d33-886c-e1aa266637c3']
-          }
-        }
-      ]
-    }
-  ]
-}
-
-const unknownControllerDef = structuredClone(brokenConditionDef)
-unknownControllerDef.name = 'Unknown controller fixture'
-unknownControllerDef.conditions = []
-Reflect.deleteProperty(unknownControllerDef.pages[0].components[0], 'list')
-unknownControllerDef.pages[0].controller = 'NoSuchPageController'
-
-const schemaInvalidDef = structuredClone(brokenConditionDef)
-schemaInvalidDef.name = 'Schema invalid fixture'
-// pages must be unique by path — duplicate to force a Joi validation error
-schemaInvalidDef.pages.push(structuredClone(schemaInvalidDef.pages[0]))
 
 const SLUG = fixtures.form.metadata.slug
 const PREVIEW_URL = `${FORM_PREFIX}/preview/draft/${SLUG}`
@@ -135,17 +55,17 @@ describe('preview error details (drift canary)', () => {
   test.each([
     [
       'broken condition',
-      brokenConditionDef,
+      buildBrokenConditionDefinition(),
       'The condition &#39;Existing user&#39; is invalid'
     ],
     [
       'unknown page controller',
-      unknownControllerDef,
+      buildUnknownControllerDefinition(),
       'uses a page type this version of the service does not recognise'
     ],
     [
       'schema-invalid definition',
-      schemaInvalidDef,
+      buildSchemaInvalidDefinition(),
       'Each page must have a unique'
     ]
   ])(
@@ -211,7 +131,7 @@ describe('preview error details (drift canary)', () => {
       .mocked(getFormDefinition)
       .mockResolvedValue(
         /** @type {FormDefinition} */ (
-          /** @type {unknown} */ (brokenConditionDef)
+          /** @type {unknown} */ (buildBrokenConditionDefinition())
         )
       )
 

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -11,6 +11,7 @@ import {
 import {
   buildBrokenConditionDefinition,
   buildSchemaInvalidDefinition,
+  buildUnknownComponentDefinition,
   buildUnknownControllerDefinition
 } from '~/test/fixtures/definitions.js'
 import * as fixtures from '~/test/fixtures/index.js'
@@ -63,6 +64,11 @@ describe('preview error details (drift canary)', () => {
       'unknown page controller',
       buildUnknownControllerDefinition(),
       'uses a page type this version of the service does not recognise'
+    ],
+    [
+      'unknown component type',
+      buildUnknownComponentDefinition(),
+      'uses a question type (&#39;MyUnknownField&#39;) this version of the service does not recognise'
     ],
     [
       'schema-invalid definition',

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { FORM_PREFIX } from '~/src/server/constants.js'
 import { createServer } from '~/src/server/index.js'
+import { MetadataValidationError } from '~/src/server/services/errors.js'
 import {
   getFormDefinition,
   getFormMetadata
@@ -110,7 +111,9 @@ describe('preview error details (drift canary)', () => {
 
       // formsService throws the raw Joi error when the manager response
       // fails metadata validation
-      jest.mocked(getFormMetadata).mockRejectedValue(error)
+      jest
+        .mocked(getFormMetadata)
+        .mockRejectedValue(new MetadataValidationError(error))
 
       const res = await server.inject({ method: 'GET', url: PREVIEW_URL })
 

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -58,7 +58,7 @@ describe('preview error details (drift canary)', () => {
     [
       'broken condition',
       buildBrokenConditionDefinition(),
-      'The condition &#39;Existing user&#39; is invalid'
+      'The condition &quot;Existing user&quot; isn&#39;t configured correctly'
     ],
     [
       'unknown page controller',

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -137,7 +137,11 @@ describe('preview error details (drift canary)', () => {
       brokenConditionDef,
       'The condition &#39;Existing user&#39; could not be understood'
     ],
-    ['unknown page controller', unknownControllerDef, 'NoSuchPageController'],
+    [
+      'unknown page controller',
+      unknownControllerDef,
+      'uses a page type this version of the service does not recognise'
+    ],
     [
       'schema-invalid definition',
       schemaInvalidDef,

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -1,3 +1,4 @@
+import { formMetadataSchema } from '@defra/forms-model'
 import { StatusCodes } from 'http-status-codes'
 
 import { FORM_PREFIX } from '~/src/server/constants.js'
@@ -162,6 +163,42 @@ describe('preview error details (drift canary)', () => {
       expect(res.payload).toContain('govuk-details')
       expect(res.payload).toContain('What went wrong')
       expect(res.payload).toContain(expectedText)
+    }
+  )
+
+  test.each([
+    [
+      'an invalid notification email',
+      {
+        ...fixtures.form.metadata,
+        notificationEmail: 'wildlife@naturalengland'
+      },
+      '&#39;notificationEmail&#39; must be a valid email'
+    ],
+    [
+      'an invalid contact structure',
+      { ...fixtures.form.metadata, contact: { phone: 12345 } },
+      '&#39;contact.phone&#39; must be a string'
+    ]
+  ])(
+    'preview URL renders metadata causes for %s',
+    async (_label, badMetadata, expectedText) => {
+      const { error } = formMetadataSchema.validate(badMetadata, {
+        abortEarly: false
+      })
+      if (!error) throw new Error('expected metadata validation error')
+
+      // formsService throws the raw Joi error when the manager response
+      // fails metadata validation
+      jest.mocked(getFormMetadata).mockRejectedValue(error)
+
+      const res = await server.inject({ method: 'GET', url: PREVIEW_URL })
+
+      expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(res.payload).toContain('What went wrong')
+      expect(res.payload).toContain(expectedText)
+      // metadata failures must not claim the form definition is broken
+      expect(res.payload).not.toContain('form definition')
     }
   )
 

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -173,16 +173,16 @@ describe('preview error details (drift canary)', () => {
         ...fixtures.form.metadata,
         notificationEmail: 'wildlife@naturalengland'
       },
-      '&#39;notificationEmail&#39; must be a valid email'
+      '&quot;notificationEmail&quot; must be a valid email'
     ],
     [
       'an invalid contact structure',
       { ...fixtures.form.metadata, contact: { phone: 12345 } },
-      '&#39;contact.phone&#39; must be a string'
+      '&quot;contact.phone&quot; must be a string'
     ]
   ])(
     'preview URL renders metadata causes for %s',
-    async (_label, badMetadata, expectedText) => {
+    async (_label, badMetadata, expectedTechnicalText) => {
       const { error } = formMetadataSchema.validate(badMetadata, {
         abortEarly: false
       })
@@ -196,7 +196,11 @@ describe('preview error details (drift canary)', () => {
 
       expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
       expect(res.payload).toContain('What went wrong')
-      expect(res.payload).toContain(expectedText)
+      expect(res.payload).toContain(
+        'Go back to the form overview and check details'
+      )
+      // the field-level detail still appears in the technical block
+      expect(res.payload).toContain(expectedTechnicalText)
       // metadata failures must not claim the form definition is broken
       expect(res.payload).not.toContain('form definition')
     }

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -103,7 +103,7 @@ const brokenConditionDef = {
 const unknownControllerDef = structuredClone(brokenConditionDef)
 unknownControllerDef.name = 'Unknown controller fixture'
 unknownControllerDef.conditions = []
-delete unknownControllerDef.pages[0].components[0].list
+Reflect.deleteProperty(unknownControllerDef.pages[0].components[0], 'list')
 unknownControllerDef.pages[0].controller = 'NoSuchPageController'
 
 const schemaInvalidDef = structuredClone(brokenConditionDef)
@@ -142,7 +142,11 @@ describe('preview error details (drift canary)', () => {
   ])(
     'preview URL renders details for a %s',
     async (_label, definition, expectedText) => {
-      jest.mocked(getFormDefinition).mockResolvedValue(definition)
+      jest
+        .mocked(getFormDefinition)
+        .mockResolvedValue(
+          /** @type {FormDefinition} */ (/** @type {unknown} */ (definition))
+        )
 
       const res = await server.inject({ method: 'GET', url: PREVIEW_URL })
 
@@ -154,7 +158,13 @@ describe('preview error details (drift canary)', () => {
   )
 
   test('public URL renders the 500 page without details', async () => {
-    jest.mocked(getFormDefinition).mockResolvedValue(brokenConditionDef)
+    jest
+      .mocked(getFormDefinition)
+      .mockResolvedValue(
+        /** @type {FormDefinition} */ (
+          /** @type {unknown} */ (brokenConditionDef)
+        )
+      )
 
     const res = await server.inject({
       method: 'GET',
@@ -181,3 +191,7 @@ describe('preview error details (drift canary)', () => {
     expect(res.payload).not.toContain('What went wrong (preview only)')
   })
 })
+
+/**
+ * @import { FormDefinition } from '@defra/forms-model'
+ */

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -142,7 +142,11 @@ describe('preview error details (drift canary)', () => {
       unknownControllerDef,
       'uses a page type this version of the service does not recognise'
     ],
-    ['schema-invalid definition', schemaInvalidDef, 'Two pages have the same']
+    [
+      'schema-invalid definition',
+      schemaInvalidDef,
+      'Each page must have a unique'
+    ]
   ])(
     'preview URL renders details for a %s',
     async (_label, definition, expectedText) => {

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -156,7 +156,7 @@ describe('preview error details (drift canary)', () => {
 
       expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
       expect(res.payload).toContain('govuk-details')
-      expect(res.payload).toContain('What went wrong (preview only)')
+      expect(res.payload).toContain('What went wrong')
       expect(res.payload).toContain(expectedText)
     }
   )
@@ -177,7 +177,7 @@ describe('preview error details (drift canary)', () => {
 
     expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
     expect(res.payload).not.toContain('govuk-details')
-    expect(res.payload).not.toContain('What went wrong (preview only)')
+    expect(res.payload).not.toContain('What went wrong')
   })
 
   test('404 pages are unaffected', async () => {
@@ -192,7 +192,7 @@ describe('preview error details (drift canary)', () => {
     })
 
     expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
-    expect(res.payload).not.toContain('What went wrong (preview only)')
+    expect(res.payload).not.toContain('What went wrong')
   })
 })
 

--- a/test/form/preview-error-details.test.js
+++ b/test/form/preview-error-details.test.js
@@ -1,0 +1,183 @@
+import { StatusCodes } from 'http-status-codes'
+
+import { FORM_PREFIX } from '~/src/server/constants.js'
+import { createServer } from '~/src/server/index.js'
+import {
+  getFormDefinition,
+  getFormMetadata
+} from '~/src/server/services/formsService.js'
+import * as fixtures from '~/test/fixtures/index.js'
+
+jest.mock('~/src/server/services/formsService.js')
+
+const now = new Date()
+const author = { id: 'test-author', displayName: 'Test author' }
+const stateStamp = {
+  createdAt: now,
+  createdBy: author,
+  updatedAt: now,
+  updatedBy: author
+}
+
+// Metadata with both states so live and preview URLs resolve
+const metadata = {
+  ...fixtures.form.metadata,
+  draft: stateStamp,
+  live: stateStamp
+}
+
+const brokenConditionDef = {
+  name: 'Broken condition fixture',
+  engine: 'V2',
+  schema: 2,
+  startPage: '/summary',
+  pages: [
+    {
+      id: '449c053b-9201-4312-9a75-187afc6ba48b',
+      path: '/licence',
+      title: 'Licence',
+      components: [
+        {
+          id: 'a7c0242f-2a31-45b2-8c71-ff2ac7f53288',
+          name: 'xVrYaJ',
+          type: 'YesNoField',
+          title: 'Do you have a licence?',
+          shortDescription: 'Licence',
+          options: { required: true },
+          schema: {},
+          list: '4fa26e9c-07cf-47cd-a9dd-5cec0dd3f544'
+        }
+      ],
+      next: []
+    },
+    {
+      id: '449c053b-9201-4312-9a75-187afc6ba48c',
+      path: '/summary',
+      title: 'Summary',
+      controller: 'SummaryPageController',
+      components: [],
+      next: []
+    }
+  ],
+  lists: [
+    {
+      id: '4fa26e9c-07cf-47cd-a9dd-5cec0dd3f544',
+      name: 'XtfRYR',
+      title: 'User type list',
+      type: 'string',
+      items: [
+        {
+          id: '55fe0067-d011-4d33-886c-e1aa266637c3',
+          text: 'existing user',
+          value: 'existing user'
+        },
+        {
+          id: '2277c7e5-7fef-46c6-993b-d294116d6d6b',
+          text: 'new user',
+          value: 'new user'
+        }
+      ]
+    }
+  ],
+  sections: [],
+  conditions: [
+    {
+      id: '3f9d3a35-6dee-4706-806c-3f776129f631',
+      displayName: 'Existing user',
+      items: [
+        {
+          id: '7d7f58ee-c860-4d24-8a13-de5cb9af53d8',
+          componentId: 'a7c0242f-2a31-45b2-8c71-ff2ac7f53288',
+          operator: 'is',
+          type: 'ListItemRef',
+          value: {
+            listId: '4fa26e9c-07cf-47cd-a9dd-5cec0dd3f544',
+            itemId: ['55fe0067-d011-4d33-886c-e1aa266637c3']
+          }
+        }
+      ]
+    }
+  ]
+}
+
+const unknownControllerDef = structuredClone(brokenConditionDef)
+unknownControllerDef.name = 'Unknown controller fixture'
+unknownControllerDef.conditions = []
+delete unknownControllerDef.pages[0].components[0].list
+unknownControllerDef.pages[0].controller = 'NoSuchPageController'
+
+const schemaInvalidDef = structuredClone(brokenConditionDef)
+schemaInvalidDef.name = 'Schema invalid fixture'
+// pages must be unique by path — duplicate to force a Joi validation error
+schemaInvalidDef.pages.push(structuredClone(schemaInvalidDef.pages[0]))
+
+const SLUG = fixtures.form.metadata.slug
+const PREVIEW_URL = `${FORM_PREFIX}/preview/draft/${SLUG}`
+
+describe('preview error details (drift canary)', () => {
+  /** @type {import('@hapi/hapi').Server} */
+  let server
+
+  beforeAll(async () => {
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop()
+  })
+
+  beforeEach(() => {
+    jest.mocked(getFormMetadata).mockResolvedValue(metadata)
+  })
+
+  test.each([
+    [
+      'broken condition',
+      brokenConditionDef,
+      'The condition &#39;Existing user&#39; could not be understood'
+    ],
+    ['unknown page controller', unknownControllerDef, 'NoSuchPageController'],
+    ['schema-invalid definition', schemaInvalidDef, 'Technical details']
+  ])(
+    'preview URL renders details for a %s',
+    async (_label, definition, expectedText) => {
+      jest.mocked(getFormDefinition).mockResolvedValue(definition)
+
+      const res = await server.inject({ method: 'GET', url: PREVIEW_URL })
+
+      expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+      expect(res.payload).toContain('govuk-details')
+      expect(res.payload).toContain('What went wrong (preview only)')
+      expect(res.payload).toContain(expectedText)
+    }
+  )
+
+  test('public URL renders the 500 page without details', async () => {
+    jest.mocked(getFormDefinition).mockResolvedValue(brokenConditionDef)
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `${FORM_PREFIX}/${SLUG}`
+    })
+
+    expect(res.statusCode).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+    expect(res.payload).not.toContain('govuk-details')
+    expect(res.payload).not.toContain('What went wrong (preview only)')
+  })
+
+  test('404 pages are unaffected', async () => {
+    const Boom = await import('@hapi/boom')
+    jest
+      .mocked(getFormMetadata)
+      .mockRejectedValue(Boom.default.notFound('Form not found'))
+
+    const res = await server.inject({
+      method: 'GET',
+      url: `${FORM_PREFIX}/preview/draft/no-such-form-here`
+    })
+
+    expect(res.statusCode).toBe(StatusCodes.NOT_FOUND)
+    expect(res.payload).not.toContain('What went wrong (preview only)')
+  })
+})


### PR DESCRIPTION
This PR depends on https://github.com/DEFRA/forms-engine-plugin/pull/459.

When a form is broken, the error page currently displays a standard HTTP 500 page. This PR introduces an error page specifically for form previews to tell the form designer what is broken.

This page is only shown when accessing a preview form. Live submissions will not show it.

This page is only displayed if the error is related to the form definition or form metadata. Standard errors during a preview will show up as the standard HTTP 500 page.

Jira ticket: [DF-1248](https://eaflood.atlassian.net/browse/DF-1248)

## Invalid form definition

<img width="1242" height="1200" alt="image" src="https://github.com/user-attachments/assets/cef55470-8582-4784-aed0-f5f6c688bede" />

## Invalid metadata

<img width="1200" height="1143" alt="image" src="https://github.com/user-attachments/assets/44b3dbe1-fb0e-4e70-b32b-44a0cf716464" />

## Unknown page controllers

<img width="1185" height="1100" alt="image" src="https://github.com/user-attachments/assets/8832cfdd-2c6a-4581-ad87-1ac4d9a24782" />

## Unknown components

<img width="1237" height="1100" alt="image" src="https://github.com/user-attachments/assets/440a3bab-c6df-4a96-826a-a93a3f8fd96a" />


[DF-1248]: https://eaflood.atlassian.net/browse/DF-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ