### PR TITLE
fix/df 1287: prevent 500s being thrown on a 404

### DIFF
--- a/src/server/i18n/index.test.ts
+++ b/src/server/i18n/index.test.ts
@@ -36,6 +36,7 @@ describe('Runner i18n', () => {
     it('returns the language set in the session', () => {
       const blankRequest = {
         yar: {
+          id: 'session-id',
           get: jest.fn().mockReturnValue('cy')
         }
       } as unknown as Request
@@ -46,6 +47,7 @@ describe('Runner i18n', () => {
       const mockYarSet = jest.fn()
       const blankRequest = {
         yar: {
+          id: 'session-id',
           get: jest.fn(),
           set: mockYarSet
         },

--- a/src/server/utils/utils.js
+++ b/src/server/utils/utils.js
@@ -43,11 +43,16 @@ export function resolveLanguage(query, yar) {
 
   query ??= {}
 
-  if (yar && 'language' in query) {
+  // yar.id is only set once yar's session has been initialised (onPreAuth),
+  // so calling yar.get/set beforehand (e.g. for a 404 raised pre-routing)
+  // would throw as its internal store is still null
+  const sessionReady = Boolean(yar?.id)
+
+  if (sessionReady && yar && 'language' in query) {
     yar.set('language', query.language)
   }
 
-  return yar?.get('language') ?? defaultLang
+  return (sessionReady && yar ? yar.get('language') : null) ?? defaultLang
 }
 
 /**

--- a/src/server/utils/utils.js
+++ b/src/server/utils/utils.js
@@ -46,13 +46,13 @@ export function resolveLanguage(query, yar) {
   // yar.id is only set once yar's session has been initialised (onPreAuth),
   // so calling yar.get/set beforehand (e.g. for a 404 raised pre-routing)
   // would throw as its internal store is still null
-  const sessionReady = Boolean(yar?.id)
+  const sessionReady = yar && Boolean(yar.id)
 
-  if (sessionReady && yar && 'language' in query) {
+  if (sessionReady && 'language' in query) {
     yar.set('language', query.language)
   }
 
-  return (sessionReady && yar ? yar.get('language') : null) ?? defaultLang
+  return (sessionReady ? yar.get('language') : null) ?? defaultLang
 }
 
 /**

--- a/src/server/utils/utils.test.js
+++ b/src/server/utils/utils.test.js
@@ -3,7 +3,8 @@ import { getTraceId } from '@defra/hapi-tracing'
 import { config } from '~/src/config/index.js'
 import {
   applyTraceHeaders,
-  getFeedbackFormLink
+  getFeedbackFormLink,
+  resolveLanguage
 } from '~/src/server/utils/utils.js'
 
 jest.mock('@defra/hapi-tracing')
@@ -62,6 +63,43 @@ describe('utils', () => {
       expect(getFeedbackFormLink('source-form-id')).toEqual({
         feedbackLink: '/form/feedback?formId=source-form-id'
       })
+    })
+  })
+
+  describe('resolveLanguage', () => {
+    const mockYarStore = /** @type {Record<string,string>} */ ({})
+    /**
+     * @param {string} name
+     * @param {string} value
+     */
+    function yarSet(name, value) {
+      mockYarStore[name] = value
+    }
+    /**
+     * @param {string} name
+     */
+    function yarGet(name) {
+      return mockYarStore[name]
+    }
+
+    it('should return default language if yar session not properly constructed yet', () => {
+      expect(resolveLanguage({}, undefined)).toBe('en-GB')
+    })
+
+    it('should return specified language if yar session up and language passed as query param', () => {
+      // @ts-expect-error - partial mock of methods
+      expect(
+        resolveLanguage(
+          { language: 'cy' },
+          { id: 'session-id', set: yarSet, get: yarGet }
+        )
+      ).toBe('cy')
+
+      // Should retrieve session value when language not passed
+      // @ts-expect-error - partial mock of methods
+      expect(
+        resolveLanguage({}, { id: 'session-id', set: yarSet, get: yarGet })
+      ).toBe('cy')
     })
   })
 })

--- a/src/server/utils/utils.test.js
+++ b/src/server/utils/utils.test.js
@@ -87,17 +87,17 @@ describe('utils', () => {
     })
 
     it('should return specified language if yar session up and language passed as query param', () => {
-      // @ts-expect-error - partial mock of methods
       expect(
         resolveLanguage(
           { language: 'cy' },
+          // @ts-expect-error - partial mock of methods
           { id: 'session-id', set: yarSet, get: yarGet }
         )
       ).toBe('cy')
 
       // Should retrieve session value when language not passed
-      // @ts-expect-error - partial mock of methods
       expect(
+        // @ts-expect-error - partial mock of methods
         resolveLanguage({}, { id: 'session-id', set: yarSet, get: yarGet })
       ).toBe('cy')
     })


### PR DESCRIPTION
The error pages may get actioned before the Yar session has had chance to initialise fully (on PreAuth).
Therefore this defensive code is required to prevent random 404 urls (where no previous session, soperhaps from a hack attempt) throwing 500s